### PR TITLE
server: remove default API Key

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -24,7 +24,7 @@ ENV DB_PASSWORD=password
 ENV DB_PORT=5432
 
 # required exposed env vars, with defaults provided
-ENV API_KEYS=abc
+ENV API_KEYS=""
 ENV DB_NAME="appointment-availability"
 
 # run our built server

--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -51,6 +51,7 @@ module "api_task" {
     DB_NAME     = module.db.db_name
     DB_USERNAME = var.db_user
     DB_PASSWORD = var.db_password
+    API_KEY     = var.api_key
     ENV         = "production"
   }
 


### PR DESCRIPTION
This commit updates the default api key of 'abc' and replaces
it with a secure string from the terraform ui.