### PR TITLE
HOTFIX: CVS API updates are not marked as public

### DIFF
--- a/loader/src/sources/cvs/api.js
+++ b/loader/src/sources/cvs/api.js
@@ -131,7 +131,7 @@ function parseApiLocation(location, lastUpdated) {
       updated_at: lastUpdated || checkTime,
       checked_at: checkTime,
       available,
-      is_public: false,
+      is_public: true,
     },
   };
 }

--- a/loader/test/cvs.api.test.js
+++ b/loader/test/cvs.api.test.js
@@ -74,7 +74,7 @@ describe("CVS API", () => {
         availability: {
           available: "NO",
           checked_at: expectDatetimeString(),
-          is_public: false,
+          is_public: true,
           source: "cvs-api",
           updated_at: "2021-03-09T17:08:30.842Z",
         },
@@ -98,7 +98,7 @@ describe("CVS API", () => {
         availability: {
           available: "YES",
           checked_at: expectDatetimeString(),
-          is_public: false,
+          is_public: true,
           source: "cvs-api",
           updated_at: "2021-03-09T17:08:30.842Z",
         },


### PR DESCRIPTION
I think we set these as non-public back when NJ was still treating the CVS API as not-ready-for-prime-time, but that hasn't been the case for a while. In the mean time, we have effectively not been showing CVS updates in the API. (Noticed this while testing the demo UI against our production data after fixing the CORS issue in #28.)