### PR TITLE
Set and use repo secrets for the UI's DATA_URL

### DIFF
--- a/.github/workflows/ui-deploy.yml
+++ b/.github/workflows/ui-deploy.yml
@@ -39,6 +39,8 @@ jobs:
           npm ci
 
       - name: Build UI
+        env:
+          DATA_URL: ${{ secrets.DATA_URL }}
         run: |
           cd main/ui
           NODE_ENV=production npm run build


### PR DESCRIPTION
I foolishly forgot to set and use repo secrets for the UI’s `DATA_URL` setting, so if you visit `https://usdigitalresponse.github.io/appointment-availability-infra/` it won’t work unless you have a local server running. :(

I’ve set the repo secret, and this updates the deploy workflow to use it.