### PR TITLE
Only tag images with `latest` from `main` branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,22 @@ jobs:
 
   build_docker:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Instead of building all combinations of a set of options, just build
+        # these particular combinations.
+        include:
+          - repository: appointment-db-seed
+            dockerfile: ./server/Dockerfile.seed-db
+            build_path: ./server
+
+          - repository: appointment-server
+            dockerfile: ./server/Dockerfile
+            build_path: ./server
+
+          - repository: appointment-loader
+            dockerfile: ./loader/Dockerfile
+            build_path: ./loader
     env:
       IMAGE_TAG: ${{ github.sha }}
     steps:
@@ -124,53 +140,19 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
-      - name: Build and push appointment-db-seed
+      - name: Build and push ${{ matrix.repository }}
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: appointment-db-seed
+          ECR_REPOSITORY: ${{ matrix.repository }}
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f ./server/Dockerfile.seed-db ./server
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f ${{ matrix.dockerfile }} ${{ matrix.build_path }}
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
 
-      - name: Tag and push appointment-db-seed latest
+      - name: Tag and push ${{ matrix.repository }} latest
         if: ${{ github.ref == 'refs/heads/main' }}
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: appointment-db-seed
-        run: |
-          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:latest
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
-
-      - name: Build and push appointment-server
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: appointment-server
-        run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f ./server/Dockerfile ./server
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-
-      - name: Tag and push appointment-server latest
-        if: ${{ github.ref == 'refs/heads/main' }}
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: appointment-server
-        run: |
-          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:latest
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
-
-      - name: Build and push appointment-loader
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: appointment-loader
-        run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f ./loader/Dockerfile ./loader
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-
-      - name: Tag and push appointment-loader latest
-        if: ${{ github.ref == 'refs/heads/main' }}
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: appointment-loader
+          ECR_REPOSITORY: ${{ matrix.repository }}
         run: |
           docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:latest
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest


### PR DESCRIPTION
Pull requests and other experimental branches should not tag and publish built Docker images with `latest`, since they are obviously not production-ready until they at least land on `main`.

This is the most conservative change that fulfills #41 — it keeps building and publishing images tagged by commit hash on PRs and only avoids the `latest` tag. We could possibly go further by not publishing built images at all.

Fixes #41.