### PR TITLE
Fix Sentry DSN configuration for loaders

### DIFF
--- a/terraform/loaders.tf
+++ b/terraform/loaders.tf
@@ -7,6 +7,7 @@
 #   loader_source = "cvsScraper"
 #   api_url = "http://${aws_alb.main.dns_name}"
 #   api_key = var.api_key
+#   sentry_dsn = var.loader_sentry_dsn
 #   schedule = "rate(10 minutes)"
 #   cluster_arn = aws_ecs_cluster.main.arn
 #   role = aws_iam_role.ecs_task_execution_role.arn
@@ -20,6 +21,7 @@ module "cvs_api_loader" {
   loader_source = "cvsApi"
   api_url       = "http://${aws_alb.main.dns_name}"
   api_key       = var.api_key
+  sentry_dsn    = var.loader_sentry_dsn
   schedule      = "rate(3 minutes)"
   cluster_arn   = aws_ecs_cluster.main.arn
   role          = aws_iam_role.ecs_task_execution_role.arn
@@ -37,6 +39,7 @@ module "njvss_loader" {
   loader_source = "njvss"
   api_url       = "http://${aws_alb.main.dns_name}"
   api_key       = var.api_key
+  sentry_dsn    = var.loader_sentry_dsn
   schedule      = "rate(3 minutes)"
   cluster_arn   = aws_ecs_cluster.main.arn
   role          = aws_iam_role.ecs_task_execution_role.arn
@@ -55,6 +58,7 @@ module "vaccinespotter_loader" {
   loader_source = "vaccinespotter"
   api_url       = "http://${aws_alb.main.dns_name}"
   api_key       = var.api_key
+  sentry_dsn    = var.loader_sentry_dsn
   schedule      = "rate(2 minutes)"
   cluster_arn   = aws_ecs_cluster.main.arn
   role          = aws_iam_role.ecs_task_execution_role.arn

--- a/terraform/modules/loader/main.tf
+++ b/terraform/modules/loader/main.tf
@@ -13,7 +13,7 @@ module "loader_task" {
     SOURCES     = var.loader_source
     API_URL     = var.api_url
     API_KEY     = var.api_key
-    SENTRY_DSN  = var.loader_sentry_dsn
+    SENTRY_DSN  = var.sentry_dsn
   }, var.env_vars)
 }
 

--- a/terraform/modules/loader/variables.tf
+++ b/terraform/modules/loader/variables.tf
@@ -19,8 +19,8 @@ variable "name" {
   description = "The name of the source"
 }
 
-variable "loader_sentry_dsn" {
-  description = "The Sentry.io DSN to use for the loaders"
+variable "sentry_dsn" {
+  description = "The Sentry.io DSN to use for error reporting"
   default     = ""
   sensitive   = true
 }


### PR DESCRIPTION
I wasn't properly passing down and setting the Sentry DSN variable to the loader module, and so loaders aren't reporting errors. This should fix that up! (This is a follow-on from #59.)