### PR TITLE
HOTFIX: Actually parse Rite Aid `last_updated` dates

### DIFF
--- a/loader/test/riteaid.api.test.js
+++ b/loader/test/riteaid.api.test.js
@@ -173,7 +173,7 @@ describe("Rite Aid Source", () => {
           ],
         },
         source: "rite-aid-api",
-        updated_at: "2021-04-27T12:31:21.000-04:00",
+        updated_at: "2021-04-23T14:52:05.000Z",
       },
     });
 


### PR DESCRIPTION
Due to a horrible copy/paste error on my part, we were checking the format of the actual data string for Rite Aid, but then *parsing* a hard-coded value! Needless to say, our dates were not very correct. This also improves parsing by trying to parse the date as ISO 8601 if it was not in Rite Aid's wonky format, and if that fails, logging a useful error.