### PR TITLE
Increase the length of `provider_locations.id`

### DIFF
--- a/server/migrations/20210503185847_provider_locations_longer_id.js
+++ b/server/migrations/20210503185847_provider_locations_longer_id.js
@@ -1,0 +1,30 @@
+/**
+ * Increase the maximum length of the ID for provider locations. Ultimately,
+ * we probably want to replace it with an int, but for now, we have some
+ * locations with longer IDs that we need to support.
+ */
+exports.up = function (knex) {
+  return Promise.all([
+    knex.raw(`
+      ALTER TABLE provider_locations
+        ALTER COLUMN id TYPE varchar(128)
+    `),
+    knex.raw(`
+      ALTER TABLE availability
+        ALTER COLUMN provider_location_id TYPE varchar(128)
+    `),
+  ]);
+};
+
+exports.down = function (knex) {
+  return Promise.all([
+    knex.raw(`
+      ALTER TABLE provider_locations
+        ALTER COLUMN id TYPE varchar(64)
+    `),
+    knex.raw(`
+      ALTER TABLE availability
+        ALTER COLUMN provider_location_id TYPE varchar(64)
+    `),
+  ]);
+};


### PR DESCRIPTION
It turns out we have some locations that are causing errors because their IDs are longer than 64 characters. Ultimately, we might want to change this to an auto-incrementing int, but this is a good fix for now.

Fixes #87.