### PR TITLE
Log send errors with standard messaging

### DIFF
--- a/loader/src/cli.js
+++ b/loader/src/cli.js
@@ -76,14 +76,20 @@ async function run(options) {
           if (saveResult.error?.code === "out_of_date") continue;
 
           const data = saveResult.sent;
-          const source = data.availability
-            ? ` from ${data.availability.source}`
-            : "";
-          const message = `Error sending "${data.name}"${source}: ${
-            saveResult.statusCode
-          } ${saveResult.error?.message || "unknown reason"}`;
-          console.error(message);
-          Sentry.captureMessage(message, Sentry.Severity.Error);
+          const message = `Error sending: ${
+            saveResult.error?.message || "unknown reason"
+          }`;
+          const logData = {
+            status_code: saveResult.statusCode,
+            source: data.availability.source,
+            location_id: data.id,
+            location_name: data.name,
+          };
+          console.error(message, JSON.stringify(logData));
+          Sentry.captureMessage(message, {
+            level: Sentry.Severity.Error,
+            contexts: { send_error: logData },
+          });
           success = false;
         }
       }


### PR DESCRIPTION
We previously composed a nice, human-friendly message for errors sending data to the API server. However, that means every send error looks different even if they're all coming from the same cause. This uses a more standard message, and provides instance-specific details as structured data. This still reads well in logs, and will let our errors collaps and get counted and managed better in Sentry, with no loss of data or detail (in fact, there's actually more detail now).

This is solving the issue where we have a zillion one-off errors in Sentry:
<img width="823" alt="Screen Shot 2021-05-11 at 9 56 50 AM" src="https://user-images.githubusercontent.com/74178/117855381-48dc1a00-b23f-11eb-98bb-e4dd049faf20.png">
