### PR TITLE
Add test that updating with a bad UUID is ok

### DIFF
--- a/server/test/clinics.test.ts
+++ b/server/test/clinics.test.ts
@@ -238,6 +238,7 @@ describe("POST /update", () => {
       headers,
       json: {
         id: "abc123",
+        external_ids: { njiis: "nj1234" },
         meta: {
           test: "this is a test",
         },


### PR DESCRIPTION
This is a followup to #118 that adds a test, so we don't make this mistake again.