### PR TITLE
HOTFIX: multi-batch streaming of locations breaks

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -279,7 +279,7 @@ export async function* iterateLocationBatches({
   while (true) {
     if (limit) batchSize = Math.min(batchSize, limit - total);
     if (nextValues) {
-      batchWhere = where.concat(["(created_at, id) > (?, ?)"]);
+      batchWhere = where.concat(["(pl.created_at, pl.id) > (?, ?)"]);
       batchValues = values.concat(nextValues);
     }
 

--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -91,7 +91,7 @@ module "api_task" {
 
   env_vars = {
     # Bump RELEASE to force update the image/restart the service.
-    RELEASE     = "14"
+    RELEASE     = "15"
     DB_HOST     = module.db.host
     DB_NAME     = module.db.db_name
     DB_USERNAME = var.db_user


### PR DESCRIPTION
When I cleaned up the way batching was done in #124, I apparently made it possible for the query to have ambiguous references that sometimes fail (not entirely sure what the conditions are for this, since it is clearly working sometimes). This fully qualifies the pagination key references, which should resolve the issue.