### PR TITLE
Reinstate uniqueness constraint on availability

### DIFF
--- a/server/migrations/20210514123117_reinstate_unique_constraint_on_availability.js
+++ b/server/migrations/20210514123117_reinstate_unique_constraint_on_availability.js
@@ -1,0 +1,11 @@
+exports.up = function (knex) {
+  return knex.schema.alterTable("availability", (t) => {
+    t.unique(["location_id", "source"], "unique_by_location_and_source");
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.alterTable("availability", (t) => {
+    t.dropUnique(["location_id", "source"], "unique_by_location_and_source");
+  });
+};

--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -91,7 +91,7 @@ module "api_task" {
 
   env_vars = {
     # Bump RELEASE to force update the image/restart the service.
-    RELEASE     = "15"
+    RELEASE     = "16"
     DB_HOST     = module.db.host
     DB_NAME     = module.db.db_name
     DB_USERNAME = var.db_user


### PR DESCRIPTION
The availability table used to be unique by `(location_id, source)`, but that constraint appears to have gotten blown away in the primary key change in #113. This reinstates the constraint. (Fingers crossed it *can* still be reinstated.)