### PR TITLE
Trigger deploy of new API container

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -91,7 +91,7 @@ module "api_task" {
 
   env_vars = {
     # Bump RELEASE to force update the image/restart the service.
-    RELEASE     = "16"
+    RELEASE     = "17"
     DB_HOST     = module.db.host
     DB_NAME     = module.db.db_name
     DB_USERNAME = var.db_user


### PR DESCRIPTION
Parallel PRs caused #121 to no longer change the Terraform configs and no longer trigger a deploy (d'oh!). This is just making sure that PR gets pushed to production.