### PR TITLE
Vaccinespotter appointments have multiple formats

### DIFF
--- a/loader/src/sources/vaccinespotter/index.js
+++ b/loader/src/sources/vaccinespotter/index.js
@@ -165,9 +165,14 @@ const formatters = {
 
     // Determine what identifier type to use for `external_ids`.
     let provider = store.properties.provider.trim().toLowerCase();
-    let providerBrand = store.properties.provider_brand.trim().toLowerCase();
-    if (!providerBrand.includes(provider)) {
-      providerBrand = `${provider}_${providerBrand}`;
+    let providerBrand = store.properties.provider_brand;
+    if (!providerBrand) {
+      providerBrand = provider;
+    } else {
+      providerBrand = providerBrand.trim().toLowerCase();
+      if (!providerBrand.includes(provider)) {
+        providerBrand = `${provider}_${providerBrand}`;
+      }
     }
 
     let id;

--- a/loader/test/vaccinespotter.test.js
+++ b/loader/test/vaccinespotter.test.js
@@ -337,4 +337,19 @@ describe("VaccineSpotter", () => {
       },
     ]);
   });
+
+  it("should handle locations with `null` for their brand", () => {
+    const result = formatStore({
+      ...basicVaccineSpotterStore,
+      properties: {
+        ...basicVaccineSpotterStore.properties,
+        provider: "health_mart",
+        provider_brand: null,
+        provider_brand_id: null,
+        provider_brand_name: null,
+      },
+    });
+
+    expect(result).toHaveProperty("provider", "health_mart");
+  });
 });


### PR DESCRIPTION
It turns out VaccineSpotter's `appointments` field can have two differently formatted types of values, and we were only expecting one format. (We expected it to have specific slot times, analogous to how we format individual slots, but it can also have dates, which are analogous to how we handle capacity). We now account for both formats, which should resolve some errors we've been seeing *thousands* of in Sentry. (I've also confirmed the possible formats with @GUI.) This fixes the “malformed appointments” issue: https://sentry.io/organizations/usdr/issues/2392134038

While fixing that, I discovered VaccineSpotter records sometimes have no provider brand, which causes us to break. This fixes that, too.