### PR TITLE
Speed most loaders back up to every 2 minutes

### DIFF
--- a/terraform/loaders.tf
+++ b/terraform/loaders.tf
@@ -43,7 +43,7 @@ module "cvs_smart_loader" {
   api_url       = "http://${aws_alb.main.dns_name}"
   api_key       = var.api_key
   sentry_dsn    = var.loader_sentry_dsn
-  schedule      = "rate(5 minutes)"
+  schedule      = "rate(2 minutes)"
   cluster_arn   = aws_ecs_cluster.main.arn
   role          = aws_iam_role.ecs_task_execution_role.arn
   subnets       = aws_subnet.public.*.id
@@ -57,7 +57,7 @@ module "njvss_loader" {
   api_url       = "http://${aws_alb.main.dns_name}"
   api_key       = var.api_key
   sentry_dsn    = var.loader_sentry_dsn
-  schedule      = "rate(5 minutes)"
+  schedule      = "rate(2 minutes)"
   cluster_arn   = aws_ecs_cluster.main.arn
   role          = aws_iam_role.ecs_task_execution_role.arn
   subnets       = aws_subnet.public.*.id
@@ -91,7 +91,7 @@ module "rite_aid_loader" {
   api_url       = "http://${aws_alb.main.dns_name}"
   api_key       = var.api_key
   sentry_dsn    = var.loader_sentry_dsn
-  schedule      = "rate(5 minutes)"
+  schedule      = "rate(2 minutes)"
   cluster_arn   = aws_ecs_cluster.main.arn
   role          = aws_iam_role.ecs_task_execution_role.arn
   subnets       = aws_subnet.public.*.id


### PR DESCRIPTION
Earlier this week I slowed the loaders down while the database was experience high load issues. Those issues were resolved in #141, so it should be safe to bring them back up to speed now. I'm keeping VaccineSpotter slowed down for now since most of it's sources do not currently update as rapidly.

This puts most loaders at every 2 minutes, and keeps VaccineSpotter at every 5 minutes.