### PR TITLE
Wrap setting external_ids in transactions with create/update code

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -96,7 +96,7 @@ export async function createLocation(data: any): Promise<ProviderLocation> {
     );
 
     const locationId = inserted.rows[0].id;
-    await setExternalIds(tx, locationId, data.external_ids);
+    await setExternalIds(locationId, data.external_ids, tx);
     return await getLocationById(locationId);
   });
 }
@@ -109,9 +109,9 @@ export async function createLocation(data: any): Promise<ProviderLocation> {
  * @param externalIds {system: value}
  */
 export async function setExternalIds(
-  dbConn: typeof db,
   id: string,
-  externalIds: { string: string }
+  externalIds: { string: string },
+  dbConn: typeof db = db
 ): Promise<void> {
   await dbConn("external_ids")
     .insert(
@@ -157,10 +157,14 @@ export async function updateLocation(
     await tx("provider_locations").where("id", location.id).update(sqlData);
 
     if ("external_ids" in data) {
-      await setExternalIds(tx, location.id, {
-        ...location.external_ids,
-        ...data.external_ids,
-      });
+      await setExternalIds(
+        location.id,
+        {
+          ...location.external_ids,
+          ...data.external_ids,
+        },
+        tx
+      );
     }
   });
 }

--- a/server/test/lib.ts
+++ b/server/test/lib.ts
@@ -75,6 +75,7 @@ export function installTestDatabaseHooks() {
 function mockDbTransactions() {
   // mock out db.transaction since we only use one connection when testing
   // we use defineProperty here because it's defined as read-only
+  // TODO: Find a way to carry per-request db connection state so that we don't need this
   Object.defineProperty(db, "transaction", {
     value: async (f: Function) => {
       return await f(db);


### PR DESCRIPTION
There's some noise in the regular diff view due to whitespace, so see here for a cleaner view: https://github.com/usdigitalresponse/appointment-availability-infra/pull/148/files?w=1

This PR wraps the create and update code for `provider_locations` and `external_ids` in transactions so that we get all-or-nothing behavior.

Also included here is a bit of a hack for our test suite. To speed up our tests, we wrap each run in a transaction so that we can quickly rollback any changes made to the database during the test. Unfortunately, that means spinning up a new transaction hangs the database as we only allow one connection at a time. Postgres supports something like nested transaction support through `SAVEPOINT`, and `knex` also supports `SAVEPOINT`, but in order to use it the overarching transaction for the test suite would need to be done via `knex.transaction` rather than our direct `BEGIN` and `ROLLBACK` database queries.

Rather than twist ourselves into pretzels trying to adapt the `knex` way into the `jest` way, we simply hack it here, making it so that `db.transaction` just hands back in the exact same connection we're already using, effectively disabling transaction wrapping altogether for tests.

Worthwhile sacrifice? Probably.