### PR TITLE
Handle unnamed stores in VaccineSpotter loader

### DIFF
--- a/loader/test/vaccinespotter.test.js
+++ b/loader/test/vaccinespotter.test.js
@@ -352,4 +352,35 @@ describe("VaccineSpotter", () => {
 
     expect(result).toHaveProperty("provider", "health_mart");
   });
+
+  it("it should name unnamed locations by the brand name", () => {
+    const result = formatStore({
+      ...basicVaccineSpotterStore,
+      properties: {
+        ...basicVaccineSpotterStore.properties,
+        name: "",
+        provider_brand_name: "Harvey's",
+      },
+    });
+
+    expect(result.name).toEqual("Harvey's");
+  });
+
+  it("it should calculate an ID for southeasern_grocers brands", () => {
+    const result = formatStore({
+      ...basicVaccineSpotterStore,
+      properties: {
+        ...basicVaccineSpotterStore.properties,
+        name: "",
+        provider: "southeastern_grocers",
+        provider_brand: "harveys",
+        provider_brand_id: 1386,
+        provider_brand_name: "Harveys",
+        provider_location_id: "3-1688",
+      },
+    });
+
+    expect(result).toHaveProperty("name", "Harveys #1688");
+    expect(result).toHaveProperty("external_ids.harveys", "1688");
+  });
 });


### PR DESCRIPTION
This addresses some edge cases in VaccineSpotter data I discovered today after turning it on for more states. There are a few providers (mainly Southeastern Grocers) that don't have store names, and one location that appears to just be garbage data (almost all fields are `null`). This adds more graceful handling for those issues.