### PR TITLE
Turn down Rite Aid update frequency for now

### DIFF
--- a/terraform/loaders.tf
+++ b/terraform/loaders.tf
@@ -91,7 +91,7 @@ module "rite_aid_loader" {
   api_url       = "http://${aws_alb.main.dns_name}"
   api_key       = var.api_key
   sentry_dsn    = var.loader_sentry_dsn
-  schedule      = "rate(4 minutes)"
+  schedule      = "rate(5 minutes)"
   cluster_arn   = aws_ecs_cluster.main.arn
   role          = aws_iam_role.ecs_task_execution_role.arn
   subnets       = aws_subnet.public.*.id


### PR DESCRIPTION
Rite Aid has gotten in touch and is currently concerned with the number of requests, so we’re turning this down slightly for now. Need to work out with them the right frequency, and whether this should change once they release their SMART Scheduling Links API.