### PR TITLE
Add bastion security group to RDS database

### DIFF
--- a/terraform/db.tf
+++ b/terraform/db.tf
@@ -12,6 +12,9 @@ module "db" {
   engine_version                = "13.1"
   allocated_storage             = var.db_size
   instance_class                = var.db_instance
-  ingress_allow_security_groups = [aws_security_group.ecs_tasks.id]
+  ingress_allow_security_groups = compact([
+    aws_security_group.ecs_tasks.id,
+    var.bastion_security_group_id
+  ])
   performance_insights_enabled  = true
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -114,3 +114,8 @@ variable "loader_sentry_dsn" {
   default     = ""
   sensitive   = true
 }
+
+variable "bastion_security_group_id" {
+  description = "ID for a security group in AWS that allows access to a bastion server inside our VPC. SSHing into this server will allow access to any services that allow this security group."
+  default     = "sg-06fc404762de692db"
+}


### PR DESCRIPTION
@astonm pointed out this morning that I had manually created a bastion server for getting access to the RDS database in order to do dumps and run scripts like #157, but that my manual mucking about would not play nice with Terraform. This adds the security group to our Terraform configuration.

Notably, it does *not* add the security group itself to Terraform, but just manages the group's attachment to our various services (in this case, just RDS).