### PR TITLE
Restrict what states are supported for Rite Aid

### DIFF
--- a/loader/src/sources/riteaid/api.js
+++ b/loader/src/sources/riteaid/api.js
@@ -9,6 +9,28 @@ const { Available, LocationType } = require("../../model");
 // const log = logger.child({ source: "riteaidApi" });
 const log = console;
 
+// States in which Rite Aid has stores.
+const riteAidStates = new Set([
+  "CA",
+  "CO",
+  "CT",
+  "DE",
+  "ID",
+  "MA",
+  "MD",
+  "MI",
+  "NH",
+  "NJ",
+  "NV",
+  "NY",
+  "OH",
+  "OR",
+  "PA",
+  "VA",
+  "VT",
+  "WA",
+]);
+
 async function queryState(state) {
   const RITE_AID_URL = process.env["RITE_AID_URL"];
   const RITE_AID_KEY = process.env["RITE_AID_KEY"];
@@ -133,8 +155,13 @@ async function checkAvailability(handler, options) {
   } else if (options.states) {
     states = options.states.split(",").map((state) => state.trim());
   }
+  // Rite Aid only has stores in a few states, so filter down to those.
+  states = states.filter((state) => riteAidStates.has(state));
 
-  if (!states.length) console.warn("No states specified for riteAidApi");
+  if (!states.length) {
+    const statesText = Array.from(riteAidStates).join(", ");
+    console.warn(`No states set for riteAidApi (supported: ${statesText})`);
+  }
 
   let results = [];
   for (const state of states) {

--- a/loader/test/riteaid.api.test.js
+++ b/loader/test/riteaid.api.test.js
@@ -1,5 +1,5 @@
 const nock = require("nock");
-const { queryState } = require("../src/sources/riteaid/api");
+const { checkAvailability, queryState } = require("../src/sources/riteaid/api");
 
 describe("Rite Aid Source", () => {
   const API_URL = "https://api.riteaid.com/test";
@@ -13,6 +13,7 @@ describe("Rite Aid Source", () => {
 
   afterEach(() => {
     Object.assign(process.env, _env);
+    nock.cleanAll();
   });
 
   it("throws on failing API response", async () => {
@@ -178,5 +179,11 @@ describe("Rite Aid Source", () => {
     for (let location of locations) {
       expect(location.availability.checked_at).not.toBeUndefined();
     }
+  });
+
+  it("does not attempt to load states without Rite Aid stores", async () => {
+    nock(API_URL).get("?stateCode=AK").reply(403, "uhoh");
+    const results = await checkAvailability(() => {}, { states: "AK" });
+    expect(results).toHaveLength(0);
   });
 });

--- a/terraform/loaders.tf
+++ b/terraform/loaders.tf
@@ -87,7 +87,7 @@ module "rite_aid_loader" {
 
   name          = "riteAidApi"
   loader_source = "riteAidApi"
-  command       = ["--states", "AL,AK,AZ,AR,CA,CO,CT,DE,DC,FL,GA,HI,ID,IL,IN,IA,KS,KY,LA,ME,MD,MA,MI,MN,MS,MO,MT,NE,NV,NH,NJ,NM,NY,NC,ND,OH,OK,OR,PA,RI,SC,SD,TN,TX,UT,VT,VA,WA,WV,WI,WY,MH,PR,VI"]
+  command       = ["--states", "CA,CO,CT,DE,ID,MA,MD,MI,NH,NJ,NV,NY,OH,OR,PA,VA,VT,WA"]
   api_url       = "http://${aws_alb.main.dns_name}"
   api_key       = var.api_key
   sentry_dsn    = var.loader_sentry_dsn


### PR DESCRIPTION
Restrict what states we check for Rite Aid to only those where there are Rite Aid stores. Their API is giving us occasional 403 responses because we make too many requests. The way I've done this is a little redundant (the list of states is limited in the runtime configuration, but *also* in the source), but the source-level restriction seemed useful in case we are ever less careful than we should be in the future.

We used to query an even smaller set of locations (based on a map of where vaccinations are offered on Rite Aid's COVID-19 page), but later found some results outside that list, so expanded it to *all* states. This tries to cut a better happy medium by querying all states where there are Rite Aid stores, which means fewer queries, but should still cover a superset of everywhere vaccinations might be offered.