### PR TITLE
Scale main DB up to 132 GB

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -64,7 +64,7 @@ variable "db_instance" {
 
 variable "db_size" {
   description = "The storage size for the DB"
-  default     = 100
+  default     = 132
 }
 
 variable "api_key" {


### PR DESCRIPTION
This should give us a little bit more headroom for now to finish merging in the log cleaning tasks and make decisions about autoscaling, etc.