### PR TITLE
Set up Cloudwatch alarms for database and send to SNS topic

### DIFF
--- a/terraform/modules/rds/main.tf
+++ b/terraform/modules/rds/main.tf
@@ -76,6 +76,7 @@ module "aws_db_instance_alarms" {
   db_instance_id    = aws_db_instance.main.id
   db_instance_class = aws_db_instance.main.instance_class
   actions_alarm     = [aws_sns_topic.alarms_sns.arn]
+  actions_ok        = [aws_sns_topic.alarms_sns.arn]
 }
 
 resource "aws_sns_topic" "alarms_sns" {


### PR DESCRIPTION
This PR leans heavily on [lorenzoaiello/terraform-aws-rds-alarms](https://github.com/lorenzoaiello/terraform-aws-rds-alarms), which seems to have some nice defaults set up for monitoring a bunch of aspects of the RDS instance, including CPU utilization, disk space, and others. If we prefer a pruned list, we can pull just the relevant ones in explicitly, but I think it's a reasonable place to start.

On the SNS front, I'm not sure if we need any more configuration other than the name.