### PR TITLE
Switch back to using primary database

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -91,9 +91,7 @@ module "api_task" {
 
   env_vars = {
     RELEASE     = var.api_release_version
-    # Ideally this should be `module.db.host`, but this is currently pointing
-    # at a manually restored backup.
-    DB_HOST     = "availability-db-2.cljmauino9sh.us-west-2.rds.amazonaws.com"
+    DB_HOST     = module.db.host
     DB_NAME     = module.db.db_name
     DB_USERNAME = var.db_user
     DB_PASSWORD = var.db_password


### PR DESCRIPTION
This switches the API servers back to using the primary database from the restored backup that we temporarily switched to in #169. We'll lose a couple hours of availability updates, but I think that's ok, and this makes the configuration correct again.