### PR TITLE
Lower alarm threshold for RDS burst balance

### DIFF
--- a/terraform/modules/rds/main.tf
+++ b/terraform/modules/rds/main.tf
@@ -77,6 +77,11 @@ module "aws_db_instance_alarms" {
   db_instance_class = aws_db_instance.main.instance_class
   actions_alarm     = [aws_sns_topic.alarms_sns.arn]
   actions_ok        = [aws_sns_topic.alarms_sns.arn]
+
+  # Our basic behavior is bursty -- we send hundreds or thousands of updates
+  # in rapid succession every few minutes, so we expect to regularly go below
+  # 100% burst balance, but not *way* below.
+  disk_burst_balance_too_low_threshold = "80"
 }
 
 resource "aws_sns_topic" "alarms_sns" {


### PR DESCRIPTION
The default threshold is to alert anytime our burst balance goes below 100%, i.e. any time we use some burst capacity. Since our basic behavior tests to be burst-prone, this is a little spammy. Lower the threshold to limit the alarms.