### PR TITLE
Handle bad njvss zip codes

### DIFF
--- a/loader/src/sources/njvss/index.js
+++ b/loader/src/sources/njvss/index.js
@@ -464,6 +464,7 @@ async function checkAvailability(handler, _options) {
       // the same IIS identifier. `njiis_covid` adds in the location name to
       // make the identifier unique.
       njiis_covid: createNjIisId(location),
+      njvss_res_id: location.res_id || undefined,
     };
 
     let name = location.name;


### PR DESCRIPTION
NJVSS has some malformed records with 4-digit zip codes in the address (thanks to Vaccinate the States folks for calling these out). These are often missing a `0` prefix, but not always, so we can't automatically fix them. Instead, we warn on the situation and simply do not save the zip code (but do save the rest of the address).

While I was at it, I also added `njvss_res_id` as an external ID.  NJVSS now outputs `res_id`, which I understand is the GUID for the ID of the location in Microsoft Dynamics, which is what Microsoft VRAS is built on, which is what NJVSS is built on.