### PR TITLE
Load scraped Rite Aid data from VaccineSpotter

### DIFF
--- a/loader/src/sources/vaccinespotter/index.js
+++ b/loader/src/sources/vaccinespotter/index.js
@@ -155,6 +155,74 @@ function formatCapacity(apiSlots) {
 }
 
 /**
+ * Format an `availability` object from the location's data.
+ * @param {any} apiLocation
+ * @returns {any}
+ */
+function formatAvailability(apiLocation) {
+  let available = Available.unknown;
+  if (apiLocation.appointments_available) {
+    available = Available.yes;
+  } else if (apiLocation.appointments_available === false) {
+    available = Available.no;
+  }
+
+  const availability = {
+    source: "univaf-vaccinespotter",
+    valid_at: apiLocation.appointments_last_fetched,
+    checked_at: new Date().toISOString(),
+    available,
+  };
+
+  if (validateSlots(apiLocation)) {
+    const capacity = formatCapacity(apiLocation.appointments);
+    availability.capacity = capacity;
+
+    const slots = formatSlots(apiLocation.appointments);
+    if (slots) {
+      availability.slots = slots;
+    }
+
+    const allProducts = capacity
+      .flatMap((data) => data.products)
+      .filter((x) => !!x);
+    const allDoses = capacity.map((data) => data.dose).filter((x) => !!x);
+    if (allProducts.length) {
+      availability.products = Array.from(new Set(allProducts));
+    }
+    if (allDoses.length) {
+      availability.doses = Array.from(new Set(allDoses));
+    }
+  }
+
+  if (apiLocation.appointment_vaccine_types && !availability.products) {
+    const products = [];
+    for (const key in apiLocation.appointment_vaccine_types) {
+      if (key !== "unknown" && apiLocation.appointment_vaccine_types[key]) {
+        products.push(key);
+      }
+    }
+    if (products.length) {
+      availability.products = products;
+    }
+  }
+
+  if (apiLocation.appointment_types && !availability.doses) {
+    const doses = [];
+    for (const key in apiLocation.appointment_types) {
+      if (key !== "unknown" && apiLocation.appointment_types[key]) {
+        doses.push(key);
+      }
+    }
+    if (doses.length) {
+      availability.doses = doses;
+    }
+  }
+
+  return availability;
+}
+
+/**
  * Filter out some stores with bad data.
  * @param {any} store
  * @returns {boolean}
@@ -169,13 +237,6 @@ function hasUsefulData(store) {
 
 const formatters = {
   _base(store, additions = null) {
-    let available = Available.unknown;
-    if (store.properties.appointments_available) {
-      available = Available.yes;
-    } else if (store.properties.appointments_available === false) {
-      available = Available.no;
-    }
-
     // Determine what identifier type to use for `external_ids`.
     let provider = store.properties.provider.trim().toLowerCase();
     let providerBrand = store.properties.provider_brand;
@@ -193,60 +254,6 @@ const formatters = {
       id = `${providerBrand}:${store.properties.provider_location_id}`;
     } else {
       id = `vaccinespotter:${store.properties.id}`;
-    }
-
-    const availability = {
-      source: "univaf-vaccinespotter",
-      valid_at: store.properties.appointments_last_fetched,
-      checked_at: new Date().toISOString(),
-      available,
-    };
-    if (validateSlots(store.properties)) {
-      const capacity = formatCapacity(store.properties.appointments);
-      availability.capacity = capacity;
-
-      const slots = formatSlots(store.properties.appointments);
-      if (slots) {
-        availability.slots = slots;
-      }
-
-      const allProducts = capacity
-        .flatMap((data) => data.products)
-        .filter((x) => !!x);
-      const allDoses = capacity.map((data) => data.dose).filter((x) => !!x);
-      if (allProducts.length) {
-        availability.products = Array.from(new Set(allProducts));
-      }
-      if (allDoses.length) {
-        availability.doses = Array.from(new Set(allDoses));
-      }
-    }
-
-    if (store.properties.appointment_vaccine_types && !availability.products) {
-      const products = [];
-      for (const key in store.properties.appointment_vaccine_types) {
-        if (
-          key !== "unknown" &&
-          store.properties.appointment_vaccine_types[key]
-        ) {
-          products.push(key);
-        }
-      }
-      if (products.length) {
-        availability.products = products;
-      }
-    }
-
-    if (store.properties.appointment_types && !availability.doses) {
-      const doses = [];
-      for (const key in store.properties.appointment_types) {
-        if (key !== "unknown" && store.properties.appointment_types[key]) {
-          doses.push(key);
-        }
-      }
-      if (doses.length) {
-        availability.doses = doses;
-      }
     }
 
     return {
@@ -282,7 +289,7 @@ const formatters = {
         ...additions?.external_ids,
       },
       availability: {
-        ...availability,
+        ...formatAvailability(store.properties),
         ...additions?.availability,
       },
     };


### PR DESCRIPTION
We’ve avoided loading scraped Rite Aid data from VaccineSpotter since we had access to their official API. However, the API lacks product and dose information that New Jersey really wants to have, and which VaccineSpotter does gather. Loading this data will allow us to mix it with official data in #187.