### PR TITLE
Merge location fields when merging locations

### DIFF
--- a/server/scripts/remove-duplicate-locations.js
+++ b/server/scripts/remove-duplicate-locations.js
@@ -309,12 +309,11 @@ async function doChanges(toUpdate, toMerge, persist = false) {
         }
 
         // Merge main fields of provider_locations
-        let dataToUpdate = { updated_at: new Date() };
-        if (updates.newData) {
-          dataToUpdate = { ...updates.newData, ...dataToUpdate };
-        }
         await trx("provider_locations")
-          .update(dataToUpdate)
+          .update({
+            ...updates.newData,
+            updated_at: new Date(),
+          })
           .where("id", mergeTo);
 
         for (const from of mergeFroms) {


### PR DESCRIPTION
The previous locations merging script only updated the external IDs and availabilities of the location that other locations were merged into. With this change, we also fill in any fields that were NULL from the other objects that are being merged away.