### PR TITLE
Temporarily "disable" loaders

### DIFF
--- a/terraform/loaders.tf
+++ b/terraform/loaders.tf
@@ -43,7 +43,8 @@ module "cvs_smart_loader" {
   api_url       = "http://${aws_alb.main.dns_name}"
   api_key       = var.api_key
   sentry_dsn    = var.loader_sentry_dsn
-  schedule      = "rate(2 minutes)"
+  # schedule      = "rate(2 minutes)"
+  schedule      = "rate(1 day)"
   cluster_arn   = aws_ecs_cluster.main.arn
   role          = aws_iam_role.ecs_task_execution_role.arn
   subnets       = aws_subnet.public.*.id
@@ -57,7 +58,8 @@ module "njvss_loader" {
   api_url       = "http://${aws_alb.main.dns_name}"
   api_key       = var.api_key
   sentry_dsn    = var.loader_sentry_dsn
-  schedule      = "rate(2 minutes)"
+  # schedule      = "rate(2 minutes)"
+  schedule      = "rate(1 day)"
   cluster_arn   = aws_ecs_cluster.main.arn
   role          = aws_iam_role.ecs_task_execution_role.arn
   subnets       = aws_subnet.public.*.id
@@ -76,7 +78,8 @@ module "vaccinespotter_loader" {
   api_url       = "http://${aws_alb.main.dns_name}"
   api_key       = var.api_key
   sentry_dsn    = var.loader_sentry_dsn
-  schedule      = "rate(5 minutes)"
+  # schedule      = "rate(5 minutes)"
+  schedule      = "rate(1 day)"
   cluster_arn   = aws_ecs_cluster.main.arn
   role          = aws_iam_role.ecs_task_execution_role.arn
   subnets       = aws_subnet.public.*.id
@@ -91,7 +94,8 @@ module "rite_aid_loader" {
   api_url       = "http://${aws_alb.main.dns_name}"
   api_key       = var.api_key
   sentry_dsn    = var.loader_sentry_dsn
-  schedule      = "rate(5 minutes)"
+  # schedule      = "rate(5 minutes)"
+  schedule      = "rate(1 day)"
   cluster_arn   = aws_ecs_cluster.main.arn
   role          = aws_iam_role.ecs_task_execution_role.arn
   subnets       = aws_subnet.public.*.id
@@ -110,7 +114,8 @@ module "washington_doh_loader" {
   api_url       = "http://${aws_alb.main.dns_name}"
   api_key       = var.api_key
   sentry_dsn    = var.loader_sentry_dsn
-  schedule      = "rate(5 minutes)"
+  # schedule      = "rate(5 minutes)"
+  schedule      = "rate(1 day)"
   cluster_arn   = aws_ecs_cluster.main.arn
   role          = aws_iam_role.ecs_task_execution_role.arn
   subnets       = aws_subnet.public.*.id


### PR DESCRIPTION
Turn down loaders’ rate to 1/day, essentially disabling them. This is step 4 of #208. After turning them down, I'll manually compact the `availability_log` table.

(Needs to wait for step 3 to finish before merging and applying.)