### PR TITLE
Change contact e-mail to `univaf@`

### DIFF
--- a/server/public/docs/openapi.yaml
+++ b/server/public/docs/openapi.yaml
@@ -33,7 +33,7 @@ info:
     standard, a national standard for vaccine appointment availability data.
     Other names indicate custom or proprietary APIs.
   contact:
-    email: rbrackett@usdigitalresponse.org
+    email: univaf@usdigitalresponse.org
   license:
     name: MIT
     url: "https://opensource.org/licenses/MIT"


### PR DESCRIPTION
We no longer need to use my personal e-mail as the contact address for questions about the API. Now we have a group alias for the team! Any e-mails to univaf@usdigitalresponse.org will go to the UNIVAF team. :)