### PR TITLE
Add new `univaf-*` container registries

### DIFF
--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -1,4 +1,4 @@
-resource "aws_ecr_repository" "server_deprecated" {
+resource "aws_ecr_repository" "server" {
   name                 = "appointment-server"
   image_tag_mutability = "MUTABLE"
 
@@ -7,7 +7,7 @@ resource "aws_ecr_repository" "server_deprecated" {
   }
 }
 
-resource "aws_ecr_repository" "seed_deprecated" {
+resource "aws_ecr_repository" "seed" {
   name                 = "appointment-db-seed"
   image_tag_mutability = "MUTABLE"
 
@@ -16,7 +16,7 @@ resource "aws_ecr_repository" "seed_deprecated" {
   }
 }
 
-resource "aws_ecr_repository" "loader_deprecated" {
+resource "aws_ecr_repository" "loader" {
   name                 = "appointment-loader"
   image_tag_mutability = "MUTABLE"
 
@@ -25,7 +25,7 @@ resource "aws_ecr_repository" "loader_deprecated" {
   }
 }
 
-resource "aws_ecr_repository" "server" {
+resource "aws_ecr_repository" "server_repository" {
   name                 = "univaf-server"
   image_tag_mutability = "MUTABLE"
 
@@ -34,7 +34,7 @@ resource "aws_ecr_repository" "server" {
   }
 }
 
-resource "aws_ecr_repository" "seed" {
+resource "aws_ecr_repository" "seed_repository" {
   name                 = "univaf-db-seed"
   image_tag_mutability = "MUTABLE"
 
@@ -43,7 +43,7 @@ resource "aws_ecr_repository" "seed" {
   }
 }
 
-resource "aws_ecr_repository" "loader" {
+resource "aws_ecr_repository" "loader_repository" {
   name                 = "univaf-loader"
   image_tag_mutability = "MUTABLE"
 


### PR DESCRIPTION
This adds the new registries so we can start using them in #255. If we merge this first, that should resolve the build errors in that PR, and we won’t have build errors when we first land it.