### PR TITLE
Start pushing builds to new ECR repositories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,15 +136,15 @@ jobs:
         # Instead of building all combinations of a set of options, just build
         # these particular combinations.
         include:
-          - repository: appointment-db-seed
+          - repository: univaf-db-seed
             dockerfile: "./server/Dockerfile.seed-db"
             build_path: "./server"
 
-          - repository: appointment-server
+          - repository: univaf-server
             dockerfile: "./server/Dockerfile"
             build_path: "./server"
 
-          - repository: appointment-loader
+          - repository: univaf-loader
             dockerfile: "./loader/Dockerfile"
             build_path: "./loader"
     env:


### PR DESCRIPTION
This is follow-on 1 for #258. It starts pushing images to the new repositories. Once we've got releases in there, we can switch the tasks to start using them in the next PR.