### PR TITLE
Switch to loading task images from new ECR repos

### DIFF
--- a/terraform/db_seed.tf
+++ b/terraform/db_seed.tf
@@ -4,7 +4,7 @@ module "db_seed_task" {
   source = "./modules/task"
 
   name   = "db-seed"
-  image  = "681497372638.dkr.ecr.us-west-2.amazonaws.com/appointment-db-seed"
+  image  = "681497372638.dkr.ecr.us-west-2.amazonaws.com/univaf-db-seed"
   role   = aws_iam_role.ecs_task_execution_role.arn
   cpu    = var.cpu
   memory = var.memory

--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -1,3 +1,4 @@
+# DEPRECATED: Images should now all be in univaf-server (see below).
 resource "aws_ecr_repository" "server" {
   name                 = "appointment-server"
   image_tag_mutability = "MUTABLE"
@@ -7,6 +8,7 @@ resource "aws_ecr_repository" "server" {
   }
 }
 
+# DEPRECATED: Images should now all be in univaf-db-seed (see below).
 resource "aws_ecr_repository" "seed" {
   name                 = "appointment-db-seed"
   image_tag_mutability = "MUTABLE"
@@ -16,6 +18,7 @@ resource "aws_ecr_repository" "seed" {
   }
 }
 
+# DEPRECATED: Images should now all be in univaf-loader (see below).
 resource "aws_ecr_repository" "loader" {
   name                 = "appointment-loader"
   image_tag_mutability = "MUTABLE"

--- a/terraform/modules/loader/main.tf
+++ b/terraform/modules/loader/main.tf
@@ -2,7 +2,7 @@ module "loader_task" {
   source = "../task"
 
   name    = var.name
-  image   = "681497372638.dkr.ecr.us-west-2.amazonaws.com/appointment-loader"
+  image   = "681497372638.dkr.ecr.us-west-2.amazonaws.com/univaf-loader"
   role    = var.role
   cpu     = 1024
   memory  = 2048

--- a/terraform/server_deploy.tf.json
+++ b/terraform/server_deploy.tf.json
@@ -4,7 +4,7 @@
   "variable": {
     "api_release_version": {
       "description": "API Release Version",
-      "default": "1fc66427f2d442f7db5c04168e6d137f229f2bb2"
+      "default": "9222aa7bc470439e3c6db953dc5263ac9ad1917d"
     }
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -20,7 +20,7 @@ variable "az_count" {
 
 variable "api_image" {
   description = "Docker image to run in the ECS cluster"
-  default     = "681497372638.dkr.ecr.us-west-2.amazonaws.com/appointment-server"
+  default     = "681497372638.dkr.ecr.us-west-2.amazonaws.com/univaf-server"
 }
 
 variable "api_port" {


### PR DESCRIPTION
This is follow-on 2 for #258. Now that we are pushing images to the new `univaf-*` ECR repositories, we can safely start loading images from those repositories, which is what this PR does.

This looks like a new deploy to the API server, but there are no code changes — it just has a new hash because we started pushing to the new repository in a different commit.