### PR TITLE
Fix typo in documented SMART SL API URL

### DIFF
--- a/server/public/docs/openapi.yaml
+++ b/server/public/docs/openapi.yaml
@@ -284,7 +284,7 @@ paths:
             schema:
               $ref: "#/components/schemas/LocationUpdate"
         description: Location and availability to update/add.
-  "/smart-schedluing/$bulk-publish":
+  "/smart-scheduling/$bulk-publish":
     get:
       summary: "SMART Scheduling Links"
       description: |


### PR DESCRIPTION
The URL for our SMART Scheduling Links endpoint had a typo, so the links in the docs didn’t work!