### PR TITLE
Build images less often, and only after tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "docs/**"
+      - "terraform/**"
+      - "docker/postgis/**"
 
 name: Continuous Integration
 
@@ -131,6 +135,9 @@ jobs:
           workflows: '[".github/workflows/*.yaml", ".github/workflows/*.yml"]'
 
   build_docker:
+    needs:
+      - lint
+      - test
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
We build a lot of unnecessary docker images for commits that don't change any code involved in the build (e.g. when we update terraform configs to deploy something). This changes our CI workflow so it doesn't build the images if only the `docs`, `tarraform`, or `docker/postgis` directories changed. It also only builds after (and if) tests and linting succeeded.

It’s meant to streamline things just a little bit.