### PR TITLE
Update all repo URLs to `usdigitalresponse/univaf`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Code of Conduct](https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-blue.svg?style=flat)](https://github.com/usdigitalresponse/appointment-availability-infra/blob/main/CODE_OF_CONDUCT.md) [![CI Tests](https://github.com/usdigitalresponse/appointment-availability-infra/actions/workflows/ci.yml/badge.svg)](https://github.com/usdigitalresponse/appointment-availability-infra/actions/workflows/ci.yml)
+[![Code of Conduct](https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-blue.svg?style=flat)](https://github.com/usdigitalresponse/univaf/blob/main/CODE_OF_CONDUCT.md) [![CI Tests](https://github.com/usdigitalresponse/univaf/actions/workflows/ci.yml/badge.svg)](https://github.com/usdigitalresponse/univaf/actions/workflows/ci.yml)
 
 
 # UNIVAF: Vaccine Appointment Availability API

--- a/docs/incidents/2021-06-03--database-full.md
+++ b/docs/incidents/2021-06-03--database-full.md
@@ -73,8 +73,8 @@ Original database is finished being upsized and the API service is switched back
 - @astonm
 
 
-[issue-163]: https://github.com/usdigitalresponse/appointment-availability-infra/issues/163
-[issue-164]: https://github.com/usdigitalresponse/appointment-availability-infra/issues/164
-[issue-169]: https://github.com/usdigitalresponse/appointment-availability-infra/issues/169
-[issue-171]: https://github.com/usdigitalresponse/appointment-availability-infra/issues/171
-[issue-172]: https://github.com/usdigitalresponse/appointment-availability-infra/issues/172
+[issue-163]: https://github.com/usdigitalresponse/univaf/issues/163
+[issue-164]: https://github.com/usdigitalresponse/univaf/issues/164
+[issue-169]: https://github.com/usdigitalresponse/univaf/issues/169
+[issue-171]: https://github.com/usdigitalresponse/univaf/issues/171
+[issue-172]: https://github.com/usdigitalresponse/univaf/issues/172

--- a/docs/incidents/2021-06-11--database-low.md
+++ b/docs/incidents/2021-06-11--database-low.md
@@ -91,5 +91,5 @@ Database resized, table repacked, all good!
 - @Mr0grog
 
 
-[issue-184]: https://github.com/usdigitalresponse/appointment-availability-infra/issues/184
-[issue-208]: https://github.com/usdigitalresponse/appointment-availability-infra/issues/208
+[issue-184]: https://github.com/usdigitalresponse/univaf/issues/184
+[issue-208]: https://github.com/usdigitalresponse/univaf/issues/208

--- a/docs/runbook/README.md
+++ b/docs/runbook/README.md
@@ -62,7 +62,7 @@ After merging a PR into the `main` branch, you can deploy via the following step
 4. In Terraform Cloud, click "see details" on the latest run, and review the plan it shows to ensure it makes sense.
 5. In Terraform Cloud, click the confirm button to apply the plan.
 
-**The Demo UI** just runs as a GitHub pages site, and is automatically updated via the [`ui-deploy` workflow][workflow-ui-deploy] every time a commit lands on the `main` branch. You can view it at https://usdigitalresponse.github.io/appointment-availability-infra/.
+**The Demo UI** just runs as a GitHub pages site, and is automatically updated via the [`ui-deploy` workflow][workflow-ui-deploy] every time a commit lands on the `main` branch. You can view it at https://usdigitalresponse.github.io/univaf/.
 
 
 ## Bastion Server
@@ -86,5 +86,5 @@ And then run any commands you'd like from inside the SSH session.
 [sentry]: https://sentry.io/
 [bastion-server]: https://en.wikipedia.org/wiki/Bastion_host
 [workflow-ci]: ../../.github/workflows/ci.yml
-[workflow-ci-runs]: https://github.com/usdigitalresponse/appointment-availability-infra/actions/workflows/ci.yml
+[workflow-ci-runs]: https://github.com/usdigitalresponse/univaf/actions/workflows/ci.yml
 [workflow-ui-deploy]: ../../.github/workflows/ui-deploy.yml

--- a/docs/runbook/postgres.md
+++ b/docs/runbook/postgres.md
@@ -70,5 +70,5 @@ If a table gets too big and you need to save disk space on the database server, 
 - `pg_repack` is an extension that can remove dead rows and extra space while the table is live and available for writes, but it requires the table to have some column that can serve as a unique key (i.e. something that is effectively a primary key, although it does not have to be set as an actual primary key in the table definition). It requires the same extra space that `CLUSTER` and `VACUUM FULL` do, and runs a little bit slower. This article offers a good overview of how to get started with `pg_repack`: https://medium.com/dunzo/reclaiming-storage-space-in-postgres-d32fa4168e67
 
 
-[issue-208]: https://github.com/usdigitalresponse/appointment-availability-infra/issues/208
+[issue-208]: https://github.com/usdigitalresponse/univaf/issues/208
 [bastion-server]: ./README.md#bastion-server

--- a/loader/package.json
+++ b/loader/package.json
@@ -8,14 +8,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/usdigitalresponse/appointment-availability-infra.git"
+    "url": "git+https://github.com/usdigitalresponse/univaf.git"
   },
   "author": "USDR",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/usdigitalresponse/appointment-availability-infra/issues"
+    "url": "https://github.com/usdigitalresponse/univaf/issues"
   },
-  "homepage": "https://github.com/usdigitalresponse/appointment-availability-infra#readme",
+  "homepage": "https://getmyvax.org/",
   "devDependencies": {
     "eslint": "^7.23.0",
     "jest": "^26.6.3",

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,7 @@
   "description": "An API server that stores and provides COVID-19 vaccine appointment availability data.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/usdigitalresponse/appointment-availability-infra"
+    "url": "https://github.com/usdigitalresponse/univaf"
   },
   "author": "USDR",
   "license": "MIT",

--- a/ui/package.json
+++ b/ui/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "repository": {
     "type": "git",
-    "url": "https://github.com/usdigitalresponse/appointment-availability-infra"
+    "url": "https://github.com/usdigitalresponse/univaf"
   },
   "author": "USDR",
   "license": "MIT",


### PR DESCRIPTION
We finally renamed the repo itself. Old links will automatically redirect, but this updates all the places we have absolute URLs to the repo so they point to the new URL/name at `usdigitalresponse/univaf`.

This is part of #233.