### PR TITLE
HOTFIX: Make `locations.ndjson` not gobbledeguk

### DIFF
--- a/server/src/api/edge.ts
+++ b/server/src/api/edge.ts
@@ -115,7 +115,7 @@ export async function listStream(
       if (!started) {
         writeStart();
       }
-      await write(JSON.stringify(location + "\n"));
+      await write(JSON.stringify(location) + "\n");
     }
 
     // Stop if we've been reading for too long and write an error entry.

--- a/server/test/lib.ts
+++ b/server/test/lib.ts
@@ -97,3 +97,14 @@ export function expectDatetimeString(): any {
     /^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(.\d+)?(Z|[+-]\d\d:?\d\d)$/
   );
 }
+
+/**
+ * Parse an ND-JSON (newline-delimited JSON) string in to an array of objects.
+ * @param rawData the ND-JSON string to parse.
+ */
+export function ndjsonParse(rawData: string): any[] {
+  return rawData
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}

--- a/server/test/smart-scheduling.test.ts
+++ b/server/test/smart-scheduling.test.ts
@@ -1,5 +1,9 @@
 import type { AddressInfo } from "net";
-import { useServerForTests, installTestDatabaseHooks } from "./lib";
+import {
+  useServerForTests,
+  installTestDatabaseHooks,
+  ndjsonParse,
+} from "./lib";
 import app from "../src/app";
 import { createLocation } from "../src/db";
 import { TestLocation } from "./fixtures";
@@ -29,13 +33,6 @@ describe("GET /smart-scheduling/$bulk-publish", () => {
     expect(data.output).toHaveLength(50 * 3); // 50 states, Location/Schedule/Slot
   });
 });
-
-function ndjsonParse(s: string): any {
-  return s
-    .split("\n")
-    .filter(Boolean)
-    .map((l) => JSON.parse(l));
-}
 
 describe("GET /smart-scheduling/locations/states/:state.ndjson", () => {
   const context = useServerForTests(app);


### PR DESCRIPTION
We completely broke `/api/edge/locations.ndjson` in #266. It turns out we don't have any tests for it. This fixes the issue and adds one quick test; we'll add more as a follow-on.