### PR TITLE
Stop building and pushing `univaf-db-seed` image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,10 +144,6 @@ jobs:
         # Instead of building all combinations of a set of options, just build
         # these particular combinations.
         include:
-          - repository: univaf-db-seed
-            dockerfile: "./server/Dockerfile.seed-db"
-            build_path: "./server"
-
           - repository: univaf-server
             dockerfile: "./server/Dockerfile"
             build_path: "./server"


### PR DESCRIPTION
We no longer really need the `univaf-db-seed` image for anything in production and we want to use less of USDR's GitHub Actions minutes. This stops building that image, since it probably isn't really worthwhile.