### PR TITLE
Improve SMART SL API, use new aggregator guidance

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -47,6 +47,7 @@
         "@types/jest": "26.0.20",
         "@types/knex": "^0.16.1",
         "@types/lodash": "4.14.171",
+        "@types/luxon": "^1.27.1",
         "@types/node": "14.14.31",
         "@types/pg": "^8.6.1",
         "@types/request": "2.48.6",
@@ -1776,6 +1777,12 @@
       "version": "4.14.171",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.171.tgz",
       "integrity": "sha512-7eQ2xYLLI/LsicL2nejW9Wyko3lcpN6O/z0ZLHrEQsg280zIdCv1t/0m6UtBjUHokCGBQ3gYTbHzDkZ1xOBwwg==",
+      "dev": true
+    },
+    "node_modules/@types/luxon": {
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-1.27.1.tgz",
+      "integrity": "sha512-cPiXpOvPFDr2edMnOXlz3UBDApwUfR+cpizvxCy0n3vp9bz/qe8BWzHPIEFcy+ogUOyjKuCISgyq77ELZPmkkg==",
       "dev": true
     },
     "node_modules/@types/mime": {
@@ -11368,6 +11375,12 @@
       "version": "4.14.171",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.171.tgz",
       "integrity": "sha512-7eQ2xYLLI/LsicL2nejW9Wyko3lcpN6O/z0ZLHrEQsg280zIdCv1t/0m6UtBjUHokCGBQ3gYTbHzDkZ1xOBwwg==",
+      "dev": true
+    },
+    "@types/luxon": {
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-1.27.1.tgz",
+      "integrity": "sha512-cPiXpOvPFDr2edMnOXlz3UBDApwUfR+cpizvxCy0n3vp9bz/qe8BWzHPIEFcy+ogUOyjKuCISgyq77ELZPmkkg==",
       "dev": true
     },
     "@types/mime": {

--- a/server/package.json
+++ b/server/package.json
@@ -69,6 +69,7 @@
     "@types/jest": "26.0.20",
     "@types/knex": "^0.16.1",
     "@types/lodash": "4.14.171",
+    "@types/luxon": "^1.27.1",
     "@types/node": "14.14.31",
     "@types/pg": "^8.6.1",
     "@types/request": "2.48.6",

--- a/server/public/docs/openapi.yaml
+++ b/server/public/docs/openapi.yaml
@@ -288,9 +288,48 @@ paths:
     get:
       summary: "SMART Scheduling Links"
       description: |
-        Provides location data according to the [SMART Scheduling Links standard](https://github.com/smart-on-fhir/smart-scheduling-links/specification.md).
-        Please see https://github.com/smart-on-fhir/smart-scheduling-links/ for
-        details.
+        Provides location data according to the [SMART Scheduling Links standard](https://github.com/smart-on-fhir/smart-scheduling-links/specification.md)
+        and follows the [guidelines for Slot Aggregators](https://github.com/smart-on-fhir/smart-scheduling-links/blob/master/specification.md#slot-aggregators).
+
+        Some particulars worth noting:
+
+        - Locations use the `meta.lastUpdated` to denote when information *about
+          the location* was last changed, not when availability was (this
+          matches the FHIR standard). For availability update times, check
+          *schedules* for `meta.extension` entries where `url == "http://hl7.org/fhir/StructureDefinition/lastSourceSync"`.
+          See the [section on freshness in the specification](https://github.com/smart-on-fhir/smart-scheduling-links/blob/master/specification.md#indicate-data-freshness)
+          for details.
+
+        - Locations currently have a single schedule. If product and dose info
+          is known, all available products and doses will be listed as
+          extensions on that schedule, rather than separate schedules for each
+          combination. (We may switch to multiple schedules in the future.)
+
+        - All schedules include the `"http://fhir-registry.smarthealthit.org/StructureDefinition/has-availability"`
+          extension. If you only need to know whether there are *some*
+          appointments available and don’t need information at the date or slot
+          level, you can use this and not bother requesting the slots at all.
+
+        - Locations with unknown availability have schedules, but no slots.
+
+        - Some locations do not list slots when they are busy. We do our best to
+          represent both free and busy slots, but some providers only publish
+          the slots that are available, and we can’t get details on unavailable
+          slots.
+
+        - Some slots are individual slots, while others represent larger
+          timeframes (often a whole day). The granularity of information depends
+          on the data source.
+
+        - Not all information about provider locations is available through this
+          API. In particular, it does not show:
+            - Provider organization name (`provider` in the main API), e.g. CVS,
+              Hope Hostpital, etc.
+            - Location type (`location_type` in the main API), e.g. mass
+              vaccination site, clinic, pharmacy.
+            - Whether you have to sign up for a waitlist (`requires_waitlist`
+              in the main API).
+            - Miscellaneous extra data (`meta` in the main API).
       responses:
         "200":
           description: SMART Scheduling Links manifest

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -22,8 +22,7 @@ export function getHostUrl(request?: Request): string {
     if (!request) {
       throw new Error("Cannot calculate host URL without a request");
     } else {
-      const port = request.app.get("port");
-      hostUrl = `${request.protocol}://${request.hostname}:${port}`;
+      hostUrl = `${request.protocol}://${request.headers.host}`;
     }
   }
   if (hostUrl.endsWith("/")) hostUrl = hostUrl.slice(0, -1);

--- a/server/src/interfaces.ts
+++ b/server/src/interfaces.ts
@@ -63,7 +63,7 @@ export interface ProviderLocation {
   internal_notes: string;
   created_at: Date;
   updated_at: Date;
-  availability?: any;
+  availability?: LocationAvailability;
 }
 
 export interface LocationAvailability {

--- a/server/src/interfaces.ts
+++ b/server/src/interfaces.ts
@@ -63,7 +63,7 @@ export interface ProviderLocation {
   internal_notes: string;
   created_at: Date;
   updated_at: Date;
-  availability?: LocationAvailability;
+  availability?: any;
 }
 
 export interface LocationAvailability {

--- a/server/src/smart-scheduling-routes.ts
+++ b/server/src/smart-scheduling-routes.ts
@@ -253,14 +253,19 @@ export async function listSchedules(
           }
         }
         if (provider.availability?.doses) {
-          const doseNumbers = provider.availability.doses.flatMap(
-            (dose: string) => DOSE_NUMBERS[dose] || []
+          const doseNumbers = new Set(
+            provider.availability.doses.flatMap(
+              (dose: string) => DOSE_NUMBERS[dose] || []
+            )
           );
-          for (const doseNumber of new Set(doseNumbers)) {
-            extension.push({
-              url: EXTENSION_VACCINE_DOSE,
-              valueInteger: doseNumber,
-            });
+          // Ensure extensions numerically sorted (`DOSE_NUMBERS.*` should be).
+          for (const doseNumber of DOSE_NUMBERS.all_doses) {
+            if (doseNumbers.has(doseNumber)) {
+              extension.push({
+                url: EXTENSION_VACCINE_DOSE,
+                valueInteger: doseNumber,
+              });
+            }
           }
         }
 

--- a/server/src/smart-scheduling-routes.ts
+++ b/server/src/smart-scheduling-routes.ts
@@ -10,7 +10,12 @@
 import { Request, Response } from "express";
 import { getHostUrl } from "./config";
 import * as db from "./db";
-import { Availability, LocationAvailability } from "./interfaces";
+import {
+  Availability,
+  LocationAvailability,
+  SlotRecord,
+  CapacityRecord,
+} from "./interfaces";
 import states from "./states.json";
 
 const BOOKING_DEEP_LINK =
@@ -246,7 +251,7 @@ export async function listSchedules(
         }
         if (provider.availability?.doses) {
           const doseNumbers = provider.availability.doses.flatMap(
-            (dose) => DOSE_NUMBERS[dose] || []
+            (dose: string) => DOSE_NUMBERS[dose] || []
           );
           for (const doseNumber of new Set(doseNumbers)) {
             extension.push({
@@ -313,7 +318,7 @@ export async function listSlots(req: Request, res: Response): Promise<void> {
           provider.availability?.slots || provider.availability?.capacity;
         if (!slots || !slots.length) return [];
 
-        return slots.map((slot) => {
+        return slots.map((slot: SlotRecord | CapacityRecord) => {
           const extension: Array<any> = [];
 
           if (slot.available_count != null) {

--- a/server/test/lib.ts
+++ b/server/test/lib.ts
@@ -3,8 +3,11 @@ import type { Application } from "express";
 import type { Server } from "http";
 import got, { Got } from "got";
 
-import { db } from "../src/db";
+import { db, createLocation, updateAvailability } from "../src/db";
 import { availabilityDb } from "../src/availability-log";
+import { ProviderLocation } from "../src/interfaces";
+import { TestLocation } from "./fixtures";
+
 import type { Knex } from "knex";
 
 interface Context {
@@ -82,6 +85,35 @@ function mockDbTransactions() {
       return await f(db);
     },
   });
+}
+
+/**
+ * Create a new provider with random identifiers.
+ * @param customizations Any specific values that should be set on the location.
+ *        If the `availability` property is set, an availability record will
+ *        also be created for the location (the value for `availability` only
+ *        needs to have the values you want to customize, acceptable values for
+ *        unspecified but required properties will be created for you).
+ * @returns {ProviderLocation}
+ */
+export async function createRandomLocation(
+  customizations: any
+): Promise<ProviderLocation> {
+  const location = await createLocation({
+    ...TestLocation,
+    id: null,
+    external_ids: [["test_id", Math.random().toString()]],
+    ...customizations,
+  });
+
+  if (customizations.availability) {
+    await updateAvailability(location.id, {
+      ...TestLocation.availability,
+      ...customizations.availability,
+    });
+  }
+
+  return location;
 }
 
 /**

--- a/server/test/smart-scheduling.test.ts
+++ b/server/test/smart-scheduling.test.ts
@@ -1,43 +1,17 @@
 import type { AddressInfo } from "net";
 import { DateTime } from "luxon";
 import {
+  createRandomLocation,
   useServerForTests,
   installTestDatabaseHooks,
   ndjsonParse,
 } from "./lib";
 import app from "../src/app";
-import { createLocation, updateAvailability } from "../src/db";
+import { createLocation } from "../src/db";
 import { TestLocation } from "./fixtures";
 import { Availability } from "../src/interfaces";
 
 installTestDatabaseHooks();
-
-/**
- * Create a new provider with random identifiers.
- * @param customizations Any specific values that should be set on the location.
- *        If the `availability` property is set, an availability record will
- *        also be created for the location (the value for `availability` only
- *        needs to have the values you want to customize, acceptable values for
- *        unspecified but required properties will be created for you).
- * @returns {ProviderLocation}
- */
-async function createRandomLocation(customizations: any) {
-  const location = await createLocation({
-    ...TestLocation,
-    id: null,
-    external_ids: [["test_id", Math.random().toString()]],
-    ...customizations,
-  });
-
-  if (customizations.availability) {
-    await updateAvailability(location.id, {
-      ...TestLocation.availability,
-      ...customizations.availability,
-    });
-  }
-
-  return location;
-}
 
 describe("GET /smart-scheduling/$bulk-publish", () => {
   const context = useServerForTests(app);

--- a/server/test/smart-scheduling.test.ts
+++ b/server/test/smart-scheduling.test.ts
@@ -8,7 +8,6 @@ import app from "../src/app";
 import { createLocation, updateAvailability } from "../src/db";
 import { TestLocation, TestLocation2 } from "./fixtures";
 import { Availability } from "../src/interfaces";
-import { constant } from "async";
 
 installTestDatabaseHooks();
 

--- a/server/test/smart-scheduling.test.ts
+++ b/server/test/smart-scheduling.test.ts
@@ -5,8 +5,10 @@ import {
   ndjsonParse,
 } from "./lib";
 import app from "../src/app";
-import { createLocation } from "../src/db";
-import { TestLocation } from "./fixtures";
+import { createLocation, updateAvailability } from "../src/db";
+import { TestLocation, TestLocation2 } from "./fixtures";
+import { Availability } from "../src/interfaces";
+import { constant } from "async";
 
 installTestDatabaseHooks();
 
@@ -70,23 +72,174 @@ describe("GET /smart-scheduling/schedules/states/:state.ndjson", () => {
     const data = ndjsonParse(res.body);
     expect(data).toHaveLength(1);
   });
+
+  it("shows available with `has-availability` extension", async () => {
+    let location = await createLocation(TestLocation);
+    await updateAvailability(location.id, {
+      ...TestLocation.availability,
+      available: Availability.YES,
+    });
+    location = await createLocation({
+      ...TestLocation2,
+      state: TestLocation.state,
+    });
+    await updateAvailability(location.id, {
+      ...TestLocation.availability,
+      available: Availability.NO,
+    });
+    location = await createLocation({
+      ...TestLocation,
+      id: "123",
+      external_ids: [["random", "value"]],
+    });
+    await updateAvailability(location.id, {
+      ...TestLocation.availability,
+      available: Availability.UNKNOWN,
+    });
+    // This location has not availability record at all.
+    await createLocation({
+      ...TestLocation,
+      id: "456",
+      external_ids: [["another", "value"]],
+    });
+
+    const url = `smart-scheduling/schedules/states/${TestLocation.state}.ndjson`;
+    const response = await context.client.get(url, { responseType: "text" });
+    expect(response.statusCode).toBe(200);
+    const data = ndjsonParse(response.body);
+    expect(data).toHaveLength(4);
+
+    const extension =
+      "http://fhir-registry.smarthealthit.org/StructureDefinition/has-availability";
+    expect(data[0].extension).toContainEqual({
+      url: extension,
+      valueCode: "some",
+    });
+    expect(data[1].extension).toContainEqual({
+      url: extension,
+      valueCode: "none",
+    });
+    expect(data[2].extension).toContainEqual({
+      url: extension,
+      valueCode: "unknown",
+    });
+    expect(data[3].extension).toContainEqual({
+      url: extension,
+      valueCode: "unknown",
+    });
+  });
+
+  it("includes products as extensions", async () => {
+    const location = await createLocation(TestLocation);
+    await updateAvailability(location.id, {
+      ...TestLocation.availability,
+      available: Availability.YES,
+      products: ["moderna", "jj"],
+    });
+
+    const url = `smart-scheduling/schedules/states/${TestLocation.state}.ndjson`;
+    const response = await context.client.get(url, { responseType: "text" });
+    expect(response.statusCode).toBe(200);
+    const data = ndjsonParse(response.body);
+
+    expect(data[0].extension).toContainEqual({
+      url:
+        "http://fhir-registry.smarthealthit.org/StructureDefinition/vaccine-product",
+      valueCoding: {
+        system: "http://hl7.org/fhir/sid/cvx",
+        code: 207,
+        display: "Moderna",
+      },
+    });
+    expect(data[0].extension).toContainEqual({
+      url:
+        "http://fhir-registry.smarthealthit.org/StructureDefinition/vaccine-product",
+      valueCoding: {
+        system: "http://hl7.org/fhir/sid/cvx",
+        code: 212,
+        display: "Johnson & Johnson",
+      },
+    });
+  });
 });
 
 describe("GET /smart-scheduling/slots/states/:state.ndjson", () => {
   const context = useServerForTests(app);
 
-  it("responds with a list of slots", async () => {
-    const url = `smart-scheduling/slots/states/${TestLocation.state}.ndjson`;
-
-    let res = await context.client.get(url, { responseType: "text" });
-    expect(res.statusCode).toBe(200);
-    expect(res.body).toHaveLength(0);
-
+  it("doesn't show slots for locations with unknown availability", async () => {
     await createLocation(TestLocation);
 
-    res = await context.client.get(url, { responseType: "text" });
-    expect(res.statusCode).toBe(200);
-    const data = ndjsonParse(res.body);
-    expect(data).toHaveLength(1);
+    const url = `smart-scheduling/slots/states/${TestLocation.state}.ndjson`;
+    const response = await context.client.get(url, { responseType: "text" });
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toHaveLength(0);
+  });
+
+  it("responds with all the relevant slots", async () => {
+    const location = await createLocation(TestLocation);
+    await updateAvailability(location.id, {
+      ...TestLocation.availability,
+      slots: [
+        {
+          start: new Date(),
+          end: new Date(Date.now() + 10 * 60 * 1000),
+          available: Availability.YES,
+        },
+        {
+          start: new Date(Date.now() + 10 * 60 * 1000),
+          end: new Date(Date.now() + 20 * 60 * 1000),
+          available: Availability.NO,
+        },
+      ],
+    });
+
+    const url = `smart-scheduling/slots/states/${TestLocation.state}.ndjson`;
+    const response = await context.client.get(url, { responseType: "text" });
+    expect(response.statusCode).toBe(200);
+    const data = ndjsonParse(response.body);
+    expect(data).toHaveLength(2);
+    expect(data[0]).toHaveProperty("status", "free");
+    expect(data[1]).toHaveProperty("status", "busy");
+  });
+
+  it("responds capacity-based slots if we don't know slots", async () => {
+    const location = await createLocation(TestLocation);
+    await updateAvailability(location.id, {
+      ...TestLocation.availability,
+      capacity: [
+        {
+          date: new Date().toISOString().slice(0, 10),
+          available: Availability.YES,
+          available_count: 10,
+        },
+        {
+          date: new Date(Date.now() + 24 * 60 * 60 * 1000)
+            .toISOString()
+            .slice(0, 10),
+          available: Availability.NO,
+          available_count: 0,
+        },
+      ],
+    });
+
+    const url = `smart-scheduling/slots/states/${TestLocation.state}.ndjson`;
+    const response = await context.client.get(url, { responseType: "text" });
+    expect(response.statusCode).toBe(200);
+    const data = ndjsonParse(response.body);
+    expect(data).toHaveLength(2);
+
+    expect(data[0]).toHaveProperty("status", "free");
+    expect(data[0].extension).toContainEqual({
+      url:
+        "http://fhir-registry.smarthealthit.org/StructureDefinition/slot-capacity",
+      valueInteger: 10,
+    });
+
+    expect(data[1]).toHaveProperty("status", "busy");
+    expect(data[1].extension).toContainEqual({
+      url:
+        "http://fhir-registry.smarthealthit.org/StructureDefinition/slot-capacity",
+      valueInteger: 0,
+    });
   });
 });

--- a/server/test/smart-scheduling.test.ts
+++ b/server/test/smart-scheduling.test.ts
@@ -95,7 +95,7 @@ describe("GET /smart-scheduling/schedules/states/:state.ndjson", () => {
       ...TestLocation.availability,
       available: Availability.UNKNOWN,
     });
-    // This location has not availability record at all.
+    // This location has no availability record at all.
     await createLocation({
       ...TestLocation,
       id: "456",


### PR DESCRIPTION
This vastly improves our implementation of the SMART Scheduling Links standard. It follows the new section with features designed for aggregators and also adds actual slots or daily capacity where we have them, now that we have top-level fields for that info.

- Fixes identifiers to use the new `external_ids` format.
- Simplifies location and schedule IDs.
- Adds last updated time to locations.
- Adds the `has-availability` extension on schedules instead of the wonky way we used to handle unknown availability.
- Adds `lastSourceSync` meta extension.
- Lists actual individual slots instead of one placeholder slot per location. If we don't know slots but do know daily capcity, that's used to create slots instead.
- Adds booking phone and deep link on slots.
- Adds capacity on slots.
- Includes available products and doses on each schedule.

This doesn’t create separate schedules for each product & dose combination, but we could do that in the future. It’s still technically valid, although the standard prefers that each product have a separate schedule if possible.

This also passes the two validators:
- https://infernotest.healthit.gov/community/
- https://github.com/lazau/scheduling-links-aggregator/tree/main/validator

This also adds docs about all the various particulars or caveats to our implementation.

Fixes #117.