### PR TITLE
Load geographic coordinates for Rite Aid and CVS

### DIFF
--- a/loader/src/cli.js
+++ b/loader/src/cli.js
@@ -77,7 +77,7 @@ async function run(options) {
           }`;
           const logData = {
             status_code: saveResult.statusCode,
-            source: data.availability.source,
+            source: data.availability?.source,
             location_id: data.id,
             location_name: data.name,
           };

--- a/loader/src/index.js
+++ b/loader/src/index.js
@@ -6,6 +6,7 @@ const sources = {
   riteAidApi: require("./sources/riteaid/api"),
   vaccinespotter: require("./sources/vaccinespotter"),
   waDoh: require("./sources/wa-doh"),
+  vtsGeo: require("./sources/vts/geo"),
 };
 
 module.exports = { sources };

--- a/loader/src/sources/vts/geo.js
+++ b/loader/src/sources/vts/geo.js
@@ -99,9 +99,9 @@ function formatStore(store) {
       "vaccinespotter_org",
     ]);
 
-    const externalIds = data.concordances
-      .map(splitConcordance)
-      .filter((v) => systemsToSend.has(v[0]));
+    const concordances = data.concordances.map(splitConcordance);
+    const externalIds = concordances.filter((v) => systemsToSend.has(v[0]));
+    const univafPair = concordances.filter((v) => v[0] == "getmyvax_org")[0];
 
     if (!externalIds.length) {
       return null;
@@ -110,6 +110,7 @@ function formatStore(store) {
     result = {
       name,
       provider,
+      id: univafPair && univafPair[1],
       external_ids: externalIds,
       position: {
         longitude: store.geometry.coordinates[0],

--- a/loader/src/sources/vts/geo.js
+++ b/loader/src/sources/vts/geo.js
@@ -92,9 +92,20 @@ function formatStore(store) {
       ];
     }
 
+    systemsToSend = new Set([
+      "cvs",
+      "rite_aid",
+      "vaccinefinder_org",
+      "vaccinespotter_org",
+    ]);
+
     const externalIds = data.concordances
       .map(splitConcordance)
-      .filter((v) => v[0] != "getmyvax_org"); // ignore getmyvax concordances
+      .filter((v) => systemsToSend.has(v[0]));
+
+    if (!externalIds.length) {
+      return null;
+    }
 
     result = {
       name,
@@ -122,6 +133,7 @@ async function updateGeo(handler, options) {
     const formatted = stores.features
       .filter(hasUsefulData)
       .map(formatStore)
+      .filter(Boolean)
       .forEach((item) => handler(item, { update_location: true }));
 
     results = results.concat(formatted);

--- a/loader/src/sources/vts/geo.js
+++ b/loader/src/sources/vts/geo.js
@@ -143,6 +143,7 @@ async function updateGeo(handler, options) {
 
   if (!states || !states.length) {
     warn("No states specified for vts.geo");
+    return [];
   }
 
   const statesFilter = new Set(states);

--- a/loader/src/sources/vts/geo.js
+++ b/loader/src/sources/vts/geo.js
@@ -111,7 +111,6 @@ function formatStore(store) {
 
     const concordances = data.concordances.map((c) => splitOnce(c, ":"));
     const externalIds = concordances.filter(validConcordance).map(renameSystem);
-    const univafPair = concordances.filter((v) => v[0] == "getmyvax_org")[0];
 
     if (!externalIds.length) {
       return null;
@@ -120,7 +119,6 @@ function formatStore(store) {
     result = {
       name,
       provider,
-      id: univafPair ? univafPair[1] : undefined,
       external_ids: externalIds,
       position: {
         longitude: store.geometry.coordinates[0],

--- a/loader/src/sources/vts/geo.js
+++ b/loader/src/sources/vts/geo.js
@@ -41,8 +41,8 @@ async function queryState(state) {
       url: `https://api.vaccinatethestates.com/v0/${state}.geojson`,
     });
     return JSON.parse(response.body);
-  } catch (error) {
-    error(`Error fetching Vaccine Spotter data`, error);
+  } catch (e) {
+    error(`Error fetching Vaccine Spotter data`, e);
     return [];
   }
 }

--- a/loader/src/sources/vts/geo.js
+++ b/loader/src/sources/vts/geo.js
@@ -37,10 +37,9 @@ function error(message, context) {
 
 async function getStores() {
   try {
-    const response = await got({
-      url: `https://univaf-data-snapshots.s3.us-west-2.amazonaws.com/vts/vts-final-output-locations.geojson`,
-    });
-    return JSON.parse(response.body);
+    return await got({
+      url: `https://univaf-data-snapshots.s3.us-west-2.amazonaws.com/vts/vts-final-output-locations.geojson.gz`,
+    }).json();
   } catch (e) {
     error(`Error fetching stored Vaccine the States data`, e);
     return [];

--- a/loader/src/sources/vts/geo.js
+++ b/loader/src/sources/vts/geo.js
@@ -1,5 +1,6 @@
 const got = require("got");
 const Sentry = require("@sentry/node");
+const { splitOnce } = require("../../utils");
 
 const dataProviders = {
   "Rite-Aid": {
@@ -60,11 +61,6 @@ function hasUsefulData(store) {
   );
 }
 
-function splitConcordance(concordance) {
-  const colon = concordance.indexOf(":");
-  return [concordance.substring(0, colon), concordance.substring(colon + 1)];
-}
-
 const systemsToSend = {
   cvs: "cvs",
   rite_aid: "rite_aid",
@@ -113,7 +109,7 @@ function formatStore(store) {
       provider: provider,
     });
 
-    const concordances = data.concordances.map(splitConcordance);
+    const concordances = data.concordances.map((c) => splitOnce(c, ":"));
     const externalIds = concordances.filter(validConcordance).map(renameSystem);
     const univafPair = concordances.filter((v) => v[0] == "getmyvax_org")[0];
 

--- a/loader/src/sources/vts/geo.js
+++ b/loader/src/sources/vts/geo.js
@@ -1,9 +1,7 @@
 const got = require("got");
 const Sentry = require("@sentry/node");
-const { Available, LocationType } = require("../../model");
-const { titleCase } = require("../../utils");
 
-dataProviders = {
+const dataProviders = {
   "Rite-Aid": {
     provider: "rite_aid",
     getStoreName: (data) => {
@@ -92,7 +90,7 @@ function formatStore(store) {
       ];
     }
 
-    systemsToSend = new Set([
+    const systemsToSend = new Set([
       "cvs",
       "rite_aid",
       "vaccinefinder_org",
@@ -122,7 +120,7 @@ function formatStore(store) {
 }
 
 async function updateGeo(handler, options) {
-  let states = options.states?.split(",").map((state) => state.trim());
+  const states = options.states?.split(",").map((state) => state.trim());
 
   if (!states || !states.length) {
     warn("No states specified for vts.geo");

--- a/loader/src/sources/vts/geo.js
+++ b/loader/src/sources/vts/geo.js
@@ -3,6 +3,8 @@ const Sentry = require("@sentry/node");
 const { Available, LocationType } = require("../../model");
 const { titleCase } = require("../../utils");
 
+updateworthyProviders = new Set(["CVS", "Rite-Aid"]);
+
 function warn(message, context) {
   console.warn(`VTS Geo: ${message}`, context);
   Sentry.captureMessage(message, Sentry.Severity.Info);
@@ -31,7 +33,11 @@ async function queryState(state) {
  * @returns {boolean}
  */
 function hasUsefulData(store) {
-  return store.properties.concordances?.length && store.geometry?.coordinates;
+  return (
+    store.properties.concordances?.length &&
+    store.geometry?.coordinates &&
+    updateworthyProviders.has(store.properties.provider?.name)
+  );
 }
 
 function formatStore(store) {

--- a/loader/src/sources/vts/geo.js
+++ b/loader/src/sources/vts/geo.js
@@ -95,6 +95,7 @@ function formatStore(store) {
       rite_aid: "rite_aid",
       vaccinespotter_org: "vaccinespotter",
       vaccinefinder_org: "vaccines_gov",
+      vaccinefinder: "vaccines_gov",
     };
 
     const concordances = data.concordances.map(splitConcordance);

--- a/loader/src/sources/vts/geo.js
+++ b/loader/src/sources/vts/geo.js
@@ -90,6 +90,25 @@ function formatStore(store) {
       ];
     }
 
+    function filterConcordancePairs(pairs) {
+      return pairs
+        .filter(([systemCode, value]) => {
+          const system = systemsToSend[systemCode];
+          if (!system) {
+            return null;
+          }
+
+          if (system == "rite_aid" && value.match(/^1\d{5}$/)) {
+            // Stores like Rite Aid in this data set may have a store number like 105612.
+            // IDs with that shape (6 digits, starting with '1') are likely misparsed from VTrckS.
+            return null;
+          }
+
+          return [system, value];
+        })
+        .filter(Boolean);
+    }
+
     const systemsToSend = {
       cvs: "cvs",
       rite_aid: "rite_aid",
@@ -99,9 +118,7 @@ function formatStore(store) {
     };
 
     const concordances = data.concordances.map(splitConcordance);
-    const externalIds = concordances
-      .map((v) => (v[0] in systemsToSend ? [systemsToSend[v[0]], v[1]] : null))
-      .filter(Boolean);
+    const externalIds = filterConcordancePairs(concordances);
     const univafPair = concordances.filter((v) => v[0] == "getmyvax_org")[0];
 
     if (!externalIds.length) {

--- a/loader/src/sources/vts/geo.js
+++ b/loader/src/sources/vts/geo.js
@@ -146,9 +146,9 @@ async function updateGeo(handler, options) {
     .filter((store) => statesFilter.has(store.properties.state))
     .filter(hasUsefulData)
     .map(formatStore)
-    .filter(Boolean)
-    .forEach((item) => handler(item, { update_location: true }));
+    .filter(Boolean);
 
+  results.forEach((item) => handler(item, { update_location: true }));
   return results;
 }
 

--- a/loader/src/sources/vts/geo.js
+++ b/loader/src/sources/vts/geo.js
@@ -35,7 +35,7 @@ function error(message, context) {
   Sentry.captureMessage(message, Sentry.Severity.Error);
 }
 
-async function getStores(state) {
+async function getStores() {
   try {
     const response = await got({
       url: `https://univaf-data-snapshots.s3.us-west-2.amazonaws.com/vts/vts-final-output-locations.geojson`,

--- a/loader/src/sources/vts/geo.js
+++ b/loader/src/sources/vts/geo.js
@@ -90,15 +90,17 @@ function formatStore(store) {
       ];
     }
 
-    const systemsToSend = new Set([
-      "cvs",
-      "rite_aid",
-      "vaccinefinder_org",
-      "vaccinespotter_org",
-    ]);
+    const systemsToSend = {
+      cvs: "cvs",
+      rite_aid: "rite_aid",
+      vaccinespotter_org: "vaccinespotter",
+      vaccinefinder_org: "vaccines_gov",
+    };
 
     const concordances = data.concordances.map(splitConcordance);
-    const externalIds = concordances.filter((v) => systemsToSend.has(v[0]));
+    const externalIds = concordances
+      .map((v) => (v[0] in systemsToSend ? [systemsToSend[v[0]], v[1]] : null))
+      .filter(Boolean);
     const univafPair = concordances.filter((v) => v[0] == "getmyvax_org")[0];
 
     if (!externalIds.length) {

--- a/loader/src/sources/vts/geo.js
+++ b/loader/src/sources/vts/geo.js
@@ -1,0 +1,96 @@
+const got = require("got");
+const Sentry = require("@sentry/node");
+const { Available, LocationType } = require("../../model");
+const { titleCase } = require("../../utils");
+
+function warn(message, context) {
+  console.warn(`VTS Geo: ${message}`, context);
+  Sentry.captureMessage(message, Sentry.Severity.Info);
+}
+
+function error(message, context) {
+  console.error(`VTS Geo: ${message}`, context);
+  Sentry.captureMessage(message, Sentry.Severity.Error);
+}
+
+async function queryState(state) {
+  try {
+    const response = await got({
+      url: `https://api.vaccinatethestates.com/v0/${state}.geojson`,
+    });
+    return JSON.parse(response.body);
+  } catch (error) {
+    error(`Error fetching Vaccine Spotter data`, error);
+    return [];
+  }
+}
+
+/**
+ * Filter out some stores with bad data.
+ * @param {any} store
+ * @returns {boolean}
+ */
+function hasUsefulData(store) {
+  return store.properties.concordances?.length && store.geometry?.coordinates;
+}
+
+function formatStore(store) {
+  const data = store.properties;
+
+  let result;
+  Sentry.withScope((scope) => {
+    scope.setContext("location", {
+      id: store.id,
+      url: data.vts_url,
+      name: data.name,
+      provider: data.provider,
+    });
+
+    function splitConcordance(concordance) {
+      const colon = concordance.indexOf(":");
+      return [
+        concordance.substring(0, colon),
+        concordance.substring(colon + 1),
+      ];
+    }
+
+    const externalIds = data.concordances
+      .map(splitConcordance)
+      .filter((v) => v[0] != "getmyvax_org"); // ignore getmyvax concordances
+
+    result = {
+      name: data.name,
+      external_ids: externalIds,
+      position: {
+        longitude: store.geometry.coordinates[0],
+        latitude: store.geometry.coordinates[1],
+      },
+    };
+  });
+  return result;
+}
+
+async function updateGeo(handler, options) {
+  let states = options.states?.split(",").map((state) => state.trim());
+
+  if (!states || !states.length) {
+    warn("No states specified for vts.geo");
+  }
+
+  let results = [];
+  for (const state of states) {
+    const stores = await queryState(state);
+    const formatted = stores.features
+      .filter(hasUsefulData)
+      .map(formatStore)
+      .forEach((item) => handler(item, { update_location: true }));
+
+    results = results.concat(formatted);
+  }
+
+  return results;
+}
+
+module.exports = {
+  checkAvailability: updateGeo,
+};

--- a/loader/src/utils.js
+++ b/loader/src/utils.js
@@ -185,4 +185,19 @@ module.exports = {
   randomUserAgent() {
     return USER_AGENTS[module.exports.randomInt(0, USER_AGENTS.length)];
   },
+
+  /**
+   * Split `text` at most once by `delim`.
+   * @param {string} text
+   * @param {string} delim
+   * @returns {Array<string>}
+   */
+  splitOnce(text, delim) {
+    const i = text.indexOf(delim);
+    if (i < 0) {
+      return [text];
+    } else {
+      return [text.substring(0, i), text.substring(i + delim.length)];
+    }
+  },
 };

--- a/loader/test/fixtures/vts.geo.test.json
+++ b/loader/test/fixtures/vts.geo.test.json
@@ -1,0 +1,222 @@
+{
+  "type": "FeatureCollection",
+  "usage": {
+    "notice": "Please contact Vaccinate The States and let us know if you plan to rely on or publish this data. This data is provided with best-effort accuracy. If you are displaying this data, we expect you to display it responsibly. Please do not display it in a way that is easy to misread.",
+    "contact": {
+      "partnersEmail": "api@vaccinatethestates.com"
+    }
+  },
+  "features": [
+    {
+      "type": "Feature",
+      "id": "rec06jodBnLAWp8WW",
+      "properties": {
+        "name": "CVS Pharmacy® & Drug Store at 901 Silver Spur Rd. Rolling Hills Estates, CA 90274",
+        "provider": {
+          "name": "CVS",
+          "provider_type": "Pharmacy",
+          "vaccine_info_url": "https://www.cvs.com/immunizations/covid-19-vaccine"
+        },
+        "state": "CA",
+        "location_type": "Pharmacy",
+        "phone_number": "310-377-6728",
+        "full_address": "901 Silver Spur Rd., Rolling Hills Estates CA, 90274",
+        "city": null,
+        "county": "Los Angeles",
+        "zip_code": null,
+        "hours": {
+          "unstructured": "Mo-Fr  08:00:00-23:00:00 | Sa  08:00:00-23:00:00 | Su  08:00:00-23:00:00",
+          "structured": [
+            {
+              "day": "monday",
+              "opens": "08:00",
+              "closes": "21:00"
+            },
+            {
+              "day": "tuesday",
+              "opens": "08:00",
+              "closes": "21:00"
+            },
+            {
+              "day": "wednesday",
+              "opens": "08:00",
+              "closes": "21:00"
+            },
+            {
+              "day": "thursday",
+              "opens": "08:00",
+              "closes": "21:00"
+            },
+            {
+              "day": "friday",
+              "opens": "08:00",
+              "closes": "21:00"
+            },
+            {
+              "day": "saturday",
+              "opens": "09:00",
+              "closes": "18:00"
+            },
+            {
+              "day": "sunday",
+              "opens": "10:00",
+              "closes": "18:00"
+            }
+          ]
+        },
+        "website": "https://www.cvs.com/store-locator/details-directions/9607",
+        "vaccines_offered": [
+          "Moderna"
+        ],
+        "accepts_appointments": true,
+        "accepts_walkins": false,
+        "concordances": [
+          "google_places:ChIJc16L9MBL3YARSU_SohHPFCA",
+          "vaccinefinder_org:d91cd449-36c2-4cf5-9c1a-f4136d9a2bf7",
+          "cvs:9607",
+          "placekey:zzw-223@5z6-3dn-td9",
+          "_tag_provider:cvs",
+          "us_carbon_health:bbe71944-72d4-4b85-84b8-f4a2bf057fae",
+          "us_giscorps_vaccine_providers:488752dd-bd86-4e0c-a5fa-f3ffe29f93e3",
+          "vaccinespotter_org:270588201",
+          "cvs:09607",
+          "vtrcks:CV1009607",
+          "getmyvax_org:5e13fa03-7763-4d74-81d0-54e4613cf56c"
+        ],
+        "last_verified_by_vts": "2021-05-12T21:18:41.722721+00:00",
+        "vts_url": "https://www.vaccinatethestates.com/?lng=-118.36650&lat=33.76920#rec06jodBnLAWp8WW"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -118.3665,
+          33.7692
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "rec00SICtL8KJiLim",
+      "properties": {
+        "name": "RITE AID PHARMACY 06466",
+        "provider": {
+          "name": "Rite-Aid",
+          "provider_type": "Pharmacy",
+          "vaccine_info_url": null
+        },
+        "state": "CA",
+        "location_type": "Pharmacy",
+        "phone_number": "619-231-7405",
+        "full_address": "1411 KETTNER BOULEVARD, SAN DIEGO, CA 92101",
+        "city": null,
+        "county": "San Diego",
+        "zip_code": null,
+        "hours": {
+          "unstructured": "Monday - Sunday: 8:00 am-8:00 pm",
+          "structured": [
+            {
+              "day": "monday",
+              "opens": "08:00",
+              "closes": "20:00"
+            },
+            {
+              "day": "tuesday",
+              "opens": "08:00",
+              "closes": "20:00"
+            },
+            {
+              "day": "wednesday",
+              "opens": "08:00",
+              "closes": "20:00"
+            },
+            {
+              "day": "thursday",
+              "opens": "08:00",
+              "closes": "20:00"
+            },
+            {
+              "day": "friday",
+              "opens": "08:00",
+              "closes": "20:00"
+            },
+            {
+              "day": "saturday",
+              "opens": "10:00",
+              "closes": "18:00"
+            },
+            {
+              "day": "sunday",
+              "opens": "10:00",
+              "closes": "17:00"
+            }
+          ]
+        },
+        "website": null,
+        "vaccines_offered": [
+          "Moderna"
+        ],
+        "accepts_appointments": true,
+        "accepts_walkins": false,
+        "concordances": [
+          "google_places:ChIJt9skOKxU2YARERJMhNf4QfA",
+          "vaccinespotter_org:7382057",
+          "vaccinefinder_org:f8bd637a-1a6e-4262-b3f0-7c7a6b9b887d",
+          "rite_aid:106466",
+          "us_carbon_health:48063e1f-820f-4770-a9c5-3c4cb67077c7",
+          "_tag_provider:rite_aid",
+          "placekey:227@5z5-qf4-2tv",
+          "rite_aid:6466",
+          "us_carbon_health:c801fafc-0bc8-486c-b917-f4e188a0e0a3"
+        ],
+        "last_verified_by_vts": "2021-05-11T22:43:41.750424+00:00",
+        "vts_url": "https://www.vaccinatethestates.com/?lng=-117.16902&lat=32.71998#rec00SICtL8KJiLim"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -117.16902,
+          32.71998
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "rec03MtqJLAZ6IHiu",
+      "properties": {
+        "name": "Farmacia Familiar",
+        "provider": null,
+        "state": "CA",
+        "location_type": "Pharmacy",
+        "phone_number": "714-486-2277",
+        "full_address": "1126 S Bristol St, Santa Ana, CA 92704",
+        "city": null,
+        "county": "Orange",
+        "zip_code": null,
+        "hours": {
+          "unstructured": "Monday - Friday: 9:00 AM – 7:00 PM\nSaturday: 9:30 AM – 4:00 PM\nSunday: Closed",
+          "structured": null
+        },
+        "website": null,
+        "vaccines_offered": [],
+        "accepts_appointments": false,
+        "accepts_walkins": true,
+        "concordances": [
+          "google_places:ChIJhyEF6OTY3IARa2rXtGIaQ4I",
+          "vaccinefinder_org:387354f1-02b6-4411-8a65-c2646fc9f820",
+          "us_carbon_health:c2baa160-7761-42ed-9d0c-68a244289e8a",
+          "placekey:zzw-228@5z4-rz4-jy9",
+          "us_giscorps_vaccine_providers:bf2ee838-acbb-4c15-9b51-cdd1b8f90b28"
+        ],
+        "last_verified_by_vts": "2021-05-26T00:50:01.129454+00:00",
+        "vts_url": "https://www.vaccinatethestates.com/?lng=-117.88518&lat=33.73392#rec03MtqJLAZ6IHiu"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -117.88518,
+          33.73392
+        ]
+      }
+    }
+  ]
+}

--- a/loader/test/utils.test.js
+++ b/loader/test/utils.test.js
@@ -1,0 +1,21 @@
+const { splitOnce } = require("../src/utils");
+
+describe("splitOnce", () => {
+  it("splits once on a single character", () => {
+    expect(splitOnce("test:123", ":")).toEqual(["test", "123"]);
+    expect(splitOnce("test-123-123", "-")).toEqual(["test", "123-123"]);
+    expect(splitOnce("test:123", "3")).toEqual(["test:12", ""]);
+    expect(splitOnce("test-123-123", "t")).toEqual(["", "est-123-123"]);
+  });
+
+  it("handles a delimiter that doesn't exist in text", () => {
+    expect(splitOnce("test:123", "~")).toEqual(["test:123"]);
+    expect(splitOnce("test-123", "/")).toEqual(["test-123"]);
+  });
+
+  it("handles multi-character delimiters", () => {
+    expect(splitOnce("test:123", "st:")).toEqual(["te", "123"]);
+    expect(splitOnce("test-123", "12")).toEqual(["test-", "3"]);
+    expect(splitOnce("test-123", "test-123")).toEqual(["", ""]);
+  });
+});

--- a/loader/test/vts.geo.test.js
+++ b/loader/test/vts.geo.test.js
@@ -1,0 +1,73 @@
+const nock = require("nock");
+const { checkAvailability } = require("../src/sources/vts/geo");
+
+const apiResponse = require("./fixtures/vts.geo.test.json");
+const nopHandler = () => {};
+
+describe("VtS Geo", () => {
+  const S3_URL = "https://univaf-data-snapshots.s3.us-west-2.amazonaws.com/";
+
+  beforeEach(() => {
+    nock(S3_URL).persist().get(/.*/).reply(200, apiResponse);
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  it("gracefully handles no states", async () => {
+    locations = await checkAvailability(nopHandler, {});
+    expect(locations).toEqual([]);
+  });
+
+  it("filters by state", async () => {
+    let locations;
+    locations = await checkAvailability(nopHandler, { states: "NJ" });
+    expect(locations.length).toBe(0);
+
+    locations = await checkAvailability(nopHandler, { states: "CA" });
+    expect(locations.length).not.toBe(0);
+  });
+
+  it("skips stores we don't care about", async () => {
+    expect(apiResponse.features.length).toBe(3);
+
+    const locations = await checkAvailability(nopHandler, { states: "CA" });
+    expect(locations.length).toBe(2);
+  });
+
+  it("formats stores as expected", async () => {
+    // XXX one rite-aid, one cvs
+    const locations = await checkAvailability(nopHandler, { states: "CA" });
+    expect(locations[0]).toStrictEqual({
+      external_ids: [
+        ["vaccines_gov", "d91cd449-36c2-4cf5-9c1a-f4136d9a2bf7"],
+        ["cvs", "9607"],
+        ["vaccinespotter", "270588201"],
+        ["cvs", "09607"],
+      ],
+      id: "5e13fa03-7763-4d74-81d0-54e4613cf56c",
+      name:
+        "CVS Pharmacy® & Drug Store at 901 Silver Spur Rd. Rolling Hills Estates, CA 90274",
+      position: {
+        latitude: 33.7692,
+        longitude: -118.3665,
+      },
+      provider: "cvs",
+    });
+    expect(locations[1]).toStrictEqual({
+      external_ids: [
+        ["vaccinespotter", "7382057"],
+        ["vaccines_gov", "f8bd637a-1a6e-4262-b3f0-7c7a6b9b887d"],
+        ["rite_aid", "6466"],
+      ],
+      id: undefined,
+      name: "Rite Aid #6466",
+      position: {
+        latitude: 32.71998,
+        longitude: -117.16902,
+      },
+      provider: "rite_aid",
+    });
+  });
+});

--- a/loader/test/vts.geo.test.js
+++ b/loader/test/vts.geo.test.js
@@ -45,7 +45,6 @@ describe("VtS Geo", () => {
         ["vaccinespotter", "270588201"],
         ["cvs", "09607"],
       ],
-      id: "5e13fa03-7763-4d74-81d0-54e4613cf56c",
       name:
         "CVS Pharmacy® & Drug Store at 901 Silver Spur Rd. Rolling Hills Estates, CA 90274",
       position: {
@@ -60,7 +59,6 @@ describe("VtS Geo", () => {
         ["vaccines_gov", "f8bd637a-1a6e-4262-b3f0-7c7a6b9b887d"],
         ["rite_aid", "6466"],
       ],
-      id: undefined,
       name: "Rite Aid #6466",
       position: {
         latitude: 32.71998,

--- a/loader/test/vts.geo.test.js
+++ b/loader/test/vts.geo.test.js
@@ -2,7 +2,7 @@ const nock = require("nock");
 const { checkAvailability } = require("../src/sources/vts/geo");
 
 const apiResponse = require("./fixtures/vts.geo.test.json");
-const nopHandler = () => {};
+const noopHandler = () => {};
 
 describe("VtS Geo", () => {
   const S3_URL = "https://univaf-data-snapshots.s3.us-west-2.amazonaws.com/";
@@ -16,28 +16,28 @@ describe("VtS Geo", () => {
   });
 
   it("gracefully handles no states", async () => {
-    const locations = await checkAvailability(nopHandler, {});
+    const locations = await checkAvailability(noopHandler, {});
     expect(locations).toEqual([]);
   });
 
   it("filters by state", async () => {
     let locations;
-    locations = await checkAvailability(nopHandler, { states: "NJ" });
+    locations = await checkAvailability(noopHandler, { states: "NJ" });
     expect(locations.length).toBe(0);
 
-    locations = await checkAvailability(nopHandler, { states: "CA" });
+    locations = await checkAvailability(noopHandler, { states: "CA" });
     expect(locations.length).not.toBe(0);
   });
 
   it("skips stores we don't care about", async () => {
     expect(apiResponse.features.length).toBe(3);
 
-    const locations = await checkAvailability(nopHandler, { states: "CA" });
+    const locations = await checkAvailability(noopHandler, { states: "CA" });
     expect(locations.length).toBe(2);
   });
 
   it("formats stores as expected", async () => {
-    const locations = await checkAvailability(nopHandler, { states: "CA" });
+    const locations = await checkAvailability(noopHandler, { states: "CA" });
     expect(locations[0]).toStrictEqual({
       external_ids: [
         ["vaccines_gov", "d91cd449-36c2-4cf5-9c1a-f4136d9a2bf7"],

--- a/loader/test/vts.geo.test.js
+++ b/loader/test/vts.geo.test.js
@@ -16,7 +16,7 @@ describe("VtS Geo", () => {
   });
 
   it("gracefully handles no states", async () => {
-    locations = await checkAvailability(nopHandler, {});
+    const locations = await checkAvailability(nopHandler, {});
     expect(locations).toEqual([]);
   });
 
@@ -37,7 +37,6 @@ describe("VtS Geo", () => {
   });
 
   it("formats stores as expected", async () => {
-    // XXX one rite-aid, one cvs
     const locations = await checkAvailability(nopHandler, { states: "CA" });
     expect(locations[0]).toStrictEqual({
       external_ids: [


### PR DESCRIPTION
This PR sets up a new loader module `vts.geo` intended to update our geolocation data from Vaccinate the States's API. For the sake of more narrowly solving #236, it only works for Rite Aid and CVS locations, however I don't know of a reason why it wouldn't work for everything.

In addition to updating the `provider_location.position` field, it also may update `provider_location.name` if there is a mismatch. Most of our names *don't* match, but I did some regular expression hacking to try to get easy ones to align. To be honest, I wish it didn't touch the names, but the server requires sending one.

I haven't written any automated tests, yet. I'm not sure what would be best to test here. I did manually test this somewhat extensively, though. For the most part it does the right thing. However, I ran into a few surprises in the data set that cause issues.

First, there are some concordance values that are not unique to a location. The easy one to exclude was `_tag_provider`, which e.g. has the value `cvs` for every CVS location. But there were others that I noticed were not so reliable, like `google_places` and `placekey`. I opted to pull a shortlist of `cvs`,`rite_aid`,`vaccinefinder_org` and `vaccinespotter_org`.

Second, even with that degree of filtering, there are still some erroneous values in the data set, e.g. 

*(from https://api.vaccinatethestates.com/v0/CA.geojson)*
```json
{
  "name": "RITE AID PHARMACY 05435",
  "concordances": [
    "google_places:ChIJRzqoPqzAwoAR8AB9GQTJ6-w",
    "vaccinefinder_org:4f3cea2e-7547-4997-abf0-668e083d7f9c",
    "placekey:zzw-22f@5z5-3nz-tqf",
    "rite_aid:105435",
    "rite_aid:5436",
    "_tag_provider:rite_aid",
    "us_carbon_health:584b4f6a-0c58-4580-9354-04777cf9ca3d",
    "us_carbon_health:86c9c4fe-df2c-413c-9f9e-cf619bbe4600",
    "us_carbon_health:a515f425-e50d-4292-be59-966ae4924100",
    "vaccinespotter_org:7528795"
  ]
}
```
Which has `rite_aid:105435` and `rite_aid:5436` (the latter seems to be a typo, and there's another `rite_aid:5436` for real in the data set).

The consequence of these buggy concordances mostly mean that we may write wrong names and locations, but I'm not sure how best to handle them.

Fixes #236 