### PR TITLE
Create migration to add unpadded store ids for CVS locations

### DIFF
--- a/server/migrations/20210722181933_unpadded_ext_ids.js
+++ b/server/migrations/20210722181933_unpadded_ext_ids.js
@@ -2,7 +2,7 @@ exports.up = async function (knex) {
   const zeroPaddedRows = await knex("external_ids")
     .select("provider_location_id", "system", "value")
     .where("system", "cvs")
-    .where("value", "~", "^0\\d+$");
+    .where("value", "~", String.raw`^0\d+$`);
 
   const unpaddedRows = zeroPaddedRows.map((r) => ({
     ...r,

--- a/server/migrations/20210722181933_unpadded_ext_ids.js
+++ b/server/migrations/20210722181933_unpadded_ext_ids.js
@@ -9,7 +9,10 @@ exports.up = async function (knex) {
     value: r.value.replace(/^0+/, ""),
   }));
 
-  return knex.batchInsert("external_ids", unpaddedRows);
+  return knex("external_ids")
+    .insert(unpaddedRows)
+    .onConflict(["provider_location_id", "system", "value"])
+    .ignore();
 };
 
 exports.down = async function () {

--- a/server/migrations/20210722181933_unpadded_ext_ids.js
+++ b/server/migrations/20210722181933_unpadded_ext_ids.js
@@ -11,9 +11,9 @@ exports.up = async function (knex) {
 
   if (unpaddedRows.length) {
     return knex("external_ids")
-    .insert(unpaddedRows)
-    .onConflict(["provider_location_id", "system", "value"])
-    .ignore();
+      .insert(unpaddedRows)
+      .onConflict(["provider_location_id", "system", "value"])
+      .ignore();
   }
 };
 

--- a/server/migrations/20210722181933_unpadded_ext_ids.js
+++ b/server/migrations/20210722181933_unpadded_ext_ids.js
@@ -1,0 +1,17 @@
+exports.up = async function (knex) {
+  zeroPaddedRows = await knex("external_ids")
+    .select("provider_location_id", "system", "value")
+    .where("system", "cvs")
+    .where("value", "~", "^0\\d+$");
+
+  unpaddedRows = zeroPaddedRows.map((r) => ({
+    ...r,
+    value: r.value.replace(/^0+/, ""),
+  }));
+
+  return knex.batchInsert("external_ids", unpaddedRows);
+};
+
+exports.down = async function (knex) {
+  console.log("20210722181933_unpadded_ext_ids.js: No migrated rows removed.");
+};

--- a/server/migrations/20210722181933_unpadded_ext_ids.js
+++ b/server/migrations/20210722181933_unpadded_ext_ids.js
@@ -1,10 +1,10 @@
 exports.up = async function (knex) {
-  zeroPaddedRows = await knex("external_ids")
+  const zeroPaddedRows = await knex("external_ids")
     .select("provider_location_id", "system", "value")
     .where("system", "cvs")
     .where("value", "~", "^0\\d+$");
 
-  unpaddedRows = zeroPaddedRows.map((r) => ({
+  const unpaddedRows = zeroPaddedRows.map((r) => ({
     ...r,
     value: r.value.replace(/^0+/, ""),
   }));
@@ -12,6 +12,6 @@ exports.up = async function (knex) {
   return knex.batchInsert("external_ids", unpaddedRows);
 };
 
-exports.down = async function (knex) {
+exports.down = async function () {
   console.log("20210722181933_unpadded_ext_ids.js: No migrated rows removed.");
 };

--- a/server/migrations/20210722181933_unpadded_ext_ids.js
+++ b/server/migrations/20210722181933_unpadded_ext_ids.js
@@ -9,10 +9,12 @@ exports.up = async function (knex) {
     value: r.value.replace(/^0+/, ""),
   }));
 
-  return knex("external_ids")
+  if (unpaddedRows.length) {
+    return knex("external_ids")
     .insert(unpaddedRows)
     .onConflict(["provider_location_id", "system", "value"])
     .ignore();
+  }
 };
 
 exports.down = async function () {


### PR DESCRIPTION
This PR creates `external_id` entries for CVS stores that currently are shaped like `07000` but also may show up in other places as `7000`. This way we catch both formats.

Fixes #308 