### PR TITLE
Add data loader for CDC

### DIFF
--- a/loader/package.json
+++ b/loader/package.json
@@ -4,7 +4,8 @@
   "description": "Scripts that find COVID-19 vaccine appointment availability from various sources",
   "main": "index.js",
   "scripts": {
-    "test": "NODE_ENV=test jest"
+    "test": "NODE_ENV=test jest",
+    "eslint": "eslint --ext .js,.ts ."
   },
   "repository": {
     "type": "git",

--- a/loader/package.json
+++ b/loader/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "NODE_ENV=test jest",
-    "eslint": "eslint --ext .js,.ts ."
+    "lint": "eslint --ext .js,.ts ."
   },
   "repository": {
     "type": "git",

--- a/loader/src/index.js
+++ b/loader/src/index.js
@@ -1,4 +1,5 @@
 const sources = {
+  cdcApi: require("./sources/cdc/api"),
   cvsApi: require("./sources/cvs/api"),
   cvsScraper: require("./sources/cvs/scraper"),
   cvsSmart: require("./sources/cvs/smart"),

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -118,7 +118,7 @@ function formatStore(storeItems) {
         available_count: getAvailableCount(productList),
         available: formatAvailable(productList),
         capacity: formatCapacity(productList),
-        products: formatProducts(productList),
+        products: formatProductTypes(productList),
         // XXX should doses be here?
       },
     };
@@ -144,15 +144,28 @@ function formatAvailable(products) {
   return getAvailableCount(products) > 0 ? Available.yes : Available.no;
 }
 
-function formatProducts(products) {
-  [...new Set(products.map((p) => p.med_name))];
+function getProductType(productName) {
+  if (productName.startsWith("Pfizer")) {
+    return "pfizer";
+  }
+  if (productName.startsWith("Moderna")) {
+    return "moderna";
+  }
+  if (productName.startsWith("Janssen")) {
+    return "jj";
+  }
+  throw new Error(`Unexpected product name '${productName}'`);
+}
+
+function formatProductTypes(products) {
+  return [...new Set(products.map((p) => getProductType(p.med_name)))];
 }
 
 function formatCapacity(products) {
   return products.map((product) => {
     const availableCount = parseInt(product.supply_level, 10);
     return {
-      products: [product.med_name],
+      products: [getProductType(product.med_name)],
       date: product.quantity_last_updated,
       available: availableCount > 0 ? Available.yes : Available.no,
       available_count: availableCount,

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -55,8 +55,8 @@ function formatStore(storeItems) {
       provider: "cdc",
     });
 
-    const externalId = getExternalId(base);
-    if (!externalId) {
+    const storeExternalId = getStoreExternalId(base);
+    if (!storeExternalId) {
       return null;
     }
 
@@ -100,7 +100,10 @@ function formatStore(storeItems) {
 
     result = {
       id: `cdc:${base.provider_location_guid}`,
-      external_ids: [externalId],
+      external_ids: [
+        ["vaccines_gov", base.provider_location_guid],
+        storeExternalId,
+      ],
       name: titleCase(base.loc_name),
       provider: "cdc",
 
@@ -143,7 +146,7 @@ const systemNameRe = {
   walmart: /^Walmart/i,
 };
 
-function getExternalId(store) {
+function getStoreExternalId(store) {
   if (!store.loc_store_no || store.loc_store_no == "Not applicable") {
     return null;
   }

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -1,7 +1,7 @@
 const Sentry = require("@sentry/node");
 const got = require("got");
 
-const { Available, LocationType } = require("../../model");
+const { Available } = require("../../model");
 const { titleCase } = require("../../utils");
 
 function warn(message, context) {
@@ -25,7 +25,7 @@ async function* queryState(state) {
       });
       const results = JSON.parse(response.body);
 
-      for (result of results) {
+      for (const result of results) {
         yield result;
       }
 

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -55,6 +55,11 @@ function formatStore(storeItems) {
       provider: "cdc",
     });
 
+    const externalId = getExternalId(base);
+    if (!externalId) {
+      return null;
+    }
+
     const addressLines = [
       base.loc_admin_street1,
       base.loc_admin_street2,
@@ -95,7 +100,7 @@ function formatStore(storeItems) {
 
     result = {
       id: `cdc:${base.provider_location_guid}`,
-      external_ids: ["vaccines_gov", base.provider_location_guid], // XXX what's the right id to send here?
+      external_ids: [externalId],
       name: titleCase(base.loc_name),
       provider: "cdc",
 
@@ -124,6 +129,30 @@ function formatStore(storeItems) {
     };
   });
   return result;
+}
+
+const systemNameRe = {
+  costco: /^Costco/i,
+  cvs: /^CVS/i,
+  kroger: /^Kroger/i,
+  publix: /^Publix/i,
+  rite_aid: /^Rite Aid/i,
+  safeway: /^SAFEWAY/i,
+  sams_club: /^Sams Club/i,
+  walgreens: /^Walgreens/i,
+  walmart: /^Walmart/i,
+};
+
+function getExternalId(store) {
+  if (!store.loc_store_no || store.loc_store_no == "Not applicable") {
+    return null;
+  }
+
+  for (system in systemNameRe) {
+    if (store.loc_name.match(systemNameRe[system])) {
+      return [system, store.loc_store_no.replace(/[^0-9]/g, "")];
+    }
+  }
 }
 
 function formatValidAt(products) {

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -258,7 +258,7 @@ async function checkAvailability(handler, options) {
     const formatted = stores
       .map(formatStore)
       .filter(Boolean)
-      .map(markUnexpectedCVSs)
+      .map(markUnexpectedCvsIds)
       .forEach((item) => handler(item, { update_location: true }));
 
     results = results.concat(formatted);
@@ -269,7 +269,7 @@ async function checkAvailability(handler, options) {
 
 // 18 locations we don't have from the official CVS API that need special treatment
 // read more here: https://github.com/usdigitalresponse/univaf/pull/312#pullrequestreview-726002380
-const unexpectedCVSs = new Set([
+const unexpectedCvsIds = new Set([
   "cvs:9773",
   "cvs:9621",
   "cvs:9541",
@@ -290,10 +290,10 @@ const unexpectedCVSs = new Set([
   "cvs:7386",
 ]);
 
-function markUnexpectedCVSs(store) {
+function markUnexpectedCvsIds(store) {
   // mutates stores that match above list to hide them and add an internal note
   for (const [system, value] of store.external_ids) {
-    if (unexpectedCVSs.has(`${system}:${value}`)) {
+    if (unexpectedCvsIds.has(`${system}:${value}`)) {
       store.is_public = false;
       store.internal_notes =
         "Exists in CDC open data but not in CVS APIs; " +

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -171,7 +171,11 @@ function formatValidAt(products) {
 }
 
 function formatAvailable(products) {
-  return products.some((p) => p.in_stock) ? Available.yes : Available.no;
+  const availability = products.some((p) => {
+    const supplyLevel = parseInt(p.supply_level, 10);
+    return p.in_stock || supplyLevel > 0;
+  });
+  return availability ? Available.yes : Available.no;
 }
 
 const ndcLookup = {

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -127,7 +127,6 @@ function formatStore(storeItems) {
         available: formatAvailable(productList),
         capacity: formatCapacity(productList),
         products: formatProductTypes(productList),
-        // XXX should doses be here?
       },
     };
   });

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -241,6 +241,7 @@ async function checkAvailability(handler, options) {
 
   if (!states || !states.length) {
     warn("No states specified for cdcApi");
+    return [];
   }
 
   let results = [];

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -63,7 +63,7 @@ function formatStore(storeItems) {
     const addressLines = [
       base.loc_admin_street1,
       base.loc_admin_street2,
-    ].filter(Boolean);
+    ].filter((l) => l && l.match(/[a-z]+/i));
 
     const metaFields = [
       "insurance_accepted",

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -164,9 +164,18 @@ function formatValidAt(products) {
 }
 
 function getAvailableCount(products) {
+  if (!Array.isArray(products)) {
+    products = [products];
+  }
+
   let sum = 0;
   for (const product of products) {
-    sum += parseInt(product.supply_level, 10);
+    const supplyLevel = parseInt(product.supply_level, 10);
+    if (supplyLevel > 0) {
+      sum += supplyLevel;
+    } else {
+      sum += product.in_stock ? 1 : 0;
+    }
   }
   return sum;
 }

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -104,8 +104,7 @@ function formatStore(storeItems) {
         storeExternalId,
       ],
       name: titleCase(base.loc_name),
-      provider: "cdc",
-
+      provider: storeExternalId[0],
       address_lines: addressLines,
       city: titleCase(base.loc_admin_city),
       state: base.loc_admin_state,
@@ -115,7 +114,7 @@ function formatStore(storeItems) {
       meta,
 
       availability: {
-        source: storeExternalId[0],
+        source: "cdc",
         checked_at: new Date().toISOString(),
         valid_at: formatValidAt(productList),
         available_count: getAvailableCount(productList),

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -196,21 +196,21 @@ function formatAvailable(products) {
 const ndcLookup = {
   // from https://www.cdc.gov/vaccines/programs/iis/COVID-19-related-codes.html
   // and https://www2a.cdc.gov/vaccines/iis/iisstandards/vaccines.asp?rpt=ndc
-  [normalizeNDC("00310-1222-10")]: "astra_zeneca", //use
-  [normalizeNDC("00310-1222-15")]: "astra_zeneca", //sale
-  [normalizeNDC("59267-1000-01")]: "pfizer", //use
-  [normalizeNDC("59267-1000-02")]: "pfizer", //sale
-  [normalizeNDC("59267-1000-03")]: "pfizer", //sale
-  [normalizeNDC("59676-0580-05")]: "jj", //use
-  [normalizeNDC("59676-0580-15")]: "jj", //sale
-  [normalizeNDC("80631-0100-01")]: "novavax", //sale
-  [normalizeNDC("80631-0100-10")]: "novavax", //use
-  [normalizeNDC("80777-0273-10")]: "moderna", // use
-  [normalizeNDC("80777-0273-15")]: "moderna", // use
-  [normalizeNDC("80777-0273-98")]: "moderna", //sale
-  [normalizeNDC("80777-0273-99")]: "moderna", //sale
+  [normalizeNdc("00310-1222-10")]: "astra_zeneca", //use
+  [normalizeNdc("00310-1222-15")]: "astra_zeneca", //sale
+  [normalizeNdc("59267-1000-01")]: "pfizer", //use
+  [normalizeNdc("59267-1000-02")]: "pfizer", //sale
+  [normalizeNdc("59267-1000-03")]: "pfizer", //sale
+  [normalizeNdc("59676-0580-05")]: "jj", //use
+  [normalizeNdc("59676-0580-15")]: "jj", //sale
+  [normalizeNdc("80631-0100-01")]: "novavax", //sale
+  [normalizeNdc("80631-0100-10")]: "novavax", //use
+  [normalizeNdc("80777-0273-10")]: "moderna", // use
+  [normalizeNdc("80777-0273-15")]: "moderna", // use
+  [normalizeNdc("80777-0273-98")]: "moderna", //sale
+  [normalizeNdc("80777-0273-99")]: "moderna", //sale
 };
-function normalizeNDC(ndcCode) {
+function normalizeNdc(ndcCode) {
   // Note: this normalization makes consistent string values, not NDCs
   const parsed = ndcCode.match(/^(\d+)-(\d+)-(\d+)$/);
   if (!parsed) {
@@ -223,7 +223,7 @@ function normalizeNDC(ndcCode) {
 }
 
 function getProductType(product) {
-  const found = ndcLookup[normalizeNDC(product.ndc)];
+  const found = ndcLookup[normalizeNdc(product.ndc)];
   if (!found) {
     throw new Error(
       `Unexpected product NDC '${product.ndc}' (${JSON.stringify(product)})`

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -183,6 +183,7 @@ function getProductType(productName) {
   if (productName.startsWith("Janssen")) {
     return "jj";
   }
+  // XXX Novavax, AstraZeneca?
   throw new Error(`Unexpected product name '${productName}'`);
 }
 

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -204,7 +204,6 @@ function formatCapacity(products) {
 }
 
 async function checkAvailability(handler, options) {
-  handler = (thing) => console.log(JSON.stringify(thing));
   const states = options.states?.split(",").map((state) => state.trim());
 
   if (!states || !states.length) {

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -146,11 +146,18 @@ const systemNameRe = {
 };
 
 function getStoreExternalId(store) {
-  const m = store.loc_store_no.match(/^[A-Z]*(\d+)$/); // handle cases like RA105587 -> 105587
+  // handle numeric store numbers
+  let m = store.loc_store_no.match(/^(?<storeNo>\d+)$/);
+
+  if (!m) {
+    // handle vtrcks pins like RA105587 -> 5587 in addition to pure numeric store numbers
+    m = store.loc_store_no.match(/^([A-Z]{3}|[A-Z]{2}\d)(?<storeNo>\d{5})/i);
+  }
+
   if (!m) {
     return null;
   }
-  const storeNumber = m[1];
+  const storeNumber = parseInt(m.groups.storeNo, 10).toString();
 
   for (const system in systemNameRe) {
     if (store.loc_name.match(systemNameRe[system])) {

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -146,7 +146,7 @@ const systemNameRe = {
 };
 
 function getStoreExternalId(store) {
-  const m = store.loc_store_no.match(/^[A-Z]+(\d+)$/); // handle cases like RA105587 -> 105587
+  const m = store.loc_store_no.match(/^[A-Z]*(\d+)$/); // handle cases like RA105587 -> 105587
   if (!m) {
     return null;
   }

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -2,7 +2,7 @@ const Sentry = require("@sentry/node");
 const got = require("got");
 
 const { Available } = require("../../model");
-const { titleCase } = require("../../utils");
+const { oneLine, titleCase } = require("../../utils");
 
 function warn(message, context) {
   console.warn(`CDC API: ${message}`, context);
@@ -295,9 +295,10 @@ function markUnexpectedCvsIds(store) {
   for (const [system, value] of store.external_ids) {
     if (unexpectedCvsIds.has(`${system}:${value}`)) {
       store.is_public = false;
-      store.internal_notes =
-        "Exists in CDC open data but not in CVS APIs; " +
-        "this location is probably not actually administering vaccines.";
+      store.internal_notes = oneLine`
+        Exists in CDC open data but not in CVS APIs;
+        this location is probably not actually administering vaccines.
+      `;
     }
   }
   return store;

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -148,7 +148,7 @@ function getExternalId(store) {
     return null;
   }
 
-  for (system in systemNameRe) {
+  for (const system in systemNameRe) {
     if (store.loc_name.match(systemNameRe[system])) {
       return [system, store.loc_store_no.replace(/[^0-9]/g, "")];
     }

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -87,7 +87,6 @@ function formatStore(storeItems) {
       "ndc",
       "med_name",
       "in_stock",
-      "supply_level",
       "quantity_last_updated",
     ];
     const productList = storeItems.map((item) => {
@@ -117,7 +116,6 @@ function formatStore(storeItems) {
         source: "cdc",
         checked_at: new Date().toISOString(),
         valid_at: formatValidAt(productList),
-        available_count: getAvailableCount(productList),
         available: formatAvailable(productList),
         products: formatProductTypes(productList),
       },
@@ -172,25 +170,8 @@ function formatValidAt(products) {
   return dates[dates.length - 1];
 }
 
-function getAvailableCount(products) {
-  if (!Array.isArray(products)) {
-    products = [products];
-  }
-
-  let sum = 0;
-  for (const product of products) {
-    const supplyLevel = parseInt(product.supply_level, 10);
-    if (supplyLevel > 0) {
-      sum += supplyLevel;
-    } else {
-      sum += product.in_stock ? 1 : 0;
-    }
-  }
-  return sum;
-}
-
 function formatAvailable(products) {
-  return getAvailableCount(products) > 0 ? Available.yes : Available.no;
+  return products.some((p) => p.in_stock) ? Available.yes : Available.no;
 }
 
 const ndcLookup = {

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -257,8 +257,8 @@ async function checkAvailability(handler, options) {
     const stores = Object.values(entriesByStoreId);
     const formatted = stores
       .map(formatStore)
-      .map(markUnexpectedCVSs)
       .filter(Boolean)
+      .map(markUnexpectedCVSs)
       .forEach((item) => handler(item, { update_location: true }));
 
     results = results.concat(formatted);
@@ -291,10 +291,6 @@ const unexpectedCVSs = new Set([
 ]);
 
 function markUnexpectedCVSs(store) {
-  if (!store) {
-    return;
-  }
-
   // mutates stores that match above list to hide them and add an internal note
   for (const [system, value] of store.external_ids) {
     if (unexpectedCVSs.has(`${system}:${value}`)) {

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -1,0 +1,195 @@
+const Sentry = require("@sentry/node");
+const got = require("got");
+
+const { Available, LocationType } = require("../../model");
+const { titleCase } = require("../../utils");
+
+function warn(message, context) {
+  console.warn(`VTS Geo: ${message}`, context);
+  Sentry.captureMessage(message, Sentry.Severity.Info);
+}
+
+function error(message, context) {
+  console.error(`VTS Geo: ${message}`, context);
+  Sentry.captureMessage(message, Sentry.Severity.Error);
+}
+
+async function* queryState(state) {
+  const PAGE_SIZE = 5000;
+
+  let offset = 0;
+  while (true) {
+    try {
+      const response = await got({
+        url: `https://data.cdc.gov/resource/5jp2-pgaw.json?$limit=${PAGE_SIZE}&$offset=${offset}&loc_admin_state=${state}`,
+      });
+      const results = JSON.parse(response.body);
+
+      for (result of results) {
+        yield result;
+      }
+
+      if (results.length < PAGE_SIZE) {
+        return;
+      } else {
+        offset += PAGE_SIZE;
+      }
+    } catch (e) {
+      error(`Error fetching CDC data`, e);
+      return;
+    }
+  }
+}
+
+function formatStore(storeItems) {
+  if (storeItems.length == 0) {
+    return null;
+  }
+
+  let result;
+  Sentry.withScope((scope) => {
+    const base = storeItems[0];
+    scope.setContext("location", {
+      id: base.provider_location_guid,
+      name: base.loc_name,
+      provider: "cdc",
+    });
+
+    const addressLines = [
+      base.loc_admin_street1,
+      base.loc_admin_street2,
+    ].filter(Boolean);
+
+    const metaFields = [
+      "insurance_accepted",
+      "walkins_accepted",
+
+      // TODO: better structure open hours information
+      "sunday_hours",
+      "monday_hours",
+      "tuesday_hours",
+      "wednesday_hours",
+      "thursday_hours",
+      "friday_hours",
+      "saturday_hours",
+    ];
+    const meta = {};
+    for (const field of metaFields) {
+      meta[field] = base[field];
+    }
+
+    const productFields = [
+      "ndc",
+      "med_name",
+      "in_stock",
+      "supply_level",
+      "quantity_last_updated",
+    ];
+    const productList = storeItems.map((item) => {
+      const out = {};
+      for (const field of productFields) {
+        out[field] = item[field];
+      }
+      return out;
+    });
+
+    result = {
+      id: `cdc:${base.provider_location_guid}`,
+      external_ids: ["vaccines_gov", base.provider_location_guid], // XXX what's the right id to send here?
+      name: titleCase(base.loc_name),
+      provider: "cdc",
+
+      address_lines: addressLines,
+      city: base.loc_admin_city,
+      state: base.loc_admin_state,
+      postal_code: base.loc_admin_zip,
+      position: {
+        longitude: base.longitude,
+        latitude: base.latitude,
+      },
+      info_phone: base.loc_phone,
+      info_url: base.web_address,
+      meta,
+
+      availability: {
+        source: "cdc",
+        checked_at: new Date().toISOString(),
+        valid_at: formatValidAt(productList),
+        available_count: getAvailableCount(productList),
+        available: formatAvailable(productList),
+        capacity: formatCapacity(productList),
+        products: formatProducts(productList),
+        // XXX should doses be here?
+      },
+    };
+  });
+  return result;
+}
+
+function formatValidAt(products) {
+  const dates = products.map((p) => p.quantity_last_updated);
+  dates.sort();
+  return dates[dates.length - 1];
+}
+
+function getAvailableCount(products) {
+  let sum = 0;
+  for (const product of products) {
+    sum += parseInt(product.supply_level, 10);
+  }
+  return sum;
+}
+
+function formatAvailable(products) {
+  return getAvailableCount(products) > 0 ? Available.yes : Available.no;
+}
+
+function formatProducts(products) {
+  [...new Set(products.map((p) => p.med_name))];
+}
+
+function formatCapacity(products) {
+  return products.map((product) => {
+    const availableCount = parseInt(product.supply_level, 10);
+    return {
+      products: [product.med_name],
+      date: product.quantity_last_updated,
+      available: availableCount > 0 ? Available.yes : Available.no,
+      available_count: availableCount,
+    };
+  });
+}
+
+async function checkAvailability(handler, options) {
+  handler = (thing) => console.log(JSON.stringify(thing));
+  const states = options.states?.split(",").map((state) => state.trim());
+
+  if (!states || !states.length) {
+    warn("No states specified for cdcApi");
+  }
+
+  let results = [];
+  for (const state of states) {
+    const entriesByStoreId = {};
+    for await (const entry of queryState(state)) {
+      if (!(entry.provider_location_guid in entriesByStoreId)) {
+        entriesByStoreId[entry.provider_location_guid] = [];
+      }
+      entriesByStoreId[entry.provider_location_guid].push(entry);
+    }
+
+    const stores = Object.values(entriesByStoreId);
+    const formatted = stores
+      .map(formatStore)
+      .filter(Boolean)
+      .forEach((item) => handler(item, { update_location: true }));
+
+    results = results.concat(formatted);
+  }
+
+  return results;
+}
+
+module.exports = {
+  checkAvailability,
+};

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -5,7 +5,7 @@ const { Available } = require("../../model");
 const { titleCase } = require("../../utils");
 
 function warn(message, context) {
-  console.warn(`VTS Geo: ${message}`, context);
+  console.warn(`CDC API: ${message}`, context);
   Sentry.captureMessage(message, Sentry.Severity.Info);
 }
 


### PR DESCRIPTION
This PR is an approach to loading CDC data, and works with all of the states they support. For the sake of making sure we get good quality matches, it limits its current output to locations where we know the store number. Later on, we may be able to expand the number of locations loaded when we have more Vaccines.gov UUIDs in our system (perhaps from VtS data).

Fixes #300 