### PR TITLE
Don't run loaders more frequently than 5 minutes

### DIFF
--- a/terraform/loaders.tf
+++ b/terraform/loaders.tf
@@ -43,7 +43,7 @@ module "cvs_smart_loader" {
   api_url       = "http://${aws_alb.main.dns_name}"
   api_key       = var.api_key
   sentry_dsn    = var.loader_sentry_dsn
-  schedule      = "rate(2 minutes)"
+  schedule      = "rate(5 minutes)"
   cluster_arn   = aws_ecs_cluster.main.arn
   role          = aws_iam_role.ecs_task_execution_role.arn
   subnets       = aws_subnet.public.*.id
@@ -57,7 +57,7 @@ module "njvss_loader" {
   api_url       = "http://${aws_alb.main.dns_name}"
   api_key       = var.api_key
   sentry_dsn    = var.loader_sentry_dsn
-  schedule      = "rate(2 minutes)"
+  schedule      = "rate(5 minutes)"
   cluster_arn   = aws_ecs_cluster.main.arn
   role          = aws_iam_role.ecs_task_execution_role.arn
   subnets       = aws_subnet.public.*.id


### PR DESCRIPTION
Appointments aren't disappearing on a minute-by-minute basis anymore, so it probably doesn't make sense to run the loaders a whole lot more frequently than every five minutes at this point. This should also reduce costs *slightly*.

(Another other simple cost reductions we could do in this vein is combining loaders into a single run.)