### PR TITLE
Use correctly formatted `position` in `/api/edge/locations/<external_id>`

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -397,7 +397,9 @@ export async function getLocationByExternalIds(
       fields.map((name) => {
         name = `provider_locations.${name}`;
         // Ensure we return geo coordinates in an easy-to-handle format.
-        return name === "position" ? db.raw(selectSqlPoint(name)) : name;
+        return name === "provider_locations.position"
+          ? db.raw(selectSqlPoint(name))
+          : name;
       })
     )
     .modify((builder) => {

--- a/server/test/api.edge.test.ts
+++ b/server/test/api.edge.test.ts
@@ -185,6 +185,7 @@ describe("GET /api/edge/locations/:id", () => {
       "data.external_ids",
       TestLocation.external_ids
     );
+    expect(res.body).toHaveProperty("data.position", TestLocation.position);
   });
 
   it("can be found by external_id containing external_ids", async () => {
@@ -207,6 +208,7 @@ describe("GET /api/edge/locations/:id", () => {
       "data.external_ids",
       TestLocation.external_ids
     );
+    expect(res.body).toHaveProperty("data.position", TestLocation.position);
   });
 
   it("does not mistakenly select by external_id", async () => {

--- a/server/test/fixtures.ts
+++ b/server/test/fixtures.ts
@@ -28,6 +28,10 @@ export const TestLocation: ProviderLocation = {
   state: "NJ",
   county: "Gloucester",
   postal_code: "06492-3109",
+  position: {
+    longitude: -74.17991,
+    latitude: 40.74444,
+  },
   booking_phone: "",
   booking_url: "https://covidvaccine.nj.gov/",
   description: "This location is available for 1st and 2nd dose recipients.",


### PR DESCRIPTION
When using an external ID (as opposed to an actual UNIVAF ID) in the `/api/edge/locations/<id>` endpoint, we are currently returning the `position` value as WKB:

```js
// http://getmyvax.org/api/edge/locations/rite_aid:5610
{
  "data": {
    "id": "64d41035-6dcf-4331-a9f9-438dec46ee31",
    "position": "0101000020E6100000D122DBF97E7A5DC08716D9CEF7034140",
    // ...
  }
}
```

It looks like we introduced this bug in #147, and I noticed it while reviewing #304. This fixes it and adds coverage for it in tests.