### PR TITLE
Run CDC loader twice a day

### DIFF
--- a/terraform/loaders.tf
+++ b/terraform/loaders.tf
@@ -115,3 +115,18 @@ module "washington_doh_loader" {
   role          = aws_iam_role.ecs_task_execution_role.arn
   subnets       = aws_subnet.public.*.id
 }
+
+module "cdc_loader" {
+  source = "./modules/loader"
+
+  name          = "cdcApi"
+  loader_source = "cdcApi"
+  command       = ["--states", "AL,AK,AZ,AR,CA,CO,CT,DE,DC,FL,GA,HI,ID,IL,IN,IA,KS,KY,LA,ME,MD,MA,MI,MN,MS,MO,MT,NE,NV,NH,NJ,NM,NY,NC,ND,OH,OK,OR,PA,RI,SC,SD,TN,TX,UT,VT,VA,WA,WV,WI,WY,MH,PR,VI"]
+  api_url       = "http://${aws_alb.main.dns_name}"
+  api_key       = var.api_key
+  sentry_dsn    = var.loader_sentry_dsn
+  schedule      = "cron(0 0,12 * * ? *)"
+  cluster_arn   = aws_ecs_cluster.main.arn
+  role          = aws_iam_role.ecs_task_execution_role.arn
+  subnets       = aws_subnet.public.*.id
+}


### PR DESCRIPTION
Subject says it all. @Mr0grog I'm not sure the timing matters much, but running it at 0GMT and 12GMT should put it far away from our nightly backup jobs