### PR TITLE
Load PrepMod data from Washington and Alaska

### DIFF
--- a/terraform/loaders.tf
+++ b/terraform/loaders.tf
@@ -145,3 +145,18 @@ module "vts_geo_loader" {
   role          = aws_iam_role.ecs_task_execution_role.arn
   subnets       = aws_subnet.public.*.id
 }
+
+module "prepmod_loader" {
+  source = "./modules/loader"
+
+  name          = "prepmod"
+  command       = ["--states", "AK,WA"]
+  loader_source = "prepmod"
+  api_url       = "http://${aws_alb.main.dns_name}"
+  api_key       = var.api_key
+  sentry_dsn    = var.loader_sentry_dsn
+  schedule      = "rate(5 minutes)"
+  cluster_arn   = aws_ecs_cluster.main.arn
+  role          = aws_iam_role.ecs_task_execution_role.arn
+  subnets       = aws_subnet.public.*.id
+}


### PR DESCRIPTION
Now that the PrepMod loader works, let's start loading it! For now, the API is only turned on in Washington, and we are actively working to get it turned *back* on in Alaska, so this just runs it in those two states.