### PR TITLE
Update Knex & path-parse (a dependency) to 0.95.10

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -26,7 +26,7 @@
         "express-validator": "6.12.1",
         "hot-shots": "^8.5.0",
         "JSONStream": "^1.3.5",
-        "knex": "^0.95.9",
+        "knex": "^0.95.10",
         "lodash": "4.17.21",
         "luxon": "^1.27.0",
         "pg": "^8.7.1",
@@ -6898,9 +6898,9 @@
       }
     },
     "node_modules/knex": {
-      "version": "0.95.9",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-0.95.9.tgz",
-      "integrity": "sha512-iy8Wue3ofGBVZENgz32fx2uYSYhXCQEE7lemMIdm/FDtgwwmrzkYm9BdGZ4wb8Fg/oCgezMGWSdCflWicX4sdA==",
+      "version": "0.95.10",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-0.95.10.tgz",
+      "integrity": "sha512-I60A8TXcMdeJlE6h7DSgEYyY37S7kgLObz1qlJ7QvPMD6vnKO5dtuLEht5pMia9Qf5BomqVgkWCdVTqcC/ImOA==",
       "dependencies": {
         "colorette": "1.2.1",
         "commander": "^7.1.0",
@@ -7855,9 +7855,9 @@
       }
     },
     "node_modules/path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.7",
@@ -15404,9 +15404,9 @@
       "dev": true
     },
     "knex": {
-      "version": "0.95.9",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-0.95.9.tgz",
-      "integrity": "sha512-iy8Wue3ofGBVZENgz32fx2uYSYhXCQEE7lemMIdm/FDtgwwmrzkYm9BdGZ4wb8Fg/oCgezMGWSdCflWicX4sdA==",
+      "version": "0.95.10",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-0.95.10.tgz",
+      "integrity": "sha512-I60A8TXcMdeJlE6h7DSgEYyY37S7kgLObz1qlJ7QvPMD6vnKO5dtuLEht5pMia9Qf5BomqVgkWCdVTqcC/ImOA==",
       "requires": {
         "colorette": "1.2.1",
         "commander": "^7.1.0",
@@ -16136,9 +16136,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-to-regexp": {
       "version": "0.1.7",

--- a/server/package.json
+++ b/server/package.json
@@ -48,7 +48,7 @@
     "express-validator": "6.12.1",
     "hot-shots": "^8.5.0",
     "JSONStream": "^1.3.5",
-    "knex": "^0.95.9",
+    "knex": "^0.95.10",
     "lodash": "4.17.21",
     "luxon": "^1.27.0",
     "pg": "^8.7.1",


### PR DESCRIPTION
Fixes a minor security issue in path-parse (https://npmjs.com/advisories/1773), which is a subdependency of Knex.