### PR TITLE
Handle invalid `address_lines` data (server and loader)

### DIFF
--- a/loader/src/sources/vaccinespotter/index.js
+++ b/loader/src/sources/vaccinespotter/index.js
@@ -256,14 +256,17 @@ const formatters = {
       id = `vaccinespotter:${store.properties.id}`;
     }
 
+    let addressLines = [];
+    if (store.properties.address) {
+      addressLines.push(titleCase(store.properties.address));
+    }
+
     return {
       id,
       location_type: LocationType.pharmacy,
       name: store.properties.name || store.properties.provider_brand_name,
       provider: providerBrand,
-      address_lines: store.properties.address && [
-        titleCase(store.properties.address),
-      ],
+      address_lines: addressLines,
       city: store.properties.city && titleCase(store.properties.city),
       state: store.properties.state,
       postal_code: store.properties.postal_code,

--- a/loader/src/sources/vaccinespotter/index.js
+++ b/loader/src/sources/vaccinespotter/index.js
@@ -256,9 +256,9 @@ const formatters = {
       id = `vaccinespotter:${store.properties.id}`;
     }
 
-    const addressLines = [];
+    let addressLines;
     if (store.properties.address) {
-      addressLines.push(titleCase(store.properties.address));
+      addressLines = [titleCase(store.properties.address)];
     }
 
     return {

--- a/loader/src/sources/vaccinespotter/index.js
+++ b/loader/src/sources/vaccinespotter/index.js
@@ -256,7 +256,7 @@ const formatters = {
       id = `vaccinespotter:${store.properties.id}`;
     }
 
-    let addressLines = [];
+    const addressLines = [];
     if (store.properties.address) {
       addressLines.push(titleCase(store.properties.address));
     }

--- a/loader/test/vaccinespotter.test.js
+++ b/loader/test/vaccinespotter.test.js
@@ -383,4 +383,16 @@ describe("VaccineSpotter", () => {
     expect(result).toHaveProperty("name", "Harveys #1688");
     expect(result).toHaveProperty("external_ids.harveys", "1688");
   });
+
+  it("it should always send an array for address_lines", () => {
+    const result = formatStore({
+      ...basicVaccineSpotterStore,
+      properties: {
+        ...basicVaccineSpotterStore.properties,
+        address: "",
+      },
+    });
+
+    expect(result).toHaveProperty("address_lines", []);
+  });
 });

--- a/loader/test/vaccinespotter.test.js
+++ b/loader/test/vaccinespotter.test.js
@@ -393,6 +393,6 @@ describe("VaccineSpotter", () => {
       },
     });
 
-    expect(result).toHaveProperty("address_lines", []);
+    expect(result).toHaveProperty("address_lines", undefined);
   });
 });

--- a/server/src/api/edge.ts
+++ b/server/src/api/edge.ts
@@ -229,6 +229,14 @@ export const update = async (req: AppRequest, res: Response): Promise<any> => {
     data = { ...data, external_ids: Object.entries(data.external_ids) };
   }
 
+  if ("address_lines" in data && !Array.isArray(data.address_lines)) {
+    if (!data.address_lines) {
+      data.address_lines = []; // substitute an empty array for any falsy input value
+    } else {
+      return sendError(res, "Invalid value for `address_lines`", 422);
+    }
+  }
+
   const result: any = { location: { action: null } };
 
   // FIXME: need to make this a single PG operation or add locks around it. It's

--- a/server/test/api.edge.test.ts
+++ b/server/test/api.edge.test.ts
@@ -713,7 +713,7 @@ describe("POST /api/edge/update", () => {
     expect(res.statusCode).toBe(422);
   });
 
-  it("update location fails gracefully with empty string address_lines", async () => {
+  it("update location succeeds with empty string address_lines", async () => {
     const location = await createLocation(TestLocation);
     const res = await context.client.post("api/edge/update?update_location=1", {
       headers,

--- a/server/test/api.edge.test.ts
+++ b/server/test/api.edge.test.ts
@@ -687,4 +687,33 @@ describe("POST /api/edge/update", () => {
       TestLocation.id.toLowerCase()
     );
   });
+
+  it("create location fails gracefully with empty string address_lines", async () => {
+    const res = await context.client.post("api/edge/update?update_location=1", {
+      headers,
+      json: {
+        ...TestLocation,
+        address_lines: "",
+      },
+    });
+    expect(res.statusCode).toBe(201); // create instead of update
+
+    const result = await getLocationById(TestLocation.id);
+    expect(result).toHaveProperty("address_lines", []);
+  });
+
+  it("update location fails gracefully with empty string address_lines", async () => {
+    const location = await createLocation(TestLocation);
+    const res = await context.client.post("api/edge/update?update_location=1", {
+      headers,
+      json: {
+        id: location.id,
+        address_lines: "",
+      },
+    });
+    expect(res.statusCode).toBe(200);
+
+    const result = await getLocationById(location.id);
+    expect(result).toHaveProperty("address_lines", []);
+  });
 });

--- a/server/test/api.edge.test.ts
+++ b/server/test/api.edge.test.ts
@@ -702,6 +702,17 @@ describe("POST /api/edge/update", () => {
     expect(result).toHaveProperty("address_lines", []);
   });
 
+  it("create location errors with invalid address_lines value", async () => {
+    const res = await context.client.post("api/edge/update?update_location=1", {
+      headers,
+      json: {
+        ...TestLocation,
+        address_lines: { test: 123 },
+      },
+    });
+    expect(res.statusCode).toBe(422);
+  });
+
   it("update location fails gracefully with empty string address_lines", async () => {
     const location = await createLocation(TestLocation);
     const res = await context.client.post("api/edge/update?update_location=1", {
@@ -715,5 +726,17 @@ describe("POST /api/edge/update", () => {
 
     const result = await getLocationById(location.id);
     expect(result).toHaveProperty("address_lines", []);
+  });
+
+  it("update location errors with invalid address_lines value", async () => {
+    const location = await createLocation(TestLocation);
+    const res = await context.client.post("api/edge/update?update_location=1", {
+      headers,
+      json: {
+        id: location.id,
+        address_lines: { test: 123 },
+      },
+    });
+    expect(res.statusCode).toBe(422);
   });
 });


### PR DESCRIPTION
This PR ensures that falsy values for `address_lines` don't cause unexpected errors by adding some server-side validation to coalesce those values into an empty array. It appears the only loader sending that sort of bad data was Vaccine Spotter, so we also apply a small fix there to clean up its output.

Fixes #355 from the server side as well as the loader side. Either fix would have sufficed, but both were easy, so 🤷🏽‍♂️.