### PR TITLE
Disable `/debugme` route in production

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -53,13 +53,16 @@ app.use(urlDecodeSpecialPathChars);
  */
 
 app.get("/", (_req: Request, res: Response) => res.redirect("/docs/"));
-app.get("/debugme", (_req: Request, _res: Response) => {
-  throw new Error("TESTING SENTRY AGAIN");
-});
 app.get("/health", (req: Request, res: Response) => {
   // TODO: include the db status before declaring ourselves "up"
   res.status(200).send("OK!");
 });
+if (app.get("env") !== "production") {
+  // Use this route to test error handlers.
+  app.get("/debugme", (_req: Request, _res: Response) => {
+    throw new Error("This is an error from a route handler");
+  });
+}
 
 // Caching -------------------------------------------------------
 const shortCacheTime = 10;


### PR DESCRIPTION
This route is meant for testing error handlers, and should not actually be available in production. (It doesn’t expose anything sensitive, but it can spam Sentry and make us thing something’s broken when it’s not.)

Fixes the second part of #358, alongside #375.