### PR TITLE
HOTFIX: Bump max request body size in API server

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -48,7 +48,7 @@ app.disable("x-powered-by");
 app.use(Sentry.Handlers.requestHandler());
 app.use(logRequest);
 app.use(compression());
-app.use(bodyParser.json({ limit: "500kb" }));
+app.use(bodyParser.json({ limit: "1mb" }));
 app.use(cors());
 app.use(authorizeRequest);
 app.use(datadogMiddleware);


### PR DESCRIPTION
A few locations from the PrepMod loader are too big for our current 500 kB limit, so this is the quickest and straightest solution. We might want to do a second pass on the loader where we summarize the data more briefly, since this is a lot to ship *out* and to do joins on in our own API.

Fixes #387.