### PR TITLE
Upgrade Sentry to v6.13.3

### DIFF
--- a/loader/package-lock.json
+++ b/loader/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.33.0",
-        "@sentry/node": "^6.12.0",
+        "@sentry/node": "^6.13.3",
         "csv-parse": "^4.16.3",
         "get-stream": "^6.0.1",
         "got": "^11.8.2",
@@ -2145,14 +2145,14 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.12.0.tgz",
-      "integrity": "sha512-mU/zdjlzFHzdXDZCPZm8OeCw7c9xsbL49Mq0TrY0KJjLt4CJBkiq5SDTGfRsenBLgTedYhe5Z/J8Z+xVVq+MfQ==",
+      "version": "6.13.3",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.13.3.tgz",
+      "integrity": "sha512-obm3SjgCk8A7nB37b2AU1eq1q7gMoJRrGMv9VRIyfcG0Wlz/5lJ9O3ohUk+YZaaVfZMxXn6hFtsBiOWmlv7IIA==",
       "dependencies": {
-        "@sentry/hub": "6.12.0",
-        "@sentry/minimal": "6.12.0",
-        "@sentry/types": "6.12.0",
-        "@sentry/utils": "6.12.0",
+        "@sentry/hub": "6.13.3",
+        "@sentry/minimal": "6.13.3",
+        "@sentry/types": "6.13.3",
+        "@sentry/utils": "6.13.3",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -2165,12 +2165,12 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/hub": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.12.0.tgz",
-      "integrity": "sha512-yR/UQVU+ukr42bSYpeqvb989SowIXlKBanU0cqLFDmv5LPCnaQB8PGeXwJAwWhQgx44PARhmB82S6Xor8gYNxg==",
+      "version": "6.13.3",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.13.3.tgz",
+      "integrity": "sha512-eYppBVqvhs5cvm33snW2sxfcw6G20/74RbBn+E4WDo15hozis89kU7ZCJDOPkXuag3v1h9igns/kM6PNBb41dw==",
       "dependencies": {
-        "@sentry/types": "6.12.0",
-        "@sentry/utils": "6.12.0",
+        "@sentry/types": "6.13.3",
+        "@sentry/utils": "6.13.3",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -2183,12 +2183,12 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/minimal": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.12.0.tgz",
-      "integrity": "sha512-r3C54Q1KN+xIqUvcgX9DlcoWE7ezWvFk2pSu1Ojx9De81hVqR9u5T3sdSAP2Xma+um0zr6coOtDJG4WtYlOtsw==",
+      "version": "6.13.3",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.13.3.tgz",
+      "integrity": "sha512-63MlYYRni3fs5Bh8XBAfVZ+ctDdWg0fapSTP1ydIC37fKvbE+5zhyUqwrEKBIiclEApg1VKX7bkKxVdu/vsFdw==",
       "dependencies": {
-        "@sentry/hub": "6.12.0",
-        "@sentry/types": "6.12.0",
+        "@sentry/hub": "6.13.3",
+        "@sentry/types": "6.13.3",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -2201,15 +2201,15 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/node": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.12.0.tgz",
-      "integrity": "sha512-hfAU3cX5sNWgqyDQBCOIQOZj21l0w1z2dG4MjmrMMHKrQ18pfMaaOtEwRXMCdjTUlwsK+L3TOoUB23lbezmu1A==",
+      "version": "6.13.3",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.13.3.tgz",
+      "integrity": "sha512-ZeZSw+TcPcf4e0j7iEqNMtoVmz+WFW/TEoGokXIwysZqSgchKdAXDHqn+CqUqFan7d76JcJmzztAUK2JruQ2Kg==",
       "dependencies": {
-        "@sentry/core": "6.12.0",
-        "@sentry/hub": "6.12.0",
-        "@sentry/tracing": "6.12.0",
-        "@sentry/types": "6.12.0",
-        "@sentry/utils": "6.12.0",
+        "@sentry/core": "6.13.3",
+        "@sentry/hub": "6.13.3",
+        "@sentry/tracing": "6.13.3",
+        "@sentry/types": "6.13.3",
+        "@sentry/utils": "6.13.3",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -2225,14 +2225,14 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/tracing": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.12.0.tgz",
-      "integrity": "sha512-u10QHNknPBzbWSUUNMkvuH53sQd5NaBo6YdNPj4p5b7sE7445Sh0PwBpRbY3ZiUUiwyxV59fx9UQ4yVnPGxZQA==",
+      "version": "6.13.3",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.13.3.tgz",
+      "integrity": "sha512-yyOFIhqlprPM0g4f35Icear3eZk2mwyYcGEzljJfY2iU6pJwj1lzia5PfSwiCW7jFGMmlBJNhOAIpfhlliZi8Q==",
       "dependencies": {
-        "@sentry/hub": "6.12.0",
-        "@sentry/minimal": "6.12.0",
-        "@sentry/types": "6.12.0",
-        "@sentry/utils": "6.12.0",
+        "@sentry/hub": "6.13.3",
+        "@sentry/minimal": "6.13.3",
+        "@sentry/types": "6.13.3",
+        "@sentry/utils": "6.13.3",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -2245,19 +2245,19 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/types": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.12.0.tgz",
-      "integrity": "sha512-urtgLzE4EDMAYQHYdkgC0Ei9QvLajodK1ntg71bGn0Pm84QUpaqpPDfHRU+i6jLeteyC7kWwa5O5W1m/jrjGXA==",
+      "version": "6.13.3",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.13.3.tgz",
+      "integrity": "sha512-Vrz5CdhaTRSvCQjSyIFIaV9PodjAVFkzJkTRxyY7P77RcegMsRSsG1yzlvCtA99zG9+e6MfoJOgbOCwuZids5A==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.12.0.tgz",
-      "integrity": "sha512-oRHQ7TH5TSsJqoP9Gqq25Jvn9LKexXfAh/OoKwjMhYCGKGhqpDNUIZVgl9DWsGw5A5N5xnQyLOxDfyRV5RshdA==",
+      "version": "6.13.3",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.13.3.tgz",
+      "integrity": "sha512-zYFuFH3MaYtBZTeJ4Yajg7pDf0pM3MWs3+9k5my9Fd+eqNcl7dYQYJbT9gyC0HXK1QI4CAMNNlHNl4YXhF91ag==",
       "dependencies": {
-        "@sentry/types": "6.12.0",
+        "@sentry/types": "6.13.3",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -9900,14 +9900,14 @@
       }
     },
     "@sentry/core": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.12.0.tgz",
-      "integrity": "sha512-mU/zdjlzFHzdXDZCPZm8OeCw7c9xsbL49Mq0TrY0KJjLt4CJBkiq5SDTGfRsenBLgTedYhe5Z/J8Z+xVVq+MfQ==",
+      "version": "6.13.3",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.13.3.tgz",
+      "integrity": "sha512-obm3SjgCk8A7nB37b2AU1eq1q7gMoJRrGMv9VRIyfcG0Wlz/5lJ9O3ohUk+YZaaVfZMxXn6hFtsBiOWmlv7IIA==",
       "requires": {
-        "@sentry/hub": "6.12.0",
-        "@sentry/minimal": "6.12.0",
-        "@sentry/types": "6.12.0",
-        "@sentry/utils": "6.12.0",
+        "@sentry/hub": "6.13.3",
+        "@sentry/minimal": "6.13.3",
+        "@sentry/types": "6.13.3",
+        "@sentry/utils": "6.13.3",
         "tslib": "^1.9.3"
       },
       "dependencies": {
@@ -9919,12 +9919,12 @@
       }
     },
     "@sentry/hub": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.12.0.tgz",
-      "integrity": "sha512-yR/UQVU+ukr42bSYpeqvb989SowIXlKBanU0cqLFDmv5LPCnaQB8PGeXwJAwWhQgx44PARhmB82S6Xor8gYNxg==",
+      "version": "6.13.3",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.13.3.tgz",
+      "integrity": "sha512-eYppBVqvhs5cvm33snW2sxfcw6G20/74RbBn+E4WDo15hozis89kU7ZCJDOPkXuag3v1h9igns/kM6PNBb41dw==",
       "requires": {
-        "@sentry/types": "6.12.0",
-        "@sentry/utils": "6.12.0",
+        "@sentry/types": "6.13.3",
+        "@sentry/utils": "6.13.3",
         "tslib": "^1.9.3"
       },
       "dependencies": {
@@ -9936,12 +9936,12 @@
       }
     },
     "@sentry/minimal": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.12.0.tgz",
-      "integrity": "sha512-r3C54Q1KN+xIqUvcgX9DlcoWE7ezWvFk2pSu1Ojx9De81hVqR9u5T3sdSAP2Xma+um0zr6coOtDJG4WtYlOtsw==",
+      "version": "6.13.3",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.13.3.tgz",
+      "integrity": "sha512-63MlYYRni3fs5Bh8XBAfVZ+ctDdWg0fapSTP1ydIC37fKvbE+5zhyUqwrEKBIiclEApg1VKX7bkKxVdu/vsFdw==",
       "requires": {
-        "@sentry/hub": "6.12.0",
-        "@sentry/types": "6.12.0",
+        "@sentry/hub": "6.13.3",
+        "@sentry/types": "6.13.3",
         "tslib": "^1.9.3"
       },
       "dependencies": {
@@ -9953,15 +9953,15 @@
       }
     },
     "@sentry/node": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.12.0.tgz",
-      "integrity": "sha512-hfAU3cX5sNWgqyDQBCOIQOZj21l0w1z2dG4MjmrMMHKrQ18pfMaaOtEwRXMCdjTUlwsK+L3TOoUB23lbezmu1A==",
+      "version": "6.13.3",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.13.3.tgz",
+      "integrity": "sha512-ZeZSw+TcPcf4e0j7iEqNMtoVmz+WFW/TEoGokXIwysZqSgchKdAXDHqn+CqUqFan7d76JcJmzztAUK2JruQ2Kg==",
       "requires": {
-        "@sentry/core": "6.12.0",
-        "@sentry/hub": "6.12.0",
-        "@sentry/tracing": "6.12.0",
-        "@sentry/types": "6.12.0",
-        "@sentry/utils": "6.12.0",
+        "@sentry/core": "6.13.3",
+        "@sentry/hub": "6.13.3",
+        "@sentry/tracing": "6.13.3",
+        "@sentry/types": "6.13.3",
+        "@sentry/utils": "6.13.3",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -9976,14 +9976,14 @@
       }
     },
     "@sentry/tracing": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.12.0.tgz",
-      "integrity": "sha512-u10QHNknPBzbWSUUNMkvuH53sQd5NaBo6YdNPj4p5b7sE7445Sh0PwBpRbY3ZiUUiwyxV59fx9UQ4yVnPGxZQA==",
+      "version": "6.13.3",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.13.3.tgz",
+      "integrity": "sha512-yyOFIhqlprPM0g4f35Icear3eZk2mwyYcGEzljJfY2iU6pJwj1lzia5PfSwiCW7jFGMmlBJNhOAIpfhlliZi8Q==",
       "requires": {
-        "@sentry/hub": "6.12.0",
-        "@sentry/minimal": "6.12.0",
-        "@sentry/types": "6.12.0",
-        "@sentry/utils": "6.12.0",
+        "@sentry/hub": "6.13.3",
+        "@sentry/minimal": "6.13.3",
+        "@sentry/types": "6.13.3",
+        "@sentry/utils": "6.13.3",
         "tslib": "^1.9.3"
       },
       "dependencies": {
@@ -9995,16 +9995,16 @@
       }
     },
     "@sentry/types": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.12.0.tgz",
-      "integrity": "sha512-urtgLzE4EDMAYQHYdkgC0Ei9QvLajodK1ntg71bGn0Pm84QUpaqpPDfHRU+i6jLeteyC7kWwa5O5W1m/jrjGXA=="
+      "version": "6.13.3",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.13.3.tgz",
+      "integrity": "sha512-Vrz5CdhaTRSvCQjSyIFIaV9PodjAVFkzJkTRxyY7P77RcegMsRSsG1yzlvCtA99zG9+e6MfoJOgbOCwuZids5A=="
     },
     "@sentry/utils": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.12.0.tgz",
-      "integrity": "sha512-oRHQ7TH5TSsJqoP9Gqq25Jvn9LKexXfAh/OoKwjMhYCGKGhqpDNUIZVgl9DWsGw5A5N5xnQyLOxDfyRV5RshdA==",
+      "version": "6.13.3",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.13.3.tgz",
+      "integrity": "sha512-zYFuFH3MaYtBZTeJ4Yajg7pDf0pM3MWs3+9k5my9Fd+eqNcl7dYQYJbT9gyC0HXK1QI4CAMNNlHNl4YXhF91ag==",
       "requires": {
-        "@sentry/types": "6.12.0",
+        "@sentry/types": "6.13.3",
         "tslib": "^1.9.3"
       },
       "dependencies": {

--- a/loader/package.json
+++ b/loader/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.33.0",
-    "@sentry/node": "^6.12.0",
+    "@sentry/node": "^6.13.3",
     "csv-parse": "^4.16.3",
     "get-stream": "^6.0.1",
     "got": "^11.8.2",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@sentry/node": "^6.12.0",
-        "@sentry/tracing": "^6.12.0",
+        "@sentry/node": "^6.13.3",
+        "@sentry/tracing": "^6.13.3",
         "ajv": "^8.6.3",
         "ajv-formats": "^2.1.1",
         "ajv-keywords": "^5.0.0",
@@ -1209,14 +1209,14 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.12.0.tgz",
-      "integrity": "sha512-mU/zdjlzFHzdXDZCPZm8OeCw7c9xsbL49Mq0TrY0KJjLt4CJBkiq5SDTGfRsenBLgTedYhe5Z/J8Z+xVVq+MfQ==",
+      "version": "6.13.3",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.13.3.tgz",
+      "integrity": "sha512-obm3SjgCk8A7nB37b2AU1eq1q7gMoJRrGMv9VRIyfcG0Wlz/5lJ9O3ohUk+YZaaVfZMxXn6hFtsBiOWmlv7IIA==",
       "dependencies": {
-        "@sentry/hub": "6.12.0",
-        "@sentry/minimal": "6.12.0",
-        "@sentry/types": "6.12.0",
-        "@sentry/utils": "6.12.0",
+        "@sentry/hub": "6.13.3",
+        "@sentry/minimal": "6.13.3",
+        "@sentry/types": "6.13.3",
+        "@sentry/utils": "6.13.3",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -1224,12 +1224,12 @@
       }
     },
     "node_modules/@sentry/hub": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.12.0.tgz",
-      "integrity": "sha512-yR/UQVU+ukr42bSYpeqvb989SowIXlKBanU0cqLFDmv5LPCnaQB8PGeXwJAwWhQgx44PARhmB82S6Xor8gYNxg==",
+      "version": "6.13.3",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.13.3.tgz",
+      "integrity": "sha512-eYppBVqvhs5cvm33snW2sxfcw6G20/74RbBn+E4WDo15hozis89kU7ZCJDOPkXuag3v1h9igns/kM6PNBb41dw==",
       "dependencies": {
-        "@sentry/types": "6.12.0",
-        "@sentry/utils": "6.12.0",
+        "@sentry/types": "6.13.3",
+        "@sentry/utils": "6.13.3",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -1237,12 +1237,12 @@
       }
     },
     "node_modules/@sentry/minimal": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.12.0.tgz",
-      "integrity": "sha512-r3C54Q1KN+xIqUvcgX9DlcoWE7ezWvFk2pSu1Ojx9De81hVqR9u5T3sdSAP2Xma+um0zr6coOtDJG4WtYlOtsw==",
+      "version": "6.13.3",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.13.3.tgz",
+      "integrity": "sha512-63MlYYRni3fs5Bh8XBAfVZ+ctDdWg0fapSTP1ydIC37fKvbE+5zhyUqwrEKBIiclEApg1VKX7bkKxVdu/vsFdw==",
       "dependencies": {
-        "@sentry/hub": "6.12.0",
-        "@sentry/types": "6.12.0",
+        "@sentry/hub": "6.13.3",
+        "@sentry/types": "6.13.3",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -1250,15 +1250,15 @@
       }
     },
     "node_modules/@sentry/node": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.12.0.tgz",
-      "integrity": "sha512-hfAU3cX5sNWgqyDQBCOIQOZj21l0w1z2dG4MjmrMMHKrQ18pfMaaOtEwRXMCdjTUlwsK+L3TOoUB23lbezmu1A==",
+      "version": "6.13.3",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.13.3.tgz",
+      "integrity": "sha512-ZeZSw+TcPcf4e0j7iEqNMtoVmz+WFW/TEoGokXIwysZqSgchKdAXDHqn+CqUqFan7d76JcJmzztAUK2JruQ2Kg==",
       "dependencies": {
-        "@sentry/core": "6.12.0",
-        "@sentry/hub": "6.12.0",
-        "@sentry/tracing": "6.12.0",
-        "@sentry/types": "6.12.0",
-        "@sentry/utils": "6.12.0",
+        "@sentry/core": "6.13.3",
+        "@sentry/hub": "6.13.3",
+        "@sentry/tracing": "6.13.3",
+        "@sentry/types": "6.13.3",
+        "@sentry/utils": "6.13.3",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -1277,14 +1277,14 @@
       }
     },
     "node_modules/@sentry/tracing": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.12.0.tgz",
-      "integrity": "sha512-u10QHNknPBzbWSUUNMkvuH53sQd5NaBo6YdNPj4p5b7sE7445Sh0PwBpRbY3ZiUUiwyxV59fx9UQ4yVnPGxZQA==",
+      "version": "6.13.3",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.13.3.tgz",
+      "integrity": "sha512-yyOFIhqlprPM0g4f35Icear3eZk2mwyYcGEzljJfY2iU6pJwj1lzia5PfSwiCW7jFGMmlBJNhOAIpfhlliZi8Q==",
       "dependencies": {
-        "@sentry/hub": "6.12.0",
-        "@sentry/minimal": "6.12.0",
-        "@sentry/types": "6.12.0",
-        "@sentry/utils": "6.12.0",
+        "@sentry/hub": "6.13.3",
+        "@sentry/minimal": "6.13.3",
+        "@sentry/types": "6.13.3",
+        "@sentry/utils": "6.13.3",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -1292,19 +1292,19 @@
       }
     },
     "node_modules/@sentry/types": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.12.0.tgz",
-      "integrity": "sha512-urtgLzE4EDMAYQHYdkgC0Ei9QvLajodK1ntg71bGn0Pm84QUpaqpPDfHRU+i6jLeteyC7kWwa5O5W1m/jrjGXA==",
+      "version": "6.13.3",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.13.3.tgz",
+      "integrity": "sha512-Vrz5CdhaTRSvCQjSyIFIaV9PodjAVFkzJkTRxyY7P77RcegMsRSsG1yzlvCtA99zG9+e6MfoJOgbOCwuZids5A==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.12.0.tgz",
-      "integrity": "sha512-oRHQ7TH5TSsJqoP9Gqq25Jvn9LKexXfAh/OoKwjMhYCGKGhqpDNUIZVgl9DWsGw5A5N5xnQyLOxDfyRV5RshdA==",
+      "version": "6.13.3",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.13.3.tgz",
+      "integrity": "sha512-zYFuFH3MaYtBZTeJ4Yajg7pDf0pM3MWs3+9k5my9Fd+eqNcl7dYQYJbT9gyC0HXK1QI4CAMNNlHNl4YXhF91ag==",
       "dependencies": {
-        "@sentry/types": "6.12.0",
+        "@sentry/types": "6.13.3",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -9760,47 +9760,47 @@
       }
     },
     "@sentry/core": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.12.0.tgz",
-      "integrity": "sha512-mU/zdjlzFHzdXDZCPZm8OeCw7c9xsbL49Mq0TrY0KJjLt4CJBkiq5SDTGfRsenBLgTedYhe5Z/J8Z+xVVq+MfQ==",
+      "version": "6.13.3",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.13.3.tgz",
+      "integrity": "sha512-obm3SjgCk8A7nB37b2AU1eq1q7gMoJRrGMv9VRIyfcG0Wlz/5lJ9O3ohUk+YZaaVfZMxXn6hFtsBiOWmlv7IIA==",
       "requires": {
-        "@sentry/hub": "6.12.0",
-        "@sentry/minimal": "6.12.0",
-        "@sentry/types": "6.12.0",
-        "@sentry/utils": "6.12.0",
+        "@sentry/hub": "6.13.3",
+        "@sentry/minimal": "6.13.3",
+        "@sentry/types": "6.13.3",
+        "@sentry/utils": "6.13.3",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.12.0.tgz",
-      "integrity": "sha512-yR/UQVU+ukr42bSYpeqvb989SowIXlKBanU0cqLFDmv5LPCnaQB8PGeXwJAwWhQgx44PARhmB82S6Xor8gYNxg==",
+      "version": "6.13.3",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.13.3.tgz",
+      "integrity": "sha512-eYppBVqvhs5cvm33snW2sxfcw6G20/74RbBn+E4WDo15hozis89kU7ZCJDOPkXuag3v1h9igns/kM6PNBb41dw==",
       "requires": {
-        "@sentry/types": "6.12.0",
-        "@sentry/utils": "6.12.0",
+        "@sentry/types": "6.13.3",
+        "@sentry/utils": "6.13.3",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.12.0.tgz",
-      "integrity": "sha512-r3C54Q1KN+xIqUvcgX9DlcoWE7ezWvFk2pSu1Ojx9De81hVqR9u5T3sdSAP2Xma+um0zr6coOtDJG4WtYlOtsw==",
+      "version": "6.13.3",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.13.3.tgz",
+      "integrity": "sha512-63MlYYRni3fs5Bh8XBAfVZ+ctDdWg0fapSTP1ydIC37fKvbE+5zhyUqwrEKBIiclEApg1VKX7bkKxVdu/vsFdw==",
       "requires": {
-        "@sentry/hub": "6.12.0",
-        "@sentry/types": "6.12.0",
+        "@sentry/hub": "6.13.3",
+        "@sentry/types": "6.13.3",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/node": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.12.0.tgz",
-      "integrity": "sha512-hfAU3cX5sNWgqyDQBCOIQOZj21l0w1z2dG4MjmrMMHKrQ18pfMaaOtEwRXMCdjTUlwsK+L3TOoUB23lbezmu1A==",
+      "version": "6.13.3",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.13.3.tgz",
+      "integrity": "sha512-ZeZSw+TcPcf4e0j7iEqNMtoVmz+WFW/TEoGokXIwysZqSgchKdAXDHqn+CqUqFan7d76JcJmzztAUK2JruQ2Kg==",
       "requires": {
-        "@sentry/core": "6.12.0",
-        "@sentry/hub": "6.12.0",
-        "@sentry/tracing": "6.12.0",
-        "@sentry/types": "6.12.0",
-        "@sentry/utils": "6.12.0",
+        "@sentry/core": "6.13.3",
+        "@sentry/hub": "6.13.3",
+        "@sentry/tracing": "6.13.3",
+        "@sentry/types": "6.13.3",
+        "@sentry/utils": "6.13.3",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -9815,28 +9815,28 @@
       }
     },
     "@sentry/tracing": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.12.0.tgz",
-      "integrity": "sha512-u10QHNknPBzbWSUUNMkvuH53sQd5NaBo6YdNPj4p5b7sE7445Sh0PwBpRbY3ZiUUiwyxV59fx9UQ4yVnPGxZQA==",
+      "version": "6.13.3",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.13.3.tgz",
+      "integrity": "sha512-yyOFIhqlprPM0g4f35Icear3eZk2mwyYcGEzljJfY2iU6pJwj1lzia5PfSwiCW7jFGMmlBJNhOAIpfhlliZi8Q==",
       "requires": {
-        "@sentry/hub": "6.12.0",
-        "@sentry/minimal": "6.12.0",
-        "@sentry/types": "6.12.0",
-        "@sentry/utils": "6.12.0",
+        "@sentry/hub": "6.13.3",
+        "@sentry/minimal": "6.13.3",
+        "@sentry/types": "6.13.3",
+        "@sentry/utils": "6.13.3",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.12.0.tgz",
-      "integrity": "sha512-urtgLzE4EDMAYQHYdkgC0Ei9QvLajodK1ntg71bGn0Pm84QUpaqpPDfHRU+i6jLeteyC7kWwa5O5W1m/jrjGXA=="
+      "version": "6.13.3",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.13.3.tgz",
+      "integrity": "sha512-Vrz5CdhaTRSvCQjSyIFIaV9PodjAVFkzJkTRxyY7P77RcegMsRSsG1yzlvCtA99zG9+e6MfoJOgbOCwuZids5A=="
     },
     "@sentry/utils": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.12.0.tgz",
-      "integrity": "sha512-oRHQ7TH5TSsJqoP9Gqq25Jvn9LKexXfAh/OoKwjMhYCGKGhqpDNUIZVgl9DWsGw5A5N5xnQyLOxDfyRV5RshdA==",
+      "version": "6.13.3",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.13.3.tgz",
+      "integrity": "sha512-zYFuFH3MaYtBZTeJ4Yajg7pDf0pM3MWs3+9k5my9Fd+eqNcl7dYQYJbT9gyC0HXK1QI4CAMNNlHNl4YXhF91ag==",
       "requires": {
-        "@sentry/types": "6.12.0",
+        "@sentry/types": "6.13.3",
         "tslib": "^1.9.3"
       }
     },

--- a/server/package.json
+++ b/server/package.json
@@ -31,8 +31,8 @@
     "lint": "eslint --ext .js,.ts ."
   },
   "dependencies": {
-    "@sentry/node": "^6.12.0",
-    "@sentry/tracing": "^6.12.0",
+    "@sentry/node": "^6.13.3",
+    "@sentry/tracing": "^6.13.3",
     "ajv": "^8.6.3",
     "ajv-formats": "^2.1.1",
     "ajv-keywords": "^5.0.0",


### PR DESCRIPTION
Supersedes #390, #391. Not sure why Snyk didn’t post PRs for all the `package.json` files where we use Sentry, but this takes care of all of them together, which is better than separate updates anyway.