### PR TITLE
Drop `express-validator` dependency

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -23,7 +23,6 @@
         "dotenv": "10.0.0",
         "errorhandler": "1.5.1",
         "express": "4.17.1",
-        "express-validator": "6.12.1",
         "hot-shots": "^8.5.2",
         "JSONStream": "^1.3.5",
         "knex": "^0.95.11",
@@ -4040,18 +4039,6 @@
       },
       "engines": {
         "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/express-validator": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.12.1.tgz",
-      "integrity": "sha512-olpTAv0ZB5IhNuDQ2rodKAuJsewgFgLIsczJMAWD6T0Yvxsa+j/Hk61jl8e26lAq+oJr6hUqPRjdlOBKhFlWeQ==",
-      "dependencies": {
-        "lodash": "^4.17.21",
-        "validator": "^13.5.2"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -8433,14 +8420,6 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
-    "node_modules/validator": {
-      "version": "13.5.2",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.5.2.tgz",
-      "integrity": "sha512-mD45p0rvHVBlY2Zuy3F3ESIe1h5X58GPfAtslBjY7EtTqGquZTj+VX/J4RnHWN8FKq0C9WRVt1oWAcytWRuYLQ==",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -12020,15 +11999,6 @@
         "vary": "~1.1.2"
       }
     },
-    "express-validator": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.12.1.tgz",
-      "integrity": "sha512-olpTAv0ZB5IhNuDQ2rodKAuJsewgFgLIsczJMAWD6T0Yvxsa+j/Hk61jl8e26lAq+oJr6hUqPRjdlOBKhFlWeQ==",
-      "requires": {
-        "lodash": "^4.17.21",
-        "validator": "^13.5.2"
-      }
-    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -15395,11 +15365,6 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "validator": {
-      "version": "13.5.2",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.5.2.tgz",
-      "integrity": "sha512-mD45p0rvHVBlY2Zuy3F3ESIe1h5X58GPfAtslBjY7EtTqGquZTj+VX/J4RnHWN8FKq0C9WRVt1oWAcytWRuYLQ=="
     },
     "vary": {
       "version": "1.1.2",

--- a/server/package.json
+++ b/server/package.json
@@ -45,7 +45,6 @@
     "dotenv": "10.0.0",
     "errorhandler": "1.5.1",
     "express": "4.17.1",
-    "express-validator": "6.12.1",
     "hot-shots": "^8.5.2",
     "JSONStream": "^1.3.5",
     "knex": "^0.95.11",


### PR DESCRIPTION
We don't actually use `express-validator` at all, so we shouldn't be listing it as a dependency (we use `ajv` for similar use cases).

This supersedes #399.