### PR TITLE
HOTFIX: some vaccinespotter formatters return null

### DIFF
--- a/loader/src/sources/vaccinespotter/index.js
+++ b/loader/src/sources/vaccinespotter/index.js
@@ -424,12 +424,14 @@ function formatStore(store) {
     result = formatter(store);
 
     // Add an un-padded version of any numeric IDs and remove duplicates.
-    result.external_ids = getUniqueExternalIds(
-      result.external_ids.flatMap((id) => {
-        const unpadded = [id[0], unpadNumber(id[1])];
-        return [id, unpadded];
-      })
-    );
+    if (result) {
+      result.external_ids = getUniqueExternalIds(
+        result.external_ids.flatMap((id) => {
+          const unpadded = [id[0], unpadNumber(id[1])];
+          return [id, unpadded];
+        })
+      );
+    }
   });
   return result;
 }


### PR DESCRIPTION
Somehow missed the fact that some formatters here return `null` in testing!