### PR TITLE
Add migrations for generic & unpadded Kroger IDs

### DIFF
--- a/server/migrations/20211024003952_add_generic_kroger_ids.js
+++ b/server/migrations/20211024003952_add_generic_kroger_ids.js
@@ -1,0 +1,44 @@
+/**
+ * Kroger uses 8 digit store numbers that are unique across all Kroger brands
+ * (Kroger, Ralph's, Fred Meyer, etc.) in most places. (In some places, we've
+ * seen them use 5-digit numbers that are unique to the brand, and appear to
+ * be the last 5 digits of the 8 digit number.)
+ *
+ * When this is the case, this migration adds the same value as a generic
+ * identifier in the "kroger" system so we can more easily match against it.
+ *
+ * For example, if we have:
+ *     { system: "kroger_ralphs", value: "70300757", provider_location_id: "x" }
+ * This will add another ID like:
+ *     { system: "kroger", value: "70300757", provider_location_id: "x" }
+ */
+
+exports.up = async function (knex) {
+  const krogerIds = await knex("external_ids")
+    .select("provider_location_id", "system", "value")
+    .where("system", "LIKE", "kroger_%")
+    .where((builder) =>
+      // In some cases, we have non-zero-padded IDs with only 7 characters.
+      builder
+        .where(knex.raw("character_length(value)"), 8)
+        .orWhere(knex.raw("character_length(value)"), 7)
+    );
+
+  const newIds = krogerIds.map((row) => ({
+    ...row,
+    system: "kroger",
+  }));
+
+  if (newIds.length) {
+    const result = await knex("external_ids")
+      .insert(newIds)
+      .onConflict(["provider_location_id", "system", "value"])
+      .ignore();
+
+    console.log("Added", result.rowCount, "`kroger` IDs");
+  }
+};
+
+exports.down = async function () {
+  console.log("add_generic_kroger_ids.js: No migrated rows removed.");
+};

--- a/server/migrations/20211025181938_kroger_unpadded_ext_ids.js
+++ b/server/migrations/20211025181938_kroger_unpadded_ext_ids.js
@@ -1,0 +1,32 @@
+/**
+ * Add new external IDs without zero-padding for all `kroger` and `kroger_*`
+ * ID systems. For example, if we have a location with the external ID:
+ *   { system: "kroger", value: "01234567", provider_location_id: "x" }
+ * Add another external ID like:
+ *   { system: "kroger", value: "1234567", provider_location_id: "x" }
+ */
+
+exports.up = async function (knex) {
+  const zeroPaddedRows = await knex("external_ids")
+    .select("provider_location_id", "system", "value")
+    .where("system", "LIKE", "kroger%")
+    .where("value", "~", String.raw`^0\d+$`);
+
+  const unpaddedRows = zeroPaddedRows.map((r) => ({
+    ...r,
+    value: r.value.replace(/^0+/, ""),
+  }));
+
+  if (unpaddedRows.length) {
+    const result = await knex("external_ids")
+      .insert(unpaddedRows)
+      .onConflict(["provider_location_id", "system", "value"])
+      .ignore();
+
+    console.log("Added", result.rowCount, "unpadded `kroger*` IDs");
+  }
+};
+
+exports.down = async function () {
+  console.log("kroger_unpadded_ext_ids.js: No migrated rows removed.");
+};


### PR DESCRIPTION
While working on #160, I discovered that we have lots of Kroger locations that have Kroger-wide identifiers but that only use a system scoped down to a particular brand, e.g. `kroger_smiths:<kroger-wide-id>`. This adds `kroger:<kroger-wide-id>` in those cases.

A second migration adds non-zero-padded versions of those IDs, much like we did for CVS before. This helps enable better matching of Kroger data from various sources, which all pad differently (e.g. VaccineSpotter vs. Kroger SMART SL vs. CDC).