### PR TITLE
Add migration to hide mass vax sites in CO

### DIFF
--- a/server/migrations/20211027224234_hide_centura_and_ball_arena_locations.js
+++ b/server/migrations/20211027224234_hide_centura_and_ball_arena_locations.js
@@ -12,7 +12,7 @@ exports.up = async function (knex) {
   console.log("Updated", result, "locations");
 };
 
-exports.down = async function (knex) {
+exports.down = async function () {
   console.log(
     "hide_centura_and_ball_arena_locations.js: No migrated rows changed."
   );


### PR DESCRIPTION
This simply hides some sites that we should have long since hidden, since they no longer exist. Closes #418.