### PR TITLE
Re-do the migration to hide closed CO vax sites

### DIFF
--- a/server/migrations/20211028020858_hide_centura_and_ball_arena_v2.js
+++ b/server/migrations/20211028020858_hide_centura_and_ball_arena_v2.js
@@ -1,0 +1,17 @@
+/**
+ * The previous migration was broken; this is the same thing but done correctly.
+ */
+
+exports.up = async function (knex) {
+  const result = await knex("provider_locations")
+    .where("provider", "in", ["centura_driveup_event", "denver_ball_arena"])
+    .update({ is_public: false });
+
+  console.log("Updated", result, "locations");
+};
+
+exports.down = async function () {
+  console.log(
+    "hide_centura_and_ball_arena_locations.js: No migrated rows changed."
+  );
+};


### PR DESCRIPTION
Well, I feel dumb. I could have sworn I tested the previous migration, but I don't know what I was looking at since it clearly did not work. It was missing an "IN" operator. 🤦 