### PR TITLE
Always update a location's `external_ids`

### DIFF
--- a/server/src/api/edge.ts
+++ b/server/src/api/edge.ts
@@ -264,6 +264,10 @@ export const update = async (req: AppRequest, res: Response): Promise<any> => {
       await db.updateLocation(location, data);
       result.location.action = "updated";
     }
+  } else if (data.external_ids?.length) {
+    // Otherwise just update the external IDs. This ensures we track every
+    // relevant external ID we've seen for a location.
+    await db.addExternalIds(location.id, data.external_ids);
   }
 
   if (data.availability) {

--- a/server/test/api.edge.test.ts
+++ b/server/test/api.edge.test.ts
@@ -481,6 +481,25 @@ describe("POST /api/edge/update", () => {
     ]);
   });
 
+  it("merges new values into external_ids even if `update_location` is not set", async () => {
+    const location = await createLocation(TestLocation);
+
+    const response = await context.client.post("api/edge/update", {
+      headers,
+      json: {
+        id: location.id,
+        external_ids: [["testid", "this is a test"]],
+      },
+    });
+    expect(response.statusCode).toBe(200);
+
+    const result = await getLocationById(location.id);
+    expect(result.external_ids).toEqual([
+      ...TestLocation.external_ids,
+      ["testid", "this is a test"],
+    ]);
+  });
+
   it("supports the old external_ids input format", async () => {
     const location = await createLocation(TestLocation);
 


### PR DESCRIPTION
Even if we're not updating the other properties of a location (name, address, etc.), we should always add any new external IDs we see for a location. This is a more reasonable thing than it used to be, since you can now only add to the list for a given location, and not change existing entries.

As we add and clean up a bunch of sources from VaccineSpotter, I’m a little worried we aren’t always capturing all the new IDs we’ve seen, and aren’t able to de-duplicate as effectively as we might otherwise (if one source silently fails to add a new ID, and another source uses it, we could wind up creating a new location record). A bunch of sources already set `update_location=true` ([for example, CDC](https://github.com/usdigitalresponse/univaf/blob/6eade8ea037b32bbecea074fe9d1d0eb2387859f/loader/src/sources/cdc/api.js#L332)), so this won’t impact all sources.

If something goes horribly awry, we can roll back this change and revert to the most recent DB snapshot. I don’t think it’s too likely we’ll need that, though.