### PR TITLE
Add schemas for use in tests

### DIFF
--- a/loader/package-lock.json
+++ b/loader/package-lock.json
@@ -19,6 +19,9 @@
         "yargs": "^17.2.1"
       },
       "devDependencies": {
+        "ajv": "^8.6.3",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.0.0",
         "eslint": "^7.32.0",
         "jest": "^27.2.4",
         "nock": "^13.1.0",
@@ -1851,6 +1854,28 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
@@ -2514,18 +2539,48 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "8.6.3",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
+      "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
+      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
         "uri-js": "^4.2.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-keywords": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.0.0.tgz",
+      "integrity": "sha512-ULd1QMjRoH6JDNUQIfDLrlE+OgZlFaxyYCjzt58uNuUQtKXt8/U+vK/8Ql0gyn/C5mqZzUWtKMqr/4YquvTrWA==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
       }
     },
     "node_modules/ansi": {
@@ -4208,6 +4263,22 @@
         "node": ">=10"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/eslint/node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -4219,6 +4290,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "node_modules/espree": {
       "version": "7.3.1",
@@ -4797,6 +4874,28 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/har-validator/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/har-validator/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "peer": true
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -6090,9 +6189,10 @@
       "peer": true
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -7541,28 +7641,6 @@
       "engines": {
         "node": ">=10.0.0"
       }
-    },
-    "node_modules/table/node_modules/ajv": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.1.0.tgz",
-      "integrity": "sha512-B/Sk2Ix7A36fs/ZkuGLIR86EdjbgR6fsAcbx9lOP/QBSXujDNbVmIS/U4Itz5k8fPFDeVZl/zQ/gJW4Jrq6XjQ==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/table/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
     },
     "node_modules/tar": {
       "version": "6.1.11",
@@ -9663,6 +9741,26 @@
         "js-yaml": "^3.13.1",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        }
       }
     },
     "@humanwhocodes/config-array": {
@@ -10234,14 +10332,33 @@
       }
     },
     "ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "8.6.3",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
+      "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
         "uri-js": "^4.2.2"
+      }
+    },
+    "ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^8.0.0"
+      }
+    },
+    "ajv-keywords": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.0.0.tgz",
+      "integrity": "sha512-ULd1QMjRoH6JDNUQIfDLrlE+OgZlFaxyYCjzt58uNuUQtKXt8/U+vK/8Ql0gyn/C5mqZzUWtKMqr/4YquvTrWA==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.3"
       }
     },
     "ansi": {
@@ -11517,10 +11634,28 @@
         "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
         "escape-string-regexp": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
           "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
           "dev": true
         }
       }
@@ -11988,6 +12123,26 @@
       "requires": {
         "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "peer": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "peer": true
+        }
       }
     },
     "has": {
@@ -12976,9 +13131,10 @@
       "peer": true
     },
     "json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -14097,26 +14253,6 @@
         "lodash.truncate": "^4.4.2",
         "slice-ansi": "^4.0.0",
         "string-width": "^4.2.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.1.0.tgz",
-          "integrity": "sha512-B/Sk2Ix7A36fs/ZkuGLIR86EdjbgR6fsAcbx9lOP/QBSXujDNbVmIS/U4Itz5k8fPFDeVZl/zQ/gJW4Jrq6XjQ==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-          "dev": true
-        }
       }
     },
     "tar": {

--- a/loader/package.json
+++ b/loader/package.json
@@ -18,6 +18,9 @@
   },
   "homepage": "https://getmyvax.org/",
   "devDependencies": {
+    "ajv": "^8.6.3",
+    "ajv-formats": "^2.1.1",
+    "ajv-keywords": "^5.0.0",
     "eslint": "^7.32.0",
     "jest": "^27.2.4",
     "nock": "^13.1.0",

--- a/loader/src/sources/albertsons/index.js
+++ b/loader/src/sources/albertsons/index.js
@@ -175,10 +175,12 @@ async function fetchRawData() {
     timeout: 30000,
   });
 
+  const lastModified = response.headers["last-modified"];
+
   return {
-    validAt: DateTime.fromHTTP(response.headers["last-modified"], {
-      zone: "utc",
-    }).toISO(),
+    validAt: lastModified
+      ? DateTime.fromHTTP(lastModified, { zone: "utc" }).toISO()
+      : undefined,
     data: response.body,
   };
 }

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -156,10 +156,15 @@ function formatStore(storeItems) {
     };
 
     if (base.longitude && base.latitude) {
-      result.position = {
-        longitude: base.longitude,
-        latitude: base.latitude,
+      const position = {
+        longitude: Number(base.longitude),
+        latitude: Number(base.latitude),
       };
+      if (isNaN(position.longitude) || isNaN(position.longitude)) {
+        error("longitude and latitude are not numbers");
+      } else {
+        result.position = position;
+      }
     }
   });
   return result;
@@ -298,11 +303,12 @@ function getProductType(product) {
  * @returns {Array<string>}
  */
 function formatProductTypes(products) {
-  return [
+  const result = [
     ...new Set(
       products.filter((p) => isInStock(p) !== Available.no).map(getProductType)
     ),
   ];
+  return result.length ? result : undefined;
 }
 
 async function checkAvailability(handler, options) {

--- a/loader/src/sources/riteaid/api.js
+++ b/loader/src/sources/riteaid/api.js
@@ -94,10 +94,9 @@ function formatStore(provider) {
   }
 
   return {
-    id: `rite_aid:${provider.id}`,
     // All API locations are named "Rite Aid", so add the store number.
     name: `Rite Aid #${provider.id}`,
-    external_ids: { rite_aid: provider.id.toString() },
+    external_ids: [["rite_aid", provider.id.toString()]],
     provider: "rite_aid",
     location_type: LocationType.pharmacy,
 
@@ -106,7 +105,6 @@ function formatStore(provider) {
     state: provider.location.state,
     postal_code: provider.location.zipcode,
     county,
-    position: null,
     booking_phone: provider.contact.booking_phone,
     booking_url: provider.contact.booking_url,
     info_phone: provider.contact.info_phone,

--- a/loader/src/sources/wa-doh.js
+++ b/loader/src/sources/wa-doh.js
@@ -187,7 +187,7 @@ function formatLocation(data) {
   );
   if (!state) console.error(`WA DoH: Unknown state "${data.state}"`);
 
-  const external_ids = { wa_doh: data.locationId };
+  const external_ids = [["wa_doh", data.locationId]];
 
   // The API has IDs like `costco-293`, but the number is not a Costco ID or
   // store number (it appears to be an ID in appointment-plus). However,
@@ -195,7 +195,7 @@ function formatLocation(data) {
   if (provider === "costco") {
     const storeEmailMatch = data.email.match(/^w0*(\d+)phm@/i);
     if (storeEmailMatch) {
-      external_ids.costco = storeEmailMatch[1];
+      external_ids.push(["costco", storeEmailMatch[1]]);
     } else {
       console.error(
         `WA DoH: Unable to determine Costco store number for "${data.locationid}"`
@@ -205,7 +205,7 @@ function formatLocation(data) {
 
   if (data.schedulingLink.toLowerCase().includes("appointment-plus")) {
     const idMatch = data.locationId.match(/-0*(\d+)$/);
-    if (idMatch) external_ids.appointment_plus = idMatch[1];
+    if (idMatch) external_ids.push(["appointment_plus", idMatch[1]]);
   }
 
   const metaFields = [
@@ -249,7 +249,6 @@ function formatLocation(data) {
 
   const checkTime = new Date().toISOString();
   return {
-    id: data.locationId,
     name: data.locationName,
     external_ids,
     provider,

--- a/loader/test/albertsons.test.js
+++ b/loader/test/albertsons.test.js
@@ -2,6 +2,7 @@ const nock = require("nock");
 const { API_URL, checkAvailability } = require("../src/sources/albertsons");
 const { Available } = require("../src/model");
 const { expectDatetimeString, splitHostAndPath } = require("./support");
+const { locationSchema } = require("./support/schemas");
 
 const [API_URL_BASE, API_URL_PATH] = splitHostAndPath(API_URL);
 
@@ -42,6 +43,7 @@ describe("Albertsons", () => {
       );
 
     const result = await checkAvailability(() => {}, { states: "AK" });
+    expect(result).toContainItemsMatchingSchema(locationSchema);
     expect(result).toEqual([
       {
         name: "Safeway 3410",
@@ -128,6 +130,7 @@ describe("Albertsons", () => {
     const result = await checkAvailability(() => {}, { states: "AK" });
     expect(result[0]).toHaveProperty("name", "Safeway 3410");
     expect(result[0]).toHaveProperty("address_lines", ["30 College Rd"]);
+    expect(result).toContainItemsMatchingSchema(locationSchema);
   });
 
   it("handles unexpected availability strings", async () => {
@@ -148,6 +151,7 @@ describe("Albertsons", () => {
       ]);
 
     const result = await checkAvailability(() => {}, { states: "AK" });
+    expect(result).toContainItemsMatchingSchema(locationSchema);
     expect(result[0]).toHaveProperty(
       "availability.available",
       Available.unknown
@@ -171,6 +175,7 @@ describe("Albertsons", () => {
       ]);
 
     const result = await checkAvailability(() => {}, { states: "AK" });
+    expect(result).toContainItemsMatchingSchema(locationSchema);
     expect(result[0].availability.products).toBe(undefined);
   });
 
@@ -192,6 +197,7 @@ describe("Albertsons", () => {
       ]);
 
     const result = await checkAvailability(() => {}, { states: "AK" });
+    expect(result).toContainItemsMatchingSchema(locationSchema);
     expect(result[0]).toHaveProperty("availability.products", ["pfizer"]);
   });
 

--- a/loader/test/cdc.api.test.js
+++ b/loader/test/cdc.api.test.js
@@ -7,6 +7,7 @@ const {
   checkAvailability,
 } = require("../src/sources/cdc/api");
 const { Available } = require("../src/model");
+const { locationSchema } = require("./support/schemas");
 
 describe("CDC Open Data API", () => {
   afterEach(() => {
@@ -60,6 +61,7 @@ describe("CDC Open Data API", () => {
       "2.availability.available",
       Available.unknown
     );
+    expect(locations).toContainItemsMatchingSchema(locationSchema);
   });
 
   it("reports unknown availability if `in_stock` and `supply_level` conflict", async () => {
@@ -91,5 +93,6 @@ describe("CDC Open Data API", () => {
       "1.availability.available",
       Available.unknown
     );
+    expect(locations).toContainItemsMatchingSchema(locationSchema);
   });
 });

--- a/loader/test/cvs.smart.test.js
+++ b/loader/test/cvs.smart.test.js
@@ -8,6 +8,7 @@ const {
   splitHostAndPath,
   toNdJson,
 } = require("./support");
+const { locationSchema } = require("./support/schemas");
 const fixtures = require("./fixtures/cvs.smart.fixtures");
 const { Available } = require("../src/model");
 
@@ -67,6 +68,8 @@ describe("CVS SMART Scheduling Links API", () => {
     // Expect the `checked_at` time to be recent.
     const checkedDate = new Date(result[0].availability.checked_at);
     expect(Date.now() - checkedDate).toBeLessThan(1000);
+
+    expect(result).toContainItemsMatchingSchema(locationSchema);
   });
 
   it("should set availability to NO if no slots are free", async () => {
@@ -88,6 +91,7 @@ describe("CVS SMART Scheduling Links API", () => {
 
     const result = await checkAvailability(() => null, { states: "VA" });
     expect(result).toHaveProperty("0.availability.available", Available.no);
+    expect(result).toContainItemsMatchingSchema(locationSchema);
   });
 
   it("should not return results outside the requested states", async () => {

--- a/loader/test/kroger.smart.test.js
+++ b/loader/test/kroger.smart.test.js
@@ -5,6 +5,7 @@ const {
   splitHostAndPath,
   toNdJson,
 } = require("./support");
+const { locationSchema } = require("./support/schemas");
 const fixtures = require("./fixtures/kroger.smart.fixtures");
 const { Available } = require("../src/model");
 
@@ -74,6 +75,8 @@ describe("Kroger SMART Scheduling Links API", () => {
     // Expect the `checked_at` time to be recent.
     const checkedDate = new Date(result[0].availability.checked_at);
     expect(Date.now() - checkedDate).toBeLessThan(1000);
+
+    expect(result).toContainItemsMatchingSchema(locationSchema);
   });
 
   it("should set availability to NO if no slots are free", async () => {
@@ -95,6 +98,7 @@ describe("Kroger SMART Scheduling Links API", () => {
 
     const result = await checkAvailability(() => null, { states: "AK" });
     expect(result).toHaveProperty("0.availability.available", Available.no);
+    expect(result).toContainItemsMatchingSchema(locationSchema);
   });
 
   it("should not return results outside the requested states", async () => {

--- a/loader/test/prepmod.test.js
+++ b/loader/test/prepmod.test.js
@@ -1,6 +1,7 @@
 const nock = require("nock");
 const { checkAvailability } = require("../src/sources/prepmod");
 const { expectDatetimeString } = require("./support");
+const { locationSchema } = require("./support/schemas");
 
 describe("PrepMod API", () => {
   jest.setTimeout(60000);
@@ -573,5 +574,6 @@ describe("PrepMod API", () => {
         },
       },
     ]);
+    expect(result).toContainItemsMatchingSchema(locationSchema);
   });
 });

--- a/loader/test/riteaid.api.test.js
+++ b/loader/test/riteaid.api.test.js
@@ -1,5 +1,6 @@
 const nock = require("nock");
 const { checkAvailability, queryState } = require("../src/sources/riteaid/api");
+const { locationSchema } = require("./support/schemas");
 
 describe("Rite Aid Source", () => {
   const API_URL = "https://api.riteaid.com/test";
@@ -35,10 +36,7 @@ describe("Rite Aid Source", () => {
     expect(locations.length).toBe(108);
 
     expect(locations[0]).toStrictEqual({
-      id: "rite_aid:116",
-      external_ids: {
-        rite_aid: "116",
-      },
+      external_ids: [["rite_aid", "116"]],
       location_type: "PHARMACY",
       name: "Rite Aid #116",
       provider: "rite_aid",
@@ -47,7 +45,6 @@ describe("Rite Aid Source", () => {
       state: "NJ",
       postal_code: "08332-3762",
       county: "Cumberland",
-      position: null,
       info_phone: "(856) 825-7742",
       info_url: "https://www.riteaid.com/covid-19",
       booking_phone: "(856) 825-7742",
@@ -176,9 +173,7 @@ describe("Rite Aid Source", () => {
       },
     });
 
-    for (const location of locations) {
-      expect(location.availability.checked_at).not.toBeUndefined();
-    }
+    expect(locations).toContainItemsMatchingSchema(locationSchema);
   });
 
   it("does not attempt to load states without Rite Aid stores", async () => {

--- a/loader/test/support/matchers.js
+++ b/loader/test/support/matchers.js
@@ -23,7 +23,10 @@ function toMatchSchema(received, schema) {
     pass,
     message() {
       return (validator.errors || [])
-        .map((error) => `${error.instancePath} ${error.message}`)
+        .map((error) => {
+          const value = JSON.stringify(error.data) || "undefined";
+          return `${error.instancePath} ${error.message} (value: \`${value}\`)`;
+        })
         .join("\n");
     },
   };

--- a/loader/test/support/matchers.js
+++ b/loader/test/support/matchers.js
@@ -1,0 +1,45 @@
+const Ajv = require("ajv");
+const addFormats = require("ajv-formats");
+const addInstanceof = require("ajv-keywords/dist/keywords/instanceof");
+
+const ajv = new Ajv({ allErrors: true, verbose: true });
+addFormats(ajv);
+addInstanceof(ajv);
+const compiledSchemas = new Map();
+
+/**
+ * Expect that an object matches a given JSON Schema.
+ */
+function toMatchSchema(received, schema) {
+  // Compilation is expensive, so cache validator functions.
+  let validator = compiledSchemas.get(schema);
+  if (!validator) {
+    validator = ajv.compile(schema);
+    compiledSchemas.set(schema, validator);
+  }
+
+  const pass = validator(received);
+  return {
+    pass,
+    message() {
+      return (validator.errors || [])
+        .map((error) => `${error.instancePath} ${error.message}`)
+        .join("\n");
+    },
+  };
+}
+
+/**
+ * Expect that every item in an array matches a given JSON Schema.
+ */
+function toContainItemsMatchingSchema(received, schema) {
+  return toMatchSchema(received, {
+    type: "array",
+    items: schema,
+  });
+}
+
+module.exports = {
+  toMatchSchema,
+  toContainItemsMatchingSchema,
+};

--- a/loader/test/support/schemas.js
+++ b/loader/test/support/schemas.js
@@ -28,6 +28,7 @@ const slotSchema = {
     unavailable_count: { type: "integer", minimum: 0 },
     products: productsSchema,
     dose: { type: "string" },
+    booking_url: { type: "string", format: "uri" },
   },
   required: ["start"],
   additionalProperties: false,
@@ -61,9 +62,19 @@ const availabilitySchema = {
       uniqueItems: true,
       minItems: 1,
     },
+    capacity: { type: "array", items: capacitySchema },
+    slots: { type: "array", items: slotSchema },
     is_public: { type: "boolean" },
+    // checked_at should *always* be a specific time, but valid_at can be a
+    // less-precise date, because the source data is sometimes imprecise.
+    // (The server will process this into 00:00:00Z on that date.)
     checked_at: { type: "string", format: "date-time" },
-    valid_at: { type: "string", format: "date-time" },
+    valid_at: {
+      oneOf: [
+        { type: "string", format: "date-time" },
+        { type: "string", format: "date" },
+      ],
+    },
   },
   required: ["source", "checked_at", "available"],
   additionalProperties: false,

--- a/loader/test/support/schemas.js
+++ b/loader/test/support/schemas.js
@@ -1,0 +1,122 @@
+const { Available, VaccineProduct, LocationType } = require("../../src/model");
+
+function schemaFromEnum(enumObject) {
+  return { enum: Object.values(enumObject) };
+}
+
+const locationTypeSchema = schemaFromEnum(LocationType);
+
+const productsSchema = {
+  type: "array",
+  minItems: 1,
+  uniqueItems: true,
+  items: schemaFromEnum(VaccineProduct),
+};
+
+const slotSchema = {
+  type: "object",
+  properties: {
+    start: {
+      oneOf: [{ type: "string", format: "date-time" }, { instanceof: "Date" }],
+    },
+    end: {
+      oneOf: [{ type: "string", format: "date-time" }, { instanceof: "Date" }],
+    },
+    // Available cannot be unknown in a slot.
+    available: { enum: [Available.yes, Available.no] },
+    available_count: { type: "integer", minimum: 0 },
+    unavailable_count: { type: "integer", minimum: 0 },
+    products: productsSchema,
+    dose: { type: "string" },
+  },
+  required: ["start"],
+  additionalProperties: false,
+};
+
+const capacitySchema = {
+  type: "object",
+  properties: {
+    date: { type: "string", format: "date" },
+    // Available cannot be unknown in a capacity entry.
+    available: { enum: [Available.yes, Available.no] },
+    available_count: { type: "integer", minimum: 0 },
+    unavailable_count: { type: "integer", minimum: 0 },
+    products: productsSchema,
+    dose: { type: "string" },
+  },
+  required: ["date"],
+  additionalProperties: false,
+};
+
+const availabilitySchema = {
+  type: "object",
+  properties: {
+    source: { type: "string" },
+    available: schemaFromEnum(Available),
+    available_count: { type: "integer", minimum: 0 },
+    products: productsSchema,
+    doses: {
+      type: "array",
+      items: { type: "string" },
+      uniqueItems: true,
+      minItems: 1,
+    },
+    is_public: { type: "boolean" },
+    checked_at: { type: "string", format: "date-time" },
+    valid_at: { type: "string", format: "date-time" },
+  },
+  required: ["source", "checked_at", "available"],
+  additionalProperties: false,
+};
+
+const locationSchema = {
+  type: "object",
+  properties: {
+    id: {
+      type: "string",
+      format: "uuid",
+    },
+    external_ids: {
+      type: "array",
+      items: {
+        type: "array",
+        items: { type: "string" },
+      },
+    },
+    provider: { type: "string" },
+    location_type: locationTypeSchema,
+    name: { type: "string" },
+    address_lines: { type: "array", items: { type: "string" } },
+    city: { type: "string" },
+    state: { type: "string" },
+    postal_code: { type: "string" },
+    county: { type: "string" },
+    position: {
+      type: "object",
+      properties: {
+        longitude: { type: "number", format: "float" },
+        latitude: { type: "number", format: "float" },
+      },
+    },
+    info_phone: { type: "string" },
+    info_url: { type: "string", format: "uri" },
+    booking_phone: { type: "string" },
+    booking_url: { type: "string", format: "uri" },
+    description: { type: "string" },
+    requires_waitlist: { type: "boolean" },
+    meta: { type: "object" },
+    is_public: { type: "boolean" },
+    availability: availabilitySchema,
+  },
+  required: ["name", "provider", "address_lines", "city", "state"],
+  additionalProperties: false,
+};
+
+module.exports = {
+  locationSchema,
+  availabilitySchema,
+  capacitySchema,
+  slotSchema,
+  locationTypeSchema,
+  productsSchema,
+};

--- a/loader/test/support/setup.js
+++ b/loader/test/support/setup.js
@@ -1,3 +1,5 @@
 const nockBackPlugin = require("./nock-back-plugin");
+const customMatchers = require("./matchers");
 
 nockBackPlugin.setupJestNockBack();
+expect.extend(customMatchers);

--- a/loader/test/wa-doh.test.js
+++ b/loader/test/wa-doh.test.js
@@ -5,6 +5,7 @@ const {
   WaDohApiError,
 } = require("../src/sources/wa-doh");
 const { expectDatetimeString, splitHostAndPath } = require("./support");
+const { locationSchema } = require("./support/schemas");
 
 const [API_URL_BASE, API_URL_PATH] = splitHostAndPath(API_URL);
 
@@ -31,12 +32,11 @@ describe("Washington DoH API", () => {
         city: "Caguas",
         county: undefined,
         description: "null",
-        external_ids: {
-          appointment_plus: "625",
-          costco: "365",
-          wa_doh: "costco-625",
-        },
-        id: "costco-625",
+        external_ids: [
+          ["wa_doh", "costco-625"],
+          ["costco", "365"],
+          ["appointment_plus", "625"],
+        ],
         info_url: undefined,
         location_type: "PHARMACY",
         meta: {},
@@ -64,12 +64,11 @@ describe("Washington DoH API", () => {
         city: "Bayamon",
         county: undefined,
         description: "null",
-        external_ids: {
-          appointment_plus: "621",
-          costco: "363",
-          wa_doh: "costco-621",
-        },
-        id: "costco-621",
+        external_ids: [
+          ["wa_doh", "costco-621"],
+          ["costco", "363"],
+          ["appointment_plus", "621"],
+        ],
         info_url: undefined,
         location_type: "PHARMACY",
         meta: {},
@@ -83,6 +82,7 @@ describe("Washington DoH API", () => {
         state: "PR",
       },
     ]);
+    expect(result).toContainItemsMatchingSchema(locationSchema);
   });
 
   it("should throw WaDohApiError with detailed error info", async () => {

--- a/loader/test/walgreens.test.js
+++ b/loader/test/walgreens.test.js
@@ -5,6 +5,7 @@ const {
   splitHostAndPath,
   toNdJson,
 } = require("./support");
+const { locationSchema } = require("./support/schemas");
 const fixtures = require("./fixtures/walgreens.smart.fixtures");
 const { Available } = require("../src/model");
 
@@ -65,6 +66,8 @@ describe("Walgreens SMART Scheduling Links API", () => {
     // Expect the `checked_at` time to be recent.
     const checkedDate = new Date(result[0].availability.checked_at);
     expect(Date.now() - checkedDate).toBeLessThan(1000);
+
+    expect(result).toContainItemsMatchingSchema(locationSchema);
   });
 
   it("should set availability to NO if no slots are free", async () => {
@@ -86,6 +89,7 @@ describe("Walgreens SMART Scheduling Links API", () => {
 
     const result = await checkAvailability(() => null, { states: "AK" });
     expect(result).toHaveProperty("0.availability.available", Available.no);
+    expect(result).toContainItemsMatchingSchema(locationSchema);
   });
 
   it("should set availability to NO if there are no slots", async () => {
@@ -100,6 +104,7 @@ describe("Walgreens SMART Scheduling Links API", () => {
 
     const result = await checkAvailability(() => null, { states: "AK" });
     expect(result).toHaveProperty("0.availability.available", Available.no);
+    expect(result).toContainItemsMatchingSchema(locationSchema);
   });
 
   it("should not return results outside the requested states", async () => {


### PR DESCRIPTION
This adds an `expect(x).toMatchSchema(someJsonSchemaDefinition)` matcher to Jest in the loader project, and should be helpful in writing better tests.

There is a very nice [`jest-json-schema` package on NPM](https://www.npmjs.com/package/jest-json-schema), but it is [stuck on a several-major-releases-old version of AJV](https://github.com/americanexpress/jest-json-schema/pull/26). I wanted our schemas in the loader and server to be similar, and not have some weird edge cases because of AJV versioning problems, so I wound up just implementing something custom. At least it’s not super complicated, but still makes me sad. :(

The schemas are not the same as the server because:
- They needed to be more strict. The server ones are designed to help massage acceptable data into correct data, and here, we want to be really narrow about what we do.
- The server schemas *manipulate* the data (again, aiding in cleaning up and reshaping roughly correct data), which is not what we want here.

Ideally, the server would somehow build on/extend/inherit from these more strict schemas, but that felt like a lot more work to do and other things (https://github.com/usdigitalresponse/univaf/milestone/5) are much higher priority at the moment.

**TO-DO:** should probably actually use these!