### PR TITLE
Don't use `npi_usa` external IDs for lookups

### DIFF
--- a/loader/src/sources/walgreens.js
+++ b/loader/src/sources/walgreens.js
@@ -49,6 +49,11 @@ function formatLocation(locationInfo) {
       return [system, value];
     },
   });
+  const npiNumber = external_ids.find((id) => id[0] === "npi_usa")?.[1];
+  let meta;
+  if (npiNumber) {
+    meta = { npi_usa: npiNumber };
+  }
 
   // All Walgreens slots for a location share an identical booking URL/phone,
   // so just grab one from the first slot in a location.
@@ -95,6 +100,7 @@ function formatLocation(locationInfo) {
     info_url,
     booking_phone,
     booking_url,
+    meta,
 
     availability: {
       source: "univaf-walgreens-smart",

--- a/server/public/docs/openapi.yaml
+++ b/server/public/docs/openapi.yaml
@@ -109,6 +109,44 @@ info:
     As of late summer 2021, demand is lower than supply at *most* locations, so
     having vaccines in stock more often indicates appointments are available.
     This is still not *always* true, though.
+
+
+    ## External IDs
+
+    Every location has a list of “external IDs” in the `external_ids` property.
+    These represent ways that other systems might identify the same location
+    (for example, the store number for a CVS pharmacy, or the ID of the same
+    site in [vaccines.gov](https://vaccines.gov)). An external ID is an array,
+    where the first element names system (e.g. `cvs`) and the second is the ID
+    in that system. For example:
+
+    ```js
+    [
+      // CVS Store #10047
+      ["cvs", "10047"],
+      // ID on the Vaccines.gov website
+      ["vaccines_gov", "56789b30-ed05-4b28-b864-0b21b048a341"]
+    ]
+    ```
+
+    In general, these external IDs are unique to a location (that is, no two
+    locations in this API should ever have an identical `[system, id]`
+    combination).
+
+    **However, the `vtrcks` and `npi_usa` systems are not
+    unique!** They exist in `external_ids` for historical reasons (we thought
+    these were unique early on, and later learned this was not so). You should
+    not assume a given `vtrcks` or `npi_usa` ID represents only one location.
+
+    You can also look up locations by their external ID. The `id` path parameter
+    can be an external ID in the form `system:id` instead of the actual location
+    ID. For example, these paths all get the same location:
+
+    ```txt
+    /api/edge/locations/215f56ac-8bda-4ae9-ad5e-a567ebe8c1bb
+    /api/edge/locations/cvs:10047
+    /api/edge/locations/vaccines_gov:56789b30-ed05-4b28-b864-0b21b048a341
+    ```
   contact:
     email: univaf@usdigitalresponse.org
   license:

--- a/server/scripts/remove-duplicate-locations.js
+++ b/server/scripts/remove-duplicate-locations.js
@@ -26,6 +26,7 @@ function groupByExternalId(locations, systems = null, unpadIds = false) {
     for (const { system, value } of location.external_ids) {
       // Skip not-quite-unique systems
       if (system === "vtrcks") continue;
+      if (system === "npi_usa") continue;
       // Skip internal identifiers
       if (system === "univaf_v0") continue;
       if (system === "univaf_v1") continue;

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -381,7 +381,7 @@ export async function getLocationByExternalIds(
   // (It's a bit of a historical mistake that these are here instead of in
   // the `meta` field.)
   const queryableIds = externalIds.filter(([system, _]) => {
-    return system !== "vtrcks";
+    return system !== "vtrcks" && system !== "npi_usa";
   });
 
   // Bail out early if there was nothing to actually query on.

--- a/server/test/api.edge.test.ts
+++ b/server/test/api.edge.test.ts
@@ -444,7 +444,7 @@ describe("POST /api/edge/update", () => {
   });
 
   it("should not update based on vtrcks PINs", async () => {
-    await createLocation(TestLocation);
+    const location = await createLocation(TestLocation);
     const newName = "New Name";
 
     const res = await context.client.post("api/edge/update?update_location=1", {
@@ -457,6 +457,25 @@ describe("POST /api/edge/update", () => {
       },
     });
     expect(res.statusCode).toBe(201);
+    expect(await getLocationById(location.id)).not.toEqual(newName);
+  });
+
+  it("should not update based on NPI numbers", async () => {
+    const location = await createLocation({
+      ...TestLocation,
+      external_ids: [...TestLocation.external_ids, ["npi_usa", "test"]],
+    });
+    const newName = "New Name";
+
+    const res = await context.client.post("api/edge/update?update_location=1", {
+      headers,
+      json: {
+        external_ids: [["npi_usa", "test"]],
+        name: newName,
+      },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(await getLocationById(location.id)).not.toEqual(newName);
   });
 
   it("merges new values into the existing list of external_ids", async () => {

--- a/server/test/scripts.remove-duplicate-locations.test.ts
+++ b/server/test/scripts.remove-duplicate-locations.test.ts
@@ -184,6 +184,30 @@ describe("groupDuplicateLocations", () => {
     expect(idGroups).toEqual([]);
   });
 
+  it("should not match on npi_usa", async () => {
+    const a = {
+      ...TestLocation,
+      id: "a",
+      external_ids: [
+        { system: "npi_usa", value: "x" },
+        { system: "other_id", value: "y" },
+      ],
+    };
+    const b = {
+      ...TestLocation,
+      id: "b",
+      external_ids: [
+        { system: "npi_usa", value: "x" },
+        { system: "other_id", value: "z" },
+      ],
+    };
+
+    const groups = groupDuplicateLocations([a, b], null, true);
+    // Replace objects with IDs for easier comparisons.
+    const idGroups = groups.map((group) => [...group].map((x) => x.id));
+    expect(idGroups).toEqual([]);
+  });
+
   it("should only match IDs by the given systems", async () => {
     const a = {
       ...TestLocation,


### PR DESCRIPTION
It turns out DHHS NPI numbers are not unique to a physical location. It feels like I should have expected them to be like VTrckS PINs in this way, but I didn't. 🙄