### PR TITLE
Support Pfizer Pediatric Vaccines

### DIFF
--- a/loader/src/model.js
+++ b/loader/src/model.js
@@ -29,9 +29,14 @@ const LocationType = {
  * @enum {string}
  */
 const VaccineProduct = {
-  pfizer: "pfizer",
-  moderna: "moderna",
+  astraZeneca: "astra_zeneca",
   janssen: "jj",
+  moderna: "moderna",
+  novavax: "novavax",
+  pfizer: "pfizer",
+  pfizerAge5_11: "pfizer_age_5_11",
+  pfizerAge2_4: "pfizer_age_2_4",
+  pfizerPediatric: "pfizer_pediatric",
 };
 
 module.exports = {

--- a/loader/src/model.js
+++ b/loader/src/model.js
@@ -36,7 +36,6 @@ const VaccineProduct = {
   pfizer: "pfizer",
   pfizerAge5_11: "pfizer_age_5_11",
   pfizerAge2_4: "pfizer_age_2_4",
-  pfizerPediatric: "pfizer_pediatric",
 };
 
 module.exports = {

--- a/loader/src/smart-scheduling-links.js
+++ b/loader/src/smart-scheduling-links.js
@@ -40,6 +40,8 @@ const PRODUCTS_BY_CVX_CODE = {
   207: "moderna",
   211: "novavax",
   208: "pfizer",
+  218: "pfizer_age_5_11",
+  219: "pfizer_age_2_4",
   212: "jj",
 };
 

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -26,7 +26,7 @@
 
 const Sentry = require("@sentry/node");
 
-const { Available } = require("../../model");
+const { Available, VaccineProduct } = require("../../model");
 const { httpClient, oneLine, titleCase } = require("../../utils");
 
 const API_HOST = "https://data.cdc.gov";
@@ -259,19 +259,32 @@ function formatAvailable(products) {
 const ndcLookup = {
   // from https://www.cdc.gov/vaccines/programs/iis/COVID-19-related-codes.html
   // and https://www2a.cdc.gov/vaccines/iis/iisstandards/vaccines.asp?rpt=ndc
-  [normalizeNdc("00310-1222-10")]: "astra_zeneca", //use
-  [normalizeNdc("00310-1222-15")]: "astra_zeneca", //sale
-  [normalizeNdc("59267-1000-01")]: "pfizer", //use
-  [normalizeNdc("59267-1000-02")]: "pfizer", //sale
-  [normalizeNdc("59267-1000-03")]: "pfizer", //sale
-  [normalizeNdc("59676-0580-05")]: "jj", //use
-  [normalizeNdc("59676-0580-15")]: "jj", //sale
-  [normalizeNdc("80631-0100-01")]: "novavax", //sale
-  [normalizeNdc("80631-0100-10")]: "novavax", //use
-  [normalizeNdc("80777-0273-10")]: "moderna", // use
-  [normalizeNdc("80777-0273-15")]: "moderna", // use
-  [normalizeNdc("80777-0273-98")]: "moderna", //sale
-  [normalizeNdc("80777-0273-99")]: "moderna", //sale
+  [normalizeNdc("00310-1222-10")]: VaccineProduct.astraZeneca, // use
+  [normalizeNdc("00310-1222-15")]: VaccineProduct.astraZeneca, // sale
+  [normalizeNdc("59267-1000-01")]: VaccineProduct.pfizer, // use
+  [normalizeNdc("59267-1000-02")]: VaccineProduct.pfizer, // sale
+  [normalizeNdc("59267-1000-03")]: VaccineProduct.pfizer, // sale
+  [normalizeNdc("59267-1025-01")]: VaccineProduct.pfizer, // use
+  [normalizeNdc("59267-1025-02")]: VaccineProduct.pfizer, // sale
+  [normalizeNdc("59267-1025-03")]: VaccineProduct.pfizer, // sale
+  [normalizeNdc("59267-1025-04")]: VaccineProduct.pfizer, // sale
+  [normalizeNdc("00069-1000-01")]: VaccineProduct.pfizer, // use
+  [normalizeNdc("00069-1000-02")]: VaccineProduct.pfizer, // sale
+  [normalizeNdc("00069-1000-03")]: VaccineProduct.pfizer, // sale
+  [normalizeNdc("59267-1055-01")]: VaccineProduct.pfizerAge5_11, // use
+  [normalizeNdc("59267-1055-02")]: VaccineProduct.pfizerAge5_11, // sale
+  [normalizeNdc("59267-1055-04")]: VaccineProduct.pfizerAge5_11, // sale
+  [normalizeNdc("59267-0078-01")]: VaccineProduct.pfizerAge2_4, // use
+  [normalizeNdc("59267-0078-02")]: VaccineProduct.pfizerAge2_4, // sale
+  [normalizeNdc("59267-0078-04")]: VaccineProduct.pfizerAge2_4, // sale
+  [normalizeNdc("59676-0580-05")]: VaccineProduct.janssen, // use
+  [normalizeNdc("59676-0580-15")]: VaccineProduct.janssen, // sale
+  [normalizeNdc("80631-0100-01")]: VaccineProduct.novavax, // sale
+  [normalizeNdc("80631-0100-10")]: VaccineProduct.novavax, // use
+  [normalizeNdc("80777-0273-10")]: VaccineProduct.moderna, // use
+  [normalizeNdc("80777-0273-15")]: VaccineProduct.moderna, // use
+  [normalizeNdc("80777-0273-98")]: VaccineProduct.moderna, // sale
+  [normalizeNdc("80777-0273-99")]: VaccineProduct.moderna, // sale
 };
 
 function normalizeNdc(ndcCode) {

--- a/loader/src/sources/prepmod/index.js
+++ b/loader/src/sources/prepmod/index.js
@@ -16,7 +16,7 @@ const {
   formatExternalIds,
   valuesAsObject,
 } = require("../../smart-scheduling-links");
-const { Available, LocationType, VaccineProduct } = require("../../model");
+const { Available, LocationType } = require("../../model");
 const { prepmodHostsByState } = require("./hosts");
 const { HTTPError } = require("got");
 const { matchVaccineProduct } = require("../../utils");

--- a/loader/src/sources/prepmod/index.js
+++ b/loader/src/sources/prepmod/index.js
@@ -16,7 +16,7 @@ const {
   formatExternalIds,
   valuesAsObject,
 } = require("../../smart-scheduling-links");
-const { Available, LocationType } = require("../../model");
+const { Available, LocationType, VaccineProduct } = require("../../model");
 const { prepmodHostsByState } = require("./hosts");
 const { HTTPError } = require("got");
 
@@ -151,15 +151,21 @@ function formatSlots(smartSlots) {
           } else {
             const name = extension.valueCoding.display.toLowerCase();
             if (/astra\s*zeneca/.test(name)) {
-              product = "astra_zeneca";
+              product = VaccineProduct.astraZeneca;
             } else if (name.includes("moderna")) {
-              product = "moderna";
+              product = VaccineProduct.moderna;
             } else if (/nova\s*vax/.test(name)) {
-              product = "novavax";
+              product = VaccineProduct.novavax;
             } else if (name.includes("pfizer")) {
-              product = "pfizer";
+              if (/ages?\s+2/i.test(name)) {
+                product = VaccineProduct.pfizerAge2_4;
+              } else if (/pediatric|children|ages?\s+5/i.test(name)) {
+                product = VaccineProduct.pfizerAge5_11;
+              } else {
+                product = VaccineProduct.pfizer;
+              }
             } else if (/janssen|johnson/.test(name)) {
-              product = "jj";
+              product = VaccineProduct.janssen;
             }
           }
           if (product) {
@@ -261,6 +267,7 @@ async function checkAvailability(handler, options) {
 }
 
 module.exports = {
-  checkAvailability,
   API_PATH,
+  checkAvailability,
+  formatLocation,
 };

--- a/loader/src/sources/prepmod/index.js
+++ b/loader/src/sources/prepmod/index.js
@@ -19,6 +19,7 @@ const {
 const { Available, LocationType, VaccineProduct } = require("../../model");
 const { prepmodHostsByState } = require("./hosts");
 const { HTTPError } = require("got");
+const { matchVaccineProduct } = require("../../utils");
 
 const API_PATH = "/api/smart-scheduling-links/$bulk-publish";
 
@@ -149,24 +150,7 @@ function formatSlots(smartSlots) {
           if (extension.valueCoding.code) {
             product = PRODUCTS_BY_CVX_CODE[extension.valueCoding.code];
           } else {
-            const name = extension.valueCoding.display.toLowerCase();
-            if (/astra\s*zeneca/.test(name)) {
-              product = VaccineProduct.astraZeneca;
-            } else if (name.includes("moderna")) {
-              product = VaccineProduct.moderna;
-            } else if (/nova\s*vax/.test(name)) {
-              product = VaccineProduct.novavax;
-            } else if (name.includes("pfizer")) {
-              if (/ages?\s+2/i.test(name)) {
-                product = VaccineProduct.pfizerAge2_4;
-              } else if (/pediatric|children|ages?\s+5/i.test(name)) {
-                product = VaccineProduct.pfizerAge5_11;
-              } else {
-                product = VaccineProduct.pfizer;
-              }
-            } else if (/janssen|johnson/.test(name)) {
-              product = VaccineProduct.janssen;
-            }
+            product = matchVaccineProduct(extension.valueCoding.display);
           }
           if (product) {
             products.add(product);

--- a/loader/src/sources/wa-doh.js
+++ b/loader/src/sources/wa-doh.js
@@ -2,8 +2,8 @@
 // they have API access. (In practice, this is pretty much only Costco.)
 
 const Sentry = require("@sentry/node");
-const { Available, LocationType, VaccineProduct } = require("../model");
-const { httpClient } = require("../utils");
+const { Available, LocationType } = require("../model");
+const { httpClient, matchVaccineProduct } = require("../utils");
 const { HttpApiError } = require("../exceptions");
 const allStates = require("../states.json");
 
@@ -158,27 +158,11 @@ function toLocationType(apiValue) {
  * @returns {VaccineProduct}
  */
 function toProduct(apiValue) {
-  const name = apiValue.toLowerCase();
-  if (/astra\s*zeneca/.test(name)) {
-    return VaccineProduct.astraZeneca;
-  } else if (name.includes("moderna")) {
-    return VaccineProduct.moderna;
-  } else if (/nova\s*vax/.test(name)) {
-    return VaccineProduct.novavax;
-  } else if (name.includes("pfizer")) {
-    if (/ages?\s+2/i.test(name)) {
-      return VaccineProduct.pfizerAge2_4;
-    } else if (/pediatric|children|ages?\s+5/i.test(name)) {
-      return VaccineProduct.pfizerAge5_11;
-    } else {
-      return VaccineProduct.pfizer;
-    }
-  } else if (/janssen|johnson/.test(name)) {
-    return VaccineProduct.janssen;
+  const product = matchVaccineProduct(apiValue);
+  if (!product) {
+    warn(`Unknown product type "${apiValue}"`);
   }
-
-  warn(`Unknown product type "${name}"`);
-  return null;
+  return product;
 }
 
 /**

--- a/loader/src/sources/wa-doh.js
+++ b/loader/src/sources/wa-doh.js
@@ -1,8 +1,9 @@
 // Washington State DoH hosts data for multiple states for some providers where
 // they have API access. (In practice, this is pretty much only Costco.)
 
+const Sentry = require("@sentry/node");
 const { Available, LocationType, VaccineProduct } = require("../model");
-const { httpClient, warn } = require("../utils");
+const { httpClient } = require("../utils");
 const { HttpApiError } = require("../exceptions");
 const allStates = require("../states.json");
 
@@ -64,6 +65,16 @@ const LOCATIONS_QUERY = `
     }
   }
 `;
+
+function warn(message, context) {
+  console.warn(`WA DoH: ${message}`, context);
+  // Sentry does better fingerprinting with an actual exception object.
+  if (message instanceof Error) {
+    Sentry.captureException(message, { level: Sentry.Severity.Info });
+  } else {
+    Sentry.captureMessage(message, Sentry.Severity.Info);
+  }
+}
 
 class WaDohApiError extends HttpApiError {
   parse(response) {
@@ -137,7 +148,7 @@ function toLocationType(apiValue) {
   else if (text === "pharmacy") return LocationType.pharmacy;
   else if (text === "store") return LocationType.pharmacy;
 
-  console.error(`WA DoH: Unknown location type "${apiValue}"`);
+  warn(`Unknown location type "${apiValue}"`);
   return LocationType.pharmacy;
 }
 
@@ -147,12 +158,26 @@ function toLocationType(apiValue) {
  * @returns {VaccineProduct}
  */
 function toProduct(apiValue) {
-  const text = apiValue.toLowerCase();
-  if (text === "pfizer-biontech") return VaccineProduct.pfizer;
-  else if (text === "moderna") return VaccineProduct.moderna;
-  else if (text.includes("johnson & johnson")) return VaccineProduct.janssen;
+  const name = apiValue.toLowerCase();
+  if (/astra\s*zeneca/.test(name)) {
+    return VaccineProduct.astraZeneca;
+  } else if (name.includes("moderna")) {
+    return VaccineProduct.moderna;
+  } else if (/nova\s*vax/.test(name)) {
+    return VaccineProduct.novavax;
+  } else if (name.includes("pfizer")) {
+    if (/ages?\s+2/i.test(name)) {
+      return VaccineProduct.pfizerAge2_4;
+    } else if (/pediatric|children|ages?\s+5/i.test(name)) {
+      return VaccineProduct.pfizerAge5_11;
+    } else {
+      return VaccineProduct.pfizer;
+    }
+  } else if (/janssen|johnson/.test(name)) {
+    return VaccineProduct.janssen;
+  }
 
-  console.error(`WA DoH: Unknown product type "${apiValue}"`);
+  warn(`Unknown product type "${name}"`);
   return null;
 }
 
@@ -175,7 +200,7 @@ function formatLocation(data) {
     provider = "costco";
   }
   if (!provider) {
-    warn(`WA DoH: Unable to determine provider for ${data.locationId}`);
+    warn(`Unable to determine provider for ${data.locationId}`);
   }
 
   const address_lines = [];
@@ -185,7 +210,7 @@ function formatLocation(data) {
   const state = allStates.find(
     (state) => state.name === data.state || state.usps === data.state
   );
-  if (!state) console.error(`WA DoH: Unknown state "${data.state}"`);
+  if (!state) warn(`Unknown state "${data.state}"`);
 
   const external_ids = [["wa_doh", data.locationId]];
 
@@ -197,9 +222,7 @@ function formatLocation(data) {
     if (storeEmailMatch) {
       external_ids.push(["costco", storeEmailMatch[1]]);
     } else {
-      console.error(
-        `WA DoH: Unable to determine Costco store number for "${data.locationid}"`
-      );
+      warn(`Unable to determine Costco store number for "${data.locationid}"`);
     }
   }
 
@@ -324,4 +347,9 @@ async function checkAvailability(handler, options) {
   return results;
 }
 
-module.exports = { API_URL, checkAvailability, WaDohApiError };
+module.exports = {
+  API_URL,
+  checkAvailability,
+  formatLocation,
+  WaDohApiError,
+};

--- a/loader/src/utils.js
+++ b/loader/src/utils.js
@@ -1,6 +1,7 @@
 const got = require("got");
 const config = require("./config");
 const { ParseError } = require("./exceptions");
+const { VaccineProduct } = require("./model");
 
 const MULTIPLE_SPACE_PATTERN = /[\n\s]+/g;
 const PUNCTUATION_PATTERN = /[.,;\-–—'"“”‘’`!()/\\]+/g;
@@ -350,5 +351,34 @@ module.exports = {
       }
     }
     return result;
+  },
+
+  /**
+   * Fuzzily match a vaccine name string to one of our product types. Returns
+   * `undefined` if there's no match.
+   * @param {string} name
+   * @returns {VaccineProduct}
+   */
+  matchVaccineProduct(name) {
+    const text = name.toLowerCase();
+    if (/astra\s*zeneca/.test(text)) {
+      return VaccineProduct.astraZeneca;
+    } else if (text.includes("moderna")) {
+      return VaccineProduct.moderna;
+    } else if (/nova\s*vax/.test(text)) {
+      return VaccineProduct.novavax;
+    } else if (text.includes("pfizer")) {
+      if (/ages?\s+2/i.test(text)) {
+        return VaccineProduct.pfizerAge2_4;
+      } else if (/pediatric|children|ages?\s+5/i.test(text)) {
+        return VaccineProduct.pfizerAge5_11;
+      } else {
+        return VaccineProduct.pfizer;
+      }
+    } else if (/janssen|johnson/.test(text)) {
+      return VaccineProduct.janssen;
+    }
+
+    return undefined;
   },
 };

--- a/loader/test/prepmod.test.js
+++ b/loader/test/prepmod.test.js
@@ -635,4 +635,32 @@ describe("PrepMod API", () => {
       VaccineProduct.pfizerAge2_4,
     ]);
   });
+
+  it("identifies Pfizer for adults", async () => {
+    const testLocation = createSmartLocation({
+      schedules: [
+        {
+          extension: [
+            {
+              url: EXTENSIONS.PRODUCT,
+              valueCoding: {
+                system: "http://hl7.org/fhir/sid/cvx",
+                code: null,
+                display: "Pfizer-BioNTech COVID-19 Vaccine",
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = formatLocation(
+      "https://myhealth.alaska.gov",
+      new Date(),
+      testLocation
+    );
+    expect(result).toHaveProperty("availability.slots.0.products", [
+      VaccineProduct.pfizer,
+    ]);
+  });
 });

--- a/loader/test/prepmod.test.js
+++ b/loader/test/prepmod.test.js
@@ -1,7 +1,10 @@
 const nock = require("nock");
-const { checkAvailability } = require("../src/sources/prepmod");
+const { checkAvailability, formatLocation } = require("../src/sources/prepmod");
+const { createSmartLocation } = require("./support/smart-scheduling-links");
 const { expectDatetimeString } = require("./support");
 const { locationSchema } = require("./support/schemas");
+const { VaccineProduct } = require("../src/model");
+const { EXTENSIONS } = require("../src/smart-scheduling-links");
 
 describe("PrepMod API", () => {
   jest.setTimeout(60000);
@@ -575,5 +578,61 @@ describe("PrepMod API", () => {
       },
     ]);
     expect(result).toContainItemsMatchingSchema(locationSchema);
+  });
+
+  it("identifies Pfizer for 5-11 year olds", async () => {
+    const testLocation = createSmartLocation({
+      schedules: [
+        {
+          extension: [
+            {
+              url: EXTENSIONS.PRODUCT,
+              valueCoding: {
+                system: "http://hl7.org/fhir/sid/cvx",
+                code: null,
+                display: "Pfizer Pediatric COVID-19 Vaccine (Ages 5-11)",
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = formatLocation(
+      "https://myhealth.alaska.gov",
+      new Date(),
+      testLocation
+    );
+    expect(result).toHaveProperty("availability.slots.0.products", [
+      VaccineProduct.pfizerAge5_11,
+    ]);
+  });
+
+  it("identifies Pfizer for 2-4 year olds", async () => {
+    const testLocation = createSmartLocation({
+      schedules: [
+        {
+          extension: [
+            {
+              url: EXTENSIONS.PRODUCT,
+              valueCoding: {
+                system: "http://hl7.org/fhir/sid/cvx",
+                code: null,
+                display: "Pfizer Pediatric COVID-19 Vaccine (Ages 2-4)",
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = formatLocation(
+      "https://myhealth.alaska.gov",
+      new Date(),
+      testLocation
+    );
+    expect(result).toHaveProperty("availability.slots.0.products", [
+      VaccineProduct.pfizerAge2_4,
+    ]);
   });
 });

--- a/loader/test/support/smart-scheduling-links.js
+++ b/loader/test/support/smart-scheduling-links.js
@@ -1,0 +1,149 @@
+const {
+  scheduleReference,
+  locationReference,
+} = require("../../src/smart-scheduling-links");
+
+/**
+ * Create a new location object with dummy location data. Matches the format
+ * returned by `getLocations()` in the smart-scheduling-links module.
+ *
+ * Optionally pass in an object with any key/value pairs to override on the
+ * location. If it has an array for the `schedules` property, each element will
+ * be used as a similar set of overrides on a dummy schedule attached to the
+ * location. Similarly, if a schedules override has an array for its `slots`
+ * property, each element will be used as a set of overrides on a dummy slot
+ * attached to the schedule.
+ *
+ * By default, each location has one schedule and each schedule has one slot.
+ * You can pass empty arrays for `schedules` (or a schedule's `slots`) to not
+ * create any. If the array has > 1 item, then the same number of
+ * scheudles/slots will be created.
+ * @param {any} [overrides]
+ * @returns {{location: any, schedules any[], slots: any[]}}
+ */
+function createSmartLocation(overrides) {
+  const schedulesData = overrides?.schedules || {};
+  delete overrides?.schedules;
+
+  const id = Math.random().toString().slice(2);
+  const location = {
+    id,
+    resourceType: "Location",
+    name: "Test Location",
+    telecom: [
+      { system: "phone", value: "888-555-1234" },
+      { system: "url", value: `https://example.com/${id}` },
+    ],
+    address: {
+      line: ["123 Example Rd."],
+      city: "Somewheresville",
+      state: "SC",
+      postalCode: "29614",
+      district: "Greenville",
+    },
+    identifier: [
+      {
+        system: "https://example.com/store",
+        value: "1234",
+      },
+    ],
+    position: { latitude: 46.0763689, longitude: -118.2838519 },
+    ...overrides,
+  };
+
+  const schedules = [];
+  const slots = [];
+  schedulesData.forEach((data, index) => {
+    const result = createSmartSchedule(location, index, data);
+    schedules.push(result.schedule);
+    slots.push(...result.slots);
+  });
+
+  return { location, schedules, slots };
+}
+
+/**
+ * Create a dummy schedule object that matches the SMART Scheduling Links spec.
+ * @param {any} location Location object to create a schedule for.
+ * @param {string|number} [idSuffix] Suffix to add to the schedule ID.
+ * @param {any} [overrides]
+ * @returns {{schedule: any, slots: any[]}}
+ */
+function createSmartSchedule(location, idSuffix, overrides) {
+  const slotsData = overrides?.slots ?? [{}];
+  delete overrides?.slots;
+
+  const schedule = {
+    [locationReference]: location,
+    id: `${location.id}-${idSuffix}`,
+    actor: [{ reference: `Location/${location.id}` }],
+    resourceType: "Schedule",
+    serviceType: [
+      {
+        coding: [
+          {
+            system: "http://terminology.hl7.org/CodeSystem/service-type",
+            code: "57",
+            display: "Immunization",
+          },
+          {
+            system:
+              "http://fhir-registry.smarthealthit.org/CodeSystem/service-type",
+            code: "covid19-immunization",
+            display: "COVID-19 Immunization Appointment",
+          },
+        ],
+      },
+    ],
+    extension: [
+      {
+        url: "http://fhir-registry.smarthealthit.org/StructureDefinition/vaccine-product",
+        valueCoding: {
+          system: "http://hl7.org/fhir/sid/cvx",
+          code: 212,
+          display: "Janssen COVID-19 Vaccine",
+        },
+      },
+    ],
+    ...overrides,
+  };
+
+  const slots = slotsData.map((data, index) =>
+    createSmartSlot(schedule, index, data)
+  );
+
+  return { schedule, slots };
+}
+
+/**
+ * Create a dummy slot object that matches the SMART Scheduling Links spec.
+ * @param {any} schedule Schedule object that the slot belongs to.
+ * @param {string|number} [idSuffix] Suffix to add to the Slot ID
+ * @param {any} [overrides]
+ * @returns {any}
+ */
+function createSmartSlot(schedule, idSuffix, overrides) {
+  return {
+    [scheduleReference]: schedule,
+    id: `${schedule.id}-${idSuffix}`,
+    resourceType: "Slot",
+    schedule: { reference: `Schedule/${schedule.id}` },
+    status: "free",
+    start: "2021-09-13T09:00:00.000-08:00",
+    end: "2021-09-13T09:09:00.000-08:00",
+    extension: [
+      {
+        url: "http://fhir-registry.smarthealthit.org/StructureDefinition/booking-deep-link",
+        valueUrl:
+          "https://prepmod.doh.wa.gov//appointment/en/client/registration?clinic_id=6320",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+module.exports = {
+  createSmartLocation,
+  createSmartSchedule,
+  createSmartSlot,
+};

--- a/loader/test/wa-doh.test.js
+++ b/loader/test/wa-doh.test.js
@@ -1,8 +1,10 @@
 const nock = require("nock");
+const { VaccineProduct } = require("../src/model");
 const {
   API_URL,
   checkAvailability,
   WaDohApiError,
+  formatLocation,
 } = require("../src/sources/wa-doh");
 const { expectDatetimeString, splitHostAndPath } = require("./support");
 const { locationSchema } = require("./support/schemas");
@@ -106,5 +108,64 @@ describe("Washington DoH API", () => {
     );
     expect(error).toBeInstanceOf(WaDohApiError);
     expect(error.message).toContain("Expected type Int!");
+  });
+
+  it("identifies Pfizer adult and pediatric vaccines", () => {
+    const result = formatLocation({
+      locationId: "costco-625",
+      locationName: "Costco Caguas",
+      locationType: "Pharmacy",
+      providerId: null,
+      providerName: null,
+      departmentId: "costco-625",
+      departmentName: "Costco Caguas",
+      addressLine1: "PR #30 INTERSECCION AVENDIA",
+      addressLine2: "RAFAEL CORDERO BARIO",
+      city: "Caguas",
+      state: "PR",
+      zipcode: "PR00725",
+      county: null,
+      latitude: 18.251949,
+      longitude: -66.024857,
+      description: null,
+      contactFirstName: "Leticia",
+      contactLastName: "Ortiz Vazquez",
+      fax: "(787) 653-6948",
+      phone: "(787) 653-6929",
+      email: "w365phm@costco.com",
+      schedulingLink: "https://book.appointment-plus.com/d133yng2",
+      vaccineAvailability: "UNAVAILABLE",
+      vaccineTypes: [
+        "Pfizer-BioNTech (Comirnaty), ages 12 and up",
+        "Pfizer-BioNTech Pediatric, ages 5 - 11",
+      ],
+      infoLink: null,
+      timeZoneId: "56",
+      directions: "",
+      updatedAt: "2021-06-05T19:10:58.407Z",
+      rawDataSourceName: "CostcoLocationsFn",
+      accessibleParking: null,
+      additionalSupports: null,
+      commCardAvailable: null,
+      commCardBrailleAvailable: null,
+      driveupSite: null,
+      interpretersAvailable: null,
+      interpretersDesc: null,
+      supportUrl: null,
+      waitingArea: null,
+      walkupSite: null,
+      wheelchairAccessible: null,
+      scheduleOnline: null,
+      scheduleByPhone: null,
+      scheduleByEmail: null,
+      walkIn: null,
+      waitList: null,
+      __typename: "Location",
+    });
+
+    expect(result).toHaveProperty("availability.products", [
+      VaccineProduct.pfizer,
+      VaccineProduct.pfizerAge5_11,
+    ]);
   });
 });

--- a/server/public/docs/openapi.yaml
+++ b/server/public/docs/openapi.yaml
@@ -486,7 +486,8 @@ components:
             type: string
           description: |
             List of vaccine products available on this date. Not present if not
-            known. Current possible values include: `moderna`, `pfizer`, `jj`.
+            known. Current possible values include: `moderna`, `pfizer`,
+            `pfizer_age_5_11`, `pfizer_age_2_4`, `jj`.
         dose:
           type: string
           description: |
@@ -536,7 +537,8 @@ components:
             type: string
           description: |
             List of vaccine products available for this slot. Not present if not
-            known. Current possible values include: `moderna`, `pfizer`, `jj`.
+            known. Current possible values include: `moderna`, `pfizer`,
+            `pfizer_age_5_11`, `pfizer_age_2_4`, `jj`.
         dose:
           type: string
           description: |
@@ -598,7 +600,8 @@ components:
             type: string
           description: |
             List of vaccine products available. Not present if not known.
-            Current possible values include: `moderna`, `pfizer`, `jj`.
+            Current possible values include: `moderna`, `pfizer`,
+            `pfizer_age_5_11`, `pfizer_age_2_4`, `jj`.
         doses:
           type: array
           items:

--- a/server/src/smart-scheduling-routes.ts
+++ b/server/src/smart-scheduling-routes.ts
@@ -46,18 +46,22 @@ const EXTENSION_VACCINE_PRODUCT =
 // https://www.cdc.gov/vaccines/programs/iis/COVID-19-related-codes.html
 const CVX_CODES: { [index: string]: number } = {
   astra_zeneca: 210,
+  jj: 212,
   moderna: 207,
   novavax: 211,
   pfizer: 208,
-  jj: 212,
+  pfizer_age_5_11: 218,
+  pfizer_age_2_4: 219,
 };
 
 const PRODUCT_NAMES: { [index: string]: string } = {
   astra_zeneca: "AstraZeneca",
+  jj: "Johnson & Johnson",
   moderna: "Moderna",
   novavax: "NovaVax",
   pfizer: "Pfizer",
-  jj: "Johnson & Johnson",
+  pfizer_age_5_11: "Pfizer Pediatric (Ages 5-11)",
+  pfizer_age_2_4: "Pfizer Pediatric (Ages 2-4)",
 };
 
 const DOSE_NUMBERS: { [index: string]: number[] } = {


### PR DESCRIPTION
This adds two new product types:
- `pfizer_age_5_11` for the newly approved pediatric Pfizer vaccine for 5-11 year olds.
- `pfizer_age_2_4` for the still-in-testing pediatric Pfizer vaccine for 2-4 year olds. We *shouldn’t* be seeing this anywhere in practice, but there are official codes for it, and hopefully we’ll see it sooner or later.

And adds code to detect these for PrepMod, generic SMART SL sources, WA State Dept. of Health’s API, and the CDC’s Open Data. None of the other sources we know of support it yet.

I also discovered a few problems while doing this that I tried to fix:
- The WA DoH was failing to detect most vaccine types (the names changed)! We didn’t have its warnings hooked up for Sentry. 😱 
- We were using strings all over the place when we should have been using constants. There are probably more of these in other sources that I wasn’t working on here. 😬

Fixes #425.