### PR TITLE
Expand store support in CDC API source

### DIFF
--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -211,6 +211,28 @@ const locationSystems = [
   { system: "walgreens", pattern: /^Walgreens/i },
   { system: "sams_club", pattern: /^Sams Club/i, getId: getWalmartId },
   { system: "walmart", pattern: /^Walmart/i, getId: getWalmartId },
+  {
+    system: "shoprite",
+    // "Klein's Shoprite" is the same Shoprite as Shoprite, but just encompasses
+    // a subset of stores in Maryland.
+    pattern: /^(klein )?shoprite/i,
+    getId(location) {
+      let id;
+      // This is the only one not formatted with a # sign.
+      // TODO: this appears to be the same as store 322046, and I can't figure
+      // out which is "correct". Ideally we'd just put in both, but the current
+      // framework here can't handle that.
+      if (location.loc_name.toLowerCase().trim() === "Shoprite Pharmacy 801") {
+        id = "801";
+      }
+      // Some stores have a loc_store_no value, but some don't and just have
+      // the store number in the name.
+      if (!id) {
+        id = getSimpleId(location) || location.loc_name.match(/#(\d+)/)?.[1];
+      }
+      return id;
+    },
+  },
 ];
 
 function getStoreExternalId(location) {

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -237,6 +237,14 @@ const locationSystems = [
   // Sav-On has a handful of locations with no store number. Not sure there's
   // any useful way to handle those.
   { system: "sav_on", pattern: /^sav-?on/i },
+  // FIXME: Wegmans is disabled for now because the store numbers in CDC's data
+  // don't match up to *anything* else I can find for Wegmans. You can get some
+  // detailed data from https://shop.wegmans.com/api/v2/stores
+  // We have "wegmans" IDs that correspond to `id` in that API, but it appears
+  // the public facing store numbers (which are hard to find anyway) are really
+  // the `retailer_store_id` field. There's also `ext_id` and
+  // `store_banner.ext_id`. None of them match in any way to the CDC numbers.
+  // { system: "wegmans", pattern: /^wegmans/i },
 ];
 
 function getStoreExternalId(location) {

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -233,6 +233,7 @@ const locationSystems = [
       return id;
     },
   },
+  { system: "stop_and_shop", pattern: /^stop & shop/i },
 ];
 
 function getStoreExternalId(location) {

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -245,6 +245,7 @@ const locationSystems = [
   // the `retailer_store_id` field. There's also `ext_id` and
   // `store_banner.ext_id`. None of them match in any way to the CDC numbers.
   // { system: "wegmans", pattern: /^wegmans/i },
+  { system: "genoa_healthcare", pattern: /^Genoa Healthcare/i },
 ];
 
 function getStoreExternalId(location) {

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -246,6 +246,28 @@ const locationSystems = [
   // `store_banner.ext_id`. None of them match in any way to the CDC numbers.
   // { system: "wegmans", pattern: /^wegmans/i },
   { system: "genoa_healthcare", pattern: /^Genoa Healthcare/i },
+  {
+    system: "bartell",
+    pattern: /bartell drug/i,
+    getId(location) {
+      // Bartell store numbers are prefixed with "69" and sometimes have
+      // additional 0-padding.
+      // Can dig up more details on Bartell stores at:
+      //   https://www.bartelldrugs.com/wp-json/api/stores?per_page=100&orderby=title&order=ASC
+      // Also worth noting: it appears that the WA DoH API only sometimes
+      // surfaces store numbers, and also has addresses and store names mixed
+      // up in a few cases. Makes one worry about the data accuracy :|
+      // There doesn't appear to be a simple way to match up to their data here.
+      const id = location.loc_store_no.match(/^\s*0*69(\d\d)\s*$/)?.[1];
+      if (!id) {
+        warn("Unexpected Bartell ID format", {
+          id: location.provider_location_guid,
+          storeNumber: location.loc_store_no,
+        });
+      }
+      return id;
+    },
+  },
 ];
 
 function getStoreExternalId(location) {

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -268,6 +268,7 @@ const locationSystems = [
       return id;
     },
   },
+  { system: "meijer", pattern: /^Meijer/i },
 ];
 
 function getStoreExternalId(location) {

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -234,6 +234,9 @@ const locationSystems = [
     },
   },
   { system: "stop_and_shop", pattern: /^stop & shop/i },
+  // Sav-On has a handful of locations with no store number. Not sure there's
+  // any useful way to handle those.
+  { system: "sav_on", pattern: /^sav-?on/i },
 ];
 
 function getStoreExternalId(location) {

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -269,6 +269,23 @@ const locationSystems = [
     },
   },
   { system: "meijer", pattern: /^Meijer/i },
+  {
+    system: "southeastern_grocers_winn_dixie",
+    pattern: /^Winn-?Dixie/i,
+    getId(location) {
+      const storeNumber = getSimpleId(location);
+      if (storeNumber) {
+        // We got these IDs originally from VaccineSpotter, and they are always
+        // the store number prefixed with "1-".
+        return `1-${storeNumber}`;
+      }
+      warn("Unexpected Winn-Dixie ID format", {
+        id: location.provider_location_guid,
+        storeNumber: location.loc_store_no,
+      });
+      return null;
+    },
+  },
 ];
 
 function getStoreExternalId(location) {

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -286,6 +286,11 @@ const locationSystems = [
       return null;
     },
   },
+  // These Hannaford store numbers do not match up to the store numbers on the
+  // Hannaford website, but they *do* match up to store numbers in their COVID
+  // vaccine scheduling system (rxtouch.com). Not sure if these are just
+  // arbitrarily different, or if they are a pharmacy-specific ID or something.
+  { system: "hannaford", pattern: /^Hannaford/i },
 ];
 
 function getStoreExternalId(location) {


### PR DESCRIPTION
This fixes Walmart/Sam's Club support in the CDC source, and also adds support for:
- Shoprite
- Stop & Shop
- Sav-On
- Genoa Healthcare
- Bartell Drug
- Meijer
- Winn Dixie
- Hannaford

I focused on chains that are common in our partners' states (AK, NJ, WA) and that had lots of entries in the CDC data. I also did my best to make sure these external IDs seem sensible and match up to what we’ve already got (when we already have something for these stores). One exception here is Wegmans, which I couldn’t find a reasonable way to match up and wrote a big comment about inline.

I also tried to do this with minimal impact to the architecture of this source, but having this confined to the scope of a single external ID poses some problems, like store types that should really set more than one, or that ought to change the location's name instead of just an external ID, or that reformat the store number/ID entirely but can't touch other fields in the output that use it (Walmart, with its `10-` prefix on the store number, is a good example). It might be worth refactoring this more in [the style of how VaccineSpotter was done](https://github.com/usdigitalresponse/univaf/blob/ca56bccbd2a7f66a6abe68595c99c442fc9f3440/loader/src/sources/vaccinespotter/index.js#L242-L404). But not sure it’s worth holding up this functionality for. 🤷 

Fixes #393.