### PR TITLE
Parse pfizerAge5_11 vaccine product for NJVSS

### DIFF
--- a/loader/src/sources/njvss/index.js
+++ b/loader/src/sources/njvss/index.js
@@ -378,6 +378,14 @@ function parseVaccineProducts(text) {
     result.push(VaccineProduct.pfizer);
   }
 
+  if (
+    text.includes(
+      "<li>Pediatrics Pfizer Covid-19 Vaccine for age (5-11) years</li>"
+    )
+  ) {
+    result.push(vaccineProducts.pfizerAge5_11);
+  }
+  
   if (text.includes("<li>Janssen (J&J) COVID-19 Vaccine</li>")) {
     result.push(VaccineProduct.janssen);
   }

--- a/loader/src/sources/njvss/index.js
+++ b/loader/src/sources/njvss/index.js
@@ -383,9 +383,9 @@ function parseVaccineProducts(text) {
       "<li>Pediatrics Pfizer Covid-19 Vaccine for age (5-11) years</li>"
     )
   ) {
-    result.push(vaccineProduct.pfizerAge5_11);
+    result.push(VaccineProduct.pfizerAge5_11);
   }
-  
+
   if (text.includes("<li>Janssen (J&J) COVID-19 Vaccine</li>")) {
     result.push(VaccineProduct.janssen);
   }

--- a/loader/src/sources/njvss/index.js
+++ b/loader/src/sources/njvss/index.js
@@ -383,7 +383,7 @@ function parseVaccineProducts(text) {
       "<li>Pediatrics Pfizer Covid-19 Vaccine for age (5-11) years</li>"
     )
   ) {
-    result.push(vaccineProducts.pfizerAge5_11);
+    result.push(vaccineProduct.pfizerAge5_11);
   }
   
   if (text.includes("<li>Janssen (J&J) COVID-19 Vaccine</li>")) {


### PR DESCRIPTION
Includes the string to determine whether a location has the pediatric 5-11 pfizer product.

This is not tested since I don't have univaf running locally, but the same implementation is working now on the NJ-hosted scraper.