### PR TITLE
Make CI workflow work from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         env:
           POSTGRES_DB: univaf-test
           POSTGRES_USER: test
-          POSTGRES_PASSWORD: ${{ secrets.TEST_DB_PASSWORD }}
+          POSTGRES_PASSWORD: test-password
         ports:
           - 5432:5432
         # Set health checks to wait until postgres has started
@@ -67,7 +67,7 @@ jobs:
           DB_PORT: 5432
           DB_USERNAME: test
           DB_NAME: univaf
-          DB_PASSWORD: ${{ secrets.TEST_DB_PASSWORD }}
+          DB_PASSWORD: test-password
 
       - name: Run loader tests
         run: |
@@ -152,11 +152,21 @@ jobs:
             dockerfile: "./loader/Dockerfile"
             build_path: "./loader"
     env:
+      ECR_REPOSITORY: ${{ matrix.repository }}
       IMAGE_TAG: ${{ github.sha }}
     steps:
       - uses: actions/checkout@v2
 
+      - name: Build ${{ matrix.repository }}
+        run: |
+          docker build \
+            -t dev/$ECR_REPOSITORY:$IMAGE_TAG \
+            -f ${{ matrix.dockerfile }} \
+            --build-arg RELEASE="${IMAGE_TAG}" \
+            ${{ matrix.build_path }}
+
       - name: Configure AWS credentials
+        if: github.ref == 'refs/heads/main'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -164,26 +174,16 @@ jobs:
           aws-region: us-west-2
 
       - name: Login to Amazon ECR
+        if: github.ref == 'refs/heads/main'
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
-      - name: Build and push ${{ matrix.repository }}
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: ${{ matrix.repository }}
-        run: |
-          docker build \
-            -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
-            -f ${{ matrix.dockerfile }} \
-            --build-arg RELEASE="${IMAGE_TAG}" \
-            ${{ matrix.build_path }}
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-
       - name: Tag and push ${{ matrix.repository }} latest
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: github.ref == 'refs/heads/main'
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: ${{ matrix.repository }}
         run: |
-          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:latest
+          docker tag dev/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker tag dev/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:latest
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,7 @@ jobs:
       # installed in the server project on both at once, and have some weird
       # arguments.
       - name: Lint JS Code
+        if: github.event.head.repo.full_name == github.repository
         uses: wearerequired/lint-action@v1
         with:
           eslint: true
@@ -125,6 +126,16 @@ jobs:
           prettier: true
           prettier_dir: server/
           prettier_args: . ../loader/ ../ui/
+
+      - name: Lint JS Code (without GitHub checks)
+        if: github.event.head.repo.full_name != github.repository
+        run: |
+          cd server
+          echo "ESLint:"
+          npx eslint --ext 'js,ts' . ../loader/ ../ui/
+          echo "--------------------------------------------------------------"
+          echo "Prettier:"
+          npx prettier . ../loader/ ../ui/
 
   lint_workflows:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
           npx eslint --ext 'js,ts' . ../loader/ ../ui/
           echo "--------------------------------------------------------------"
           echo "Prettier:"
-          npx prettier . ../loader/ ../ui/
+          npx prettier --check . ../loader/ ../ui/
 
   lint_workflows:
     runs-on: ubuntu-latest

--- a/loader/src/cli.js
+++ b/loader/src/cli.js
@@ -7,13 +7,13 @@ const { ApiClient } = require("./api-client");
 const { sources } = require("./index");
 const { oneLine } = require("./utils");
 
-Sentry.init();
+Sentry.init()
 
 async function runSources(targets, handler, options) {
   targets =
     targets && targets.length ? targets : Object.getOwnPropertyNames(sources);
 
-  const runs = targets.map((name) => {
+  let runs = targets.map((name) => {
     const source = sources[name];
     const run = source
       ? source.checkAvailability(handler, options)

--- a/loader/src/cli.js
+++ b/loader/src/cli.js
@@ -13,7 +13,7 @@ async function runSources(targets, handler, options) {
   targets =
     targets && targets.length ? targets : Object.getOwnPropertyNames(sources);
 
-  let runs = targets.map((name) => {
+  const runs = targets.map((name) => {
     const source = sources[name];
     const run = source
       ? source.checkAvailability(handler, options)

--- a/loader/src/cli.js
+++ b/loader/src/cli.js
@@ -7,7 +7,7 @@ const { ApiClient } = require("./api-client");
 const { sources } = require("./index");
 const { oneLine } = require("./utils");
 
-Sentry.init()
+Sentry.init();
 
 async function runSources(targets, handler, options) {
   targets =


### PR DESCRIPTION
This removes pointless secrets (the test database is a test database and lives only for the lifetime of the workflow; there is no reason for it to have a secret password) and disable ECR login & docker push commands from even trying to run anywhere except `main` (which implicitly excludes PRs).