### PR TITLE
Hide locations that disappear from the PrepMod API

### DIFF
--- a/loader/src/api-client.js
+++ b/loader/src/api-client.js
@@ -23,13 +23,29 @@ class ApiClient {
   }
 
   async getLocations(query) {
-    const { body } = await httpClient({
-      url: `${this.url}/locations`,
+    let options = {
+      url: `${this.url}/api/edge/locations`,
       searchParams: query,
       headers: { "x-api-key": this.key },
       responseType: "json",
-    });
-    return body;
+    };
+
+    const results = [];
+    while (options) {
+      const { body } = await httpClient(options);
+      results.push(...body.data);
+
+      if (body.links?.next) {
+        options = {
+          ...options,
+          url: new URL(body.links.next, this.url).href,
+          searchParams: undefined,
+        };
+      } else {
+        options = null;
+      }
+    }
+    return results;
   }
 
   async sendUpdate(data, options) {
@@ -38,7 +54,7 @@ class ApiClient {
     }
 
     const response = await httpClient.post({
-      url: `${this.url}/update`,
+      url: `${this.url}/api/edge/update`,
       searchParams: options,
       headers: { "x-api-key": this.key },
       json: data,

--- a/loader/src/cli.js
+++ b/loader/src/cli.js
@@ -159,6 +159,18 @@ function main() {
           .option("rite-aid-states", {
             type: "string",
             describe: "Overrides the `--states` option for riteAidApi",
+          })
+          .option("hide-missing-locations", {
+            type: "boolean",
+            describe: oneLine`
+              If a previously found location stops being returned by a source,
+              output it with \`is_public: false\`. Only use this with sources
+              that are "authoritative" -- that is, you expect them to output a
+              *complete* list of whatever type of locations they cover.
+              ("Previously found" locations are loaded from the server specified
+              by the API_URL environment variable. This is currently only
+              supported by the \`prepmod\` source.)
+            `,
           }),
       handler: run,
     })

--- a/loader/src/sources/prepmod/index.js
+++ b/loader/src/sources/prepmod/index.js
@@ -154,7 +154,7 @@ function formatSlots(smartSlots) {
           }
           if (product) {
             products.add(product);
-          } else {
+          } else if (!/^influenza|flu/i.test(extension.valueCoding.display)) {
             console.warn(
               `Got unparseable product extension for PrepMod: ${JSON.stringify(
                 extension

--- a/loader/src/sources/prepmod/index.js
+++ b/loader/src/sources/prepmod/index.js
@@ -60,14 +60,14 @@ async function getKnownLocations(state) {
   });
 
   // Create a lookup object indexed by external ID.
-  const result = new Map();
+  const result = Object.create(null);
   for (const location of locations) {
     // Drop `availability` so we don't wind up sending out-of-date info back.
     // TODO: remove after doing https://github.com/usdigitalresponse/univaf/issues/201
     delete location.availability;
     const data = { location, found: false };
     for (const externalId of location.external_ids) {
-      result.set(externalId.join(":"), data);
+      result[externalId.join(":")] = data;
     }
   }
   return result;
@@ -232,7 +232,7 @@ async function checkAvailability(handler, options) {
       // and later become private, at which point we should hide them, too.)
       const knownLocations = options.hideMissingLocations
         ? await getKnownLocations(state)
-        : new Map();
+        : Object.create(null);
 
       for (const host of Object.values(namedHosts)) {
         try {
@@ -242,7 +242,7 @@ async function checkAvailability(handler, options) {
 
             // If we already knew about this location, mark it as found.
             for (const externalId of location.external_ids) {
-              const known = knownLocations.get(externalId.join(":"));
+              const known = knownLocations[externalId.join(":")];
               if (known) {
                 known.found = true;
                 break;
@@ -261,7 +261,7 @@ async function checkAvailability(handler, options) {
         }
       }
 
-      for (const known of new Set([...knownLocations.values()])) {
+      for (const known of new Set([...Object.values(knownLocations)])) {
         if (!known.found) {
           const newData = { ...known.location, is_public: false };
           results.push(newData);

--- a/loader/test/api-client.test.js
+++ b/loader/test/api-client.test.js
@@ -1,6 +1,30 @@
-const { UpdateQueue } = require("../src/api-client");
+const { UpdateQueue, ApiClient } = require("../src/api-client");
+const nock = require("nock");
+
+const MOCK_HOST = "http://univaf.test";
 
 describe("API Client", () => {
+  describe("getLocations", () => {
+    it("handles paginated results", async () => {
+      nock(MOCK_HOST)
+        .get("/api/edge/locations")
+        .reply(200, {
+          links: { next: "/api/edge/locations?p2" },
+          data: [{ id: 1 }],
+        });
+      nock(MOCK_HOST)
+        .get("/api/edge/locations?p2")
+        .reply(200, {
+          links: {},
+          data: [{ id: 2 }],
+        });
+
+      const client = new ApiClient(MOCK_HOST, "abc");
+      const result = await client.getLocations();
+      expect(result).toEqual([{ id: 1 }, { id: 2 }]);
+    });
+  });
+
   describe("UpdateQueue", () => {
     it("should limit concurrent calls", async () => {
       let currentCalls = 0;

--- a/loader/test/api-client.test.js
+++ b/loader/test/api-client.test.js
@@ -25,6 +25,29 @@ describe("API Client", () => {
     });
   });
 
+  describe("sendUpdate", () => {
+    it("sends data", async () => {
+      nock(MOCK_HOST)
+        .post("/api/edge/update")
+        .query({ test: "value" })
+        .reply(200, {
+          data: {
+            location: { action: "created" },
+            availability: { action: "created" },
+          },
+        });
+
+      const client = new ApiClient(MOCK_HOST, "abc");
+      const result = await client.sendUpdate({ id: 1 }, { test: "value" });
+      expect(result).toEqual({
+        data: {
+          location: { action: "created" },
+          availability: { action: "created" },
+        },
+      });
+    });
+  });
+
   describe("UpdateQueue", () => {
     it("should limit concurrent calls", async () => {
       let currentCalls = 0;

--- a/loader/test/prepmod.test.js
+++ b/loader/test/prepmod.test.js
@@ -19,8 +19,10 @@ describe("PrepMod API", () => {
   jest.setTimeout(60000);
 
   const _apiUrl = config.apiUrl;
+  const _apiKey = config.apiKey;
   afterEach(() => {
     config.apiUrl = _apiUrl;
+    config.apiKey = _apiKey;
     nock.cleanAll();
     nock.enableNetConnect();
   });
@@ -689,7 +691,9 @@ describe("PrepMod API", () => {
       external_ids: [["prepmod-myhealth.alaska.gov-location", "def456"]],
     };
 
+    // Mock the UNIVAF API returning both locations.
     config.apiUrl = "http://univaf.test";
+    config.apiKey = "abc";
     nock(config.apiUrl)
       .get("/api/edge/locations")
       .query(true)
@@ -698,6 +702,7 @@ describe("PrepMod API", () => {
         data: [testSavedLocation, testMissingLocation],
       });
 
+    // Mock the PrepMod API returning only one of the locations.
     const apiHost = prepmodHostsByState.AK.state;
     nock(apiHost)
       .get(API_PATH)

--- a/loader/test/prepmod.test.js
+++ b/loader/test/prepmod.test.js
@@ -23,6 +23,7 @@ describe("PrepMod API", () => {
   afterEach(() => {
     config.apiUrl = _apiUrl;
     config.apiKey = _apiKey;
+
     nock.cleanAll();
     nock.enableNetConnect();
   });

--- a/loader/test/support/smart-scheduling-links.js
+++ b/loader/test/support/smart-scheduling-links.js
@@ -22,7 +22,7 @@ const {
  * @returns {{location: any, schedules any[], slots: any[]}}
  */
 function createSmartLocation(overrides) {
-  const schedulesData = overrides?.schedules || {};
+  const schedulesData = overrides?.schedules || [{}];
   delete overrides?.schedules;
 
   const id = Math.random().toString().slice(2);
@@ -142,8 +142,31 @@ function createSmartSlot(schedule, idSuffix, overrides) {
   };
 }
 
+function createSmartManifest(apiHost, apiPath) {
+  return {
+    transactionTime: "2021-05-17T16:41:05.534Z",
+    request: `${apiHost}${apiPath}`,
+    output: [
+      {
+        type: "Location",
+        url: `${apiHost}/test/locations.ndjson`,
+      },
+      {
+        type: "Schedule",
+        url: `${apiHost}/test/schedules.ndjson`,
+      },
+      {
+        type: "Slot",
+        url: `${apiHost}/test/slots.ndjson`,
+      },
+    ],
+    error: [],
+  };
+}
+
 module.exports = {
   createSmartLocation,
   createSmartSchedule,
   createSmartSlot,
+  createSmartManifest,
 };

--- a/terraform/loaders.tf
+++ b/terraform/loaders.tf
@@ -166,7 +166,7 @@ module "prepmod_loader" {
   source = "./modules/loader"
 
   name          = "prepmod"
-  command       = ["--states", "AK,WA"]
+  command       = ["--states", "AK,WA", "--hide-missing-locations"]
   loader_source = "prepmod"
   api_url       = "http://${aws_alb.main.dns_name}"
   api_key       = var.api_key


### PR DESCRIPTION
We’ve had a lot of instances where a location in Alaska managed by PrepMod may initially be public, but is later marked private. This solves the problem by comparing the list of locations we already know about with the list of locations found in the PrepMod API, and marking any previously known locations as private if they didn’t show up in the PrepMod API.

This addresses #449 for PrepMod. It still needs to be propagated to other sources where it applies (CVS, Walgreens, Rite Aid, etc.).

A few other fixes came along for the ride here:
- `ApiClient.getLocations()` wasn’t respecting pagination! I think we used it in pretty constrained scenarios before (NJVSS) and never expected too many results. Honestly the situation is similar for PrepMod, but this felt worth fixing.
- Use the same `warn(error, context)` pattern for PrepMod that we use in many of the other sources. This still needs to be more streamlined across all sources, but just adding it here improved things a bit.
- Stop warning about Flu vaccine info in PrepMod; we should be expecting it, even if we aren’t recording it.

I also discovered a couple other PrepMod issues that I didn’t fix here because they felt too big, but want to return to immediately after this:
- #458
- #459