### PR TITLE
Provide a best-effort booking URL for PrepMod locations based on clinic search criteria

### DIFF
--- a/loader/test/prepmod.test.js
+++ b/loader/test/prepmod.test.js
@@ -47,6 +47,8 @@ describe("PrepMod API", () => {
         ],
         info_phone: "509-730-3669",
         info_url: "https://prepmod.doh.wa.gov//?locale=en",
+        booking_url:
+          "https://prepmod.doh.wa.gov/appointment/en/clinic/search?location=99362&search_radius=10+miles&q%5Bvenue_search_name_or_venue_name_i_cont%5D=Walla+Walla+Mobile+Units",
         location_type: "CLINIC",
         name: "Walla Walla Mobile Units",
         position: {
@@ -221,6 +223,8 @@ describe("PrepMod API", () => {
         ],
         info_phone: undefined,
         info_url: "https://prepmod.doh.wa.gov//?locale=en",
+        booking_url:
+          "https://prepmod.doh.wa.gov/appointment/en/clinic/search?location=98944&search_radius=10+miles&q%5Bvenue_search_name_or_venue_name_i_cont%5D=Yakima+County+Health+District+COVID+Vaccination+Site",
         location_type: "CLINIC",
         name: "Yakima County Health District COVID Vaccination Site",
         position: {

--- a/server/public/docs/openapi.yaml
+++ b/server/public/docs/openapi.yaml
@@ -22,6 +22,7 @@ info:
     - Rite Aid Pharmacy (source name: `univaf-rite-aid-api`)
     - Albertsons (source name: `univaf-albertsons`)
     - HyVee (source name: `univaf-hyvee`)
+    - PrepMod (source name: `univaf-prepmod`)
     - State of New Jersey Vaccine Scheduling System (source name: `univaf-njvss`)
     - VaccineSpotter.org (source names: `univaf-vaccinespotter`, `vaccinespotter`)
     - Centers for Disease Control (CDC) (source name: `cdc`, `univaf-cdc`)
@@ -73,6 +74,37 @@ info:
     website’s API for data about vaccine products and availability. It does not
     gather available appointment counts by day (`capacity`) or individual
     appointment slots (`slots`).
+
+
+    ### PrepMod (`univaf-prepmod`)
+
+    PrepMod is a clinic management tool in use by many public health departments
+    and built by
+    [Maryland Partnership for Prevention](https://www.immunizemaryland.org).
+    It is designed around one-off *events*, so there are some caveats with how
+    we map clinic events to physical locations in this API. In particular:
+
+    - A location’s top-level `booking_url` property is generally the best link
+        for somebody who wants to book a vaccination. It links to a search
+        results page with criteria that match the location. However, there are
+        some caveats here:
+        - Most locations have multiple listings — most PrepMod “clincs” are
+            single-day events, so a given location may have one listing for each
+            day, or sometimes one for each day & vaccine type combination (it
+            depends on how the public health department sets things up).
+        - It may also list *other* locations that aren’t exact matches. PrepMod
+            searches are based on the centroid of a zip code, and so may include
+            additional similarly named clinics nearby. (This is most often a
+            problem for mobile clinics, where multiple nearby locations share
+            the same name, e.g. “Pop-up Clinic - Anchorage Health Department.”)
+    - A location’s `info_url` property links to a listing of all the clinics
+        managed by a given PrepMod server, and may include *many* different
+        locations.
+    - Each slot in a location’s `availability.slots` array has a relatively
+        unique `booking_url` that lets you book that exact slot. However, the
+        list of vaccines available may include more than are actually offered
+        for that slot. PrepMod's API unfortunately doesn't provide fine-grained
+        enough info to explain which vaccines are available for which slot.
 
 
     ### Centers for Disease Control (`cdc`, `univaf-cdc`)


### PR DESCRIPTION
PrepMod provides an info URL that simply links to the front page of the PrepMod server, which includes *many* more locations than the one in question, or provides ultra-granular links to individual booking slots, which can be a bit hard for consumers to manage. In addition, it turns out some clinics have complicated vaccination patterns, like one in Alaska where Moderna is offered on certain days and J&J on others, but where the PrepMod API does not provide separate schedules for the two vaccines, so the product information on the slots is inaccurate and unhelpful.

This attempts to provide a happy medium by making the `booking_link` property on a location (the slot one is left as-is) that links to search results for the clinic. The caveat here is that searches are geographically based on the centroid of a zip code, and so may not include all of a zip code or may include other zip codes. A big radius is not a problem when a location's name is unique (e.g. "Bernie's Pharmacy"), but is tough to deal with when the name is generic or refers to a mobile clinic (e.g. "Anchorange Public Health Mobile Clinic"). We use a 10 mile radius as a happy medium. We might need to adjust in the future.