### PR TITLE
Handle community clinics in Albertsons data

### DIFF
--- a/loader/src/model.js
+++ b/loader/src/model.js
@@ -38,8 +38,18 @@ const VaccineProduct = {
   pfizerAge2_4: "pfizer_age_2_4",
 };
 
+/**
+ * `VaccineProduct` values that are for children.
+ * @readonly
+ */
+const PediatricVaccineProducts = new Set([
+  VaccineProduct.pfizerAge5_11,
+  VaccineProduct.pfizerAge2_4,
+]);
+
 module.exports = {
   Available,
   LocationType,
   VaccineProduct,
+  PediatricVaccineProducts,
 };

--- a/loader/src/sources/albertsons/index.js
+++ b/loader/src/sources/albertsons/index.js
@@ -174,6 +174,16 @@ const BRANDS = [
     name: "ALB Corporate Office",
     pattern: /Corporate Office/i,
   },
+  // Albertsons is now operating some clinics outside its actual stores, and
+  // this is meant to cover those. The `pattern` may need updating over time to
+  // reflect the variety of location names we might see.
+  {
+    ...BASE_BRAND,
+    key: "community_clinic",
+    name: "Community Clinic",
+    locationType: LocationType.clinic,
+    pattern: /Recreation Center/i,
+  },
 ];
 
 function warn(message, context) {
@@ -225,6 +235,7 @@ async function getData(states) {
       });
       return formatted;
     })
+    .filter(Boolean)
     .filter((location) => states.includes(location.state));
 
   // Adult & Pediatric vaccines at the same locations get different listings in
@@ -373,7 +384,7 @@ function formatLocation(data, validAt, checkedAt) {
     name,
     external_ids,
     provider: "albertsons",
-    location_type: LocationType.pharmacy,
+    location_type: storeBrand.locationType || LocationType.pharmacy,
     address_lines: address.lines,
     city: address.city,
     state: address.state,

--- a/loader/test/albertsons.test.js
+++ b/loader/test/albertsons.test.js
@@ -289,6 +289,35 @@ describe("Albertsons", () => {
     ]);
   });
 
+
+  it("should handle community clinics", async () => {
+    nock(API_URL_BASE)
+      .get(API_URL_PATH)
+      .query(true)
+      .reply(
+        200,
+        [
+          {
+            id: "1637101034326",
+            region: "Eastern_-_6",
+            address:
+              "Takoma Park Recreation Center  - 7315 New Hampshire Avenue, Takoma Park, MD, 20912",
+            lat: "38.98247194054162",
+            long: "-76.9879339600021",
+            coach_url: "https://kordinator.mhealthcoach.net/vcl/1637101034326",
+            availability: "yes",
+            drugName: ["PfizerChild"],
+          },
+        ],
+        { "Last-Modified": "Thu, 28 Oct 2021 07:06:13 GMT" }
+      );
+
+    const result = await checkAvailability(() => {}, { states: "MD" });
+    expect(result[0]).toMatchSchema(locationSchema);
+    expect(result[0]).toHaveProperty("name", "Takoma Park Recreation Center");
+    expect(result[0]).toHaveProperty("location_type", "CLINIC");
+  });
+
   it("should throw an error when HTTP requests fail", async () => {
     nock(API_URL_BASE).post(API_URL_PATH).reply(500, {
       errors: "Oh no!",

--- a/loader/test/albertsons.test.js
+++ b/loader/test/albertsons.test.js
@@ -289,6 +289,90 @@ describe("Albertsons", () => {
     ]);
   });
 
+  it("handles locations with pediatric names but no products", async () => {
+    nock(API_URL_BASE)
+      .get(API_URL_PATH)
+      .query(true)
+      .reply(
+        200,
+        [
+          {
+            id: "1610138028763",
+            region: "SoCal_-_Pasadena",
+            address:
+              "Pfizer Child - Albertsons 0393 - 1268 Madera Rd, Simi Valley, CA, 93065",
+            lat: "34.2616858",
+            long: "-118.7968621",
+            coach_url: "https://kordinator.mhealthcoach.net/vcl/1610138028763",
+            availability: "no",
+            drugName: [],
+          },
+          {
+            id: "1600118533422",
+            region: "California_-_San_Diego_4",
+            address: "Albertsons 0393 - 1268 Madera Rd, Simi Valley, CA, 93065",
+            lat: "34.2616858",
+            long: "-118.7968621",
+            coach_url: "https://kordinator.mhealthcoach.net/vcl/1600118533422",
+            availability: "no",
+            drugName: [],
+          },
+        ],
+        { "Last-Modified": "Thu, 28 Oct 2021 07:06:13 GMT" }
+      );
+    const result = await checkAvailability(() => {}, { states: "CA" });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchSchema(locationSchema);
+    expect(result).toHaveProperty("0.meta", {
+      albertsons_region: "California_-_San_Diego_4",
+      booking_url_adult:
+        "https://kordinator.mhealthcoach.net/vcl/1600118533422",
+      booking_url_pediatric:
+        "https://kordinator.mhealthcoach.net/vcl/1610138028763",
+    });
+  });
+
+  it("handles locations without pediatric names but that only have pediatric products", async () => {
+    nock(API_URL_BASE)
+      .get(API_URL_PATH)
+      .query(true)
+      .reply(
+        200,
+        [
+          {
+            id: "1610138028763",
+            region: "SoCal_-_Pasadena",
+            address: "Albertsons 0393 - 1268 Madera Rd, Simi Valley, CA, 93065",
+            lat: "34.2616858",
+            long: "-118.7968621",
+            coach_url: "https://kordinator.mhealthcoach.net/vcl/1610138028763",
+            availability: "no",
+            drugName: ["PfizerChild"],
+          },
+          {
+            id: "1600118533422",
+            region: "California_-_San_Diego_4",
+            address: "Albertsons 0393 - 1268 Madera Rd, Simi Valley, CA, 93065",
+            lat: "34.2616858",
+            long: "-118.7968621",
+            coach_url: "https://kordinator.mhealthcoach.net/vcl/1600118533422",
+            availability: "no",
+            drugName: [],
+          },
+        ],
+        { "Last-Modified": "Thu, 28 Oct 2021 07:06:13 GMT" }
+      );
+    const result = await checkAvailability(() => {}, { states: "CA" });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchSchema(locationSchema);
+    expect(result).toHaveProperty("0.meta", {
+      albertsons_region: "California_-_San_Diego_4",
+      booking_url_adult:
+        "https://kordinator.mhealthcoach.net/vcl/1600118533422",
+      booking_url_pediatric:
+        "https://kordinator.mhealthcoach.net/vcl/1610138028763",
+    });
+  });
 
   it("should handle community clinics", async () => {
     nock(API_URL_BASE)
@@ -316,6 +400,10 @@ describe("Albertsons", () => {
     expect(result[0]).toMatchSchema(locationSchema);
     expect(result[0]).toHaveProperty("name", "Takoma Park Recreation Center");
     expect(result[0]).toHaveProperty("location_type", "CLINIC");
+    expect(result[0]).toHaveProperty(
+      "meta.booking_url_pediatric",
+      "https://kordinator.mhealthcoach.net/vcl/1637101034326"
+    );
   });
 
   it("should throw an error when HTTP requests fail", async () => {


### PR DESCRIPTION
Albertsons started including a community clinic (presumably it’s being operated by a store pharmacy’s staff), which has been causing two errors in production:
- https://sentry.io/organizations/usdr/issues/2813365771
- https://sentry.io/organizations/usdr/issues/2809052505

This solves both of those issues by adding a new brand for “Community Clinic.”

It also fixes a follow-on issue that clinic alerted me to (but which was not unique to it): some pediatric clinics don’t indicate that they are pediatric in the name (but you can tell because they only list pediatric products), which some others have it in the name but list no products. Both of these are edge-casey, but do exist in the actual data.