### PR TITLE
Upgrade Sentry to v6.15.0

### DIFF
--- a/loader/package-lock.json
+++ b/loader/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.39.0",
-        "@sentry/node": "^6.13.3",
+        "@sentry/node": "^6.15.0",
         "csv-parse": "^4.16.3",
         "get-stream": "^6.0.1",
         "got": "^11.8.2",
@@ -2136,14 +2136,14 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.13.3.tgz",
-      "integrity": "sha512-obm3SjgCk8A7nB37b2AU1eq1q7gMoJRrGMv9VRIyfcG0Wlz/5lJ9O3ohUk+YZaaVfZMxXn6hFtsBiOWmlv7IIA==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.15.0.tgz",
+      "integrity": "sha512-mCbKyqvD1G3Re6gv6N8tRkBz84gvVWDfLtC6d1WBArIopzter6ktEbvq0cMT6EOvGI2OLXuJ6mtHA93/Q0gGpw==",
       "dependencies": {
-        "@sentry/hub": "6.13.3",
-        "@sentry/minimal": "6.13.3",
-        "@sentry/types": "6.13.3",
-        "@sentry/utils": "6.13.3",
+        "@sentry/hub": "6.15.0",
+        "@sentry/minimal": "6.15.0",
+        "@sentry/types": "6.15.0",
+        "@sentry/utils": "6.15.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -2156,12 +2156,12 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/hub": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.13.3.tgz",
-      "integrity": "sha512-eYppBVqvhs5cvm33snW2sxfcw6G20/74RbBn+E4WDo15hozis89kU7ZCJDOPkXuag3v1h9igns/kM6PNBb41dw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.15.0.tgz",
+      "integrity": "sha512-cUbHPeG6kKpGBaEMgbTWeU03Y1Up5T3urGF+cgtrn80PmPYYSUPvVvWlZQWPb8CJZ1yQ0gySWo5RUTatBFrEHA==",
       "dependencies": {
-        "@sentry/types": "6.13.3",
-        "@sentry/utils": "6.13.3",
+        "@sentry/types": "6.15.0",
+        "@sentry/utils": "6.15.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -2174,12 +2174,12 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/minimal": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.13.3.tgz",
-      "integrity": "sha512-63MlYYRni3fs5Bh8XBAfVZ+ctDdWg0fapSTP1ydIC37fKvbE+5zhyUqwrEKBIiclEApg1VKX7bkKxVdu/vsFdw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.15.0.tgz",
+      "integrity": "sha512-7RJIvZsjBa1qFUfMrAzQsWdfZT6Gm4t6ZTYfkpsXPBA35hkzglKbBrhhsUvkxGIhUGw/PiCUqxBUjcmzQP0vfg==",
       "dependencies": {
-        "@sentry/hub": "6.13.3",
-        "@sentry/types": "6.13.3",
+        "@sentry/hub": "6.15.0",
+        "@sentry/types": "6.15.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -2192,15 +2192,15 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/node": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.13.3.tgz",
-      "integrity": "sha512-ZeZSw+TcPcf4e0j7iEqNMtoVmz+WFW/TEoGokXIwysZqSgchKdAXDHqn+CqUqFan7d76JcJmzztAUK2JruQ2Kg==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.15.0.tgz",
+      "integrity": "sha512-V1GeupWi9ClmoMy5eBWdVTv3k+Yx/JpddT4zCzzYY9QfjYtEvQI7R3SWFtlgXuaQQaZNU0WUoE2UgJV2N/vS8g==",
       "dependencies": {
-        "@sentry/core": "6.13.3",
-        "@sentry/hub": "6.13.3",
-        "@sentry/tracing": "6.13.3",
-        "@sentry/types": "6.13.3",
-        "@sentry/utils": "6.13.3",
+        "@sentry/core": "6.15.0",
+        "@sentry/hub": "6.15.0",
+        "@sentry/tracing": "6.15.0",
+        "@sentry/types": "6.15.0",
+        "@sentry/utils": "6.15.0",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -2216,14 +2216,14 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/tracing": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.13.3.tgz",
-      "integrity": "sha512-yyOFIhqlprPM0g4f35Icear3eZk2mwyYcGEzljJfY2iU6pJwj1lzia5PfSwiCW7jFGMmlBJNhOAIpfhlliZi8Q==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.15.0.tgz",
+      "integrity": "sha512-V5unvX8qNEfdawX+m2n0jKgmH/YR2ItWZLH+3UevBTptO+xyfvRtpgGXYWUCo3iGvFgWb1C+iIC7LViR9rTvBg==",
       "dependencies": {
-        "@sentry/hub": "6.13.3",
-        "@sentry/minimal": "6.13.3",
-        "@sentry/types": "6.13.3",
-        "@sentry/utils": "6.13.3",
+        "@sentry/hub": "6.15.0",
+        "@sentry/minimal": "6.15.0",
+        "@sentry/types": "6.15.0",
+        "@sentry/utils": "6.15.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -2236,19 +2236,19 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/types": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.13.3.tgz",
-      "integrity": "sha512-Vrz5CdhaTRSvCQjSyIFIaV9PodjAVFkzJkTRxyY7P77RcegMsRSsG1yzlvCtA99zG9+e6MfoJOgbOCwuZids5A==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.15.0.tgz",
+      "integrity": "sha512-zBw5gPUsofXUSpS3ZAXqRNedLRBvirl3sqkj2Lez7X2EkKRgn5D8m9fQIrig/X3TsKcXUpijDW5Buk5zeCVzJA==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.13.3.tgz",
-      "integrity": "sha512-zYFuFH3MaYtBZTeJ4Yajg7pDf0pM3MWs3+9k5my9Fd+eqNcl7dYQYJbT9gyC0HXK1QI4CAMNNlHNl4YXhF91ag==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.15.0.tgz",
+      "integrity": "sha512-gnhKKyFtnNmKWjDizo7VKD0/Vx8cgW1lCusM6WI7jy2jlO3bQA0+Dzgmr4mIReZ74mq4VpOd2Vfrx7ZldW1DMw==",
       "dependencies": {
-        "@sentry/types": "6.13.3",
+        "@sentry/types": "6.15.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -9938,14 +9938,14 @@
       }
     },
     "@sentry/core": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.13.3.tgz",
-      "integrity": "sha512-obm3SjgCk8A7nB37b2AU1eq1q7gMoJRrGMv9VRIyfcG0Wlz/5lJ9O3ohUk+YZaaVfZMxXn6hFtsBiOWmlv7IIA==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.15.0.tgz",
+      "integrity": "sha512-mCbKyqvD1G3Re6gv6N8tRkBz84gvVWDfLtC6d1WBArIopzter6ktEbvq0cMT6EOvGI2OLXuJ6mtHA93/Q0gGpw==",
       "requires": {
-        "@sentry/hub": "6.13.3",
-        "@sentry/minimal": "6.13.3",
-        "@sentry/types": "6.13.3",
-        "@sentry/utils": "6.13.3",
+        "@sentry/hub": "6.15.0",
+        "@sentry/minimal": "6.15.0",
+        "@sentry/types": "6.15.0",
+        "@sentry/utils": "6.15.0",
         "tslib": "^1.9.3"
       },
       "dependencies": {
@@ -9957,12 +9957,12 @@
       }
     },
     "@sentry/hub": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.13.3.tgz",
-      "integrity": "sha512-eYppBVqvhs5cvm33snW2sxfcw6G20/74RbBn+E4WDo15hozis89kU7ZCJDOPkXuag3v1h9igns/kM6PNBb41dw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.15.0.tgz",
+      "integrity": "sha512-cUbHPeG6kKpGBaEMgbTWeU03Y1Up5T3urGF+cgtrn80PmPYYSUPvVvWlZQWPb8CJZ1yQ0gySWo5RUTatBFrEHA==",
       "requires": {
-        "@sentry/types": "6.13.3",
-        "@sentry/utils": "6.13.3",
+        "@sentry/types": "6.15.0",
+        "@sentry/utils": "6.15.0",
         "tslib": "^1.9.3"
       },
       "dependencies": {
@@ -9974,12 +9974,12 @@
       }
     },
     "@sentry/minimal": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.13.3.tgz",
-      "integrity": "sha512-63MlYYRni3fs5Bh8XBAfVZ+ctDdWg0fapSTP1ydIC37fKvbE+5zhyUqwrEKBIiclEApg1VKX7bkKxVdu/vsFdw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.15.0.tgz",
+      "integrity": "sha512-7RJIvZsjBa1qFUfMrAzQsWdfZT6Gm4t6ZTYfkpsXPBA35hkzglKbBrhhsUvkxGIhUGw/PiCUqxBUjcmzQP0vfg==",
       "requires": {
-        "@sentry/hub": "6.13.3",
-        "@sentry/types": "6.13.3",
+        "@sentry/hub": "6.15.0",
+        "@sentry/types": "6.15.0",
         "tslib": "^1.9.3"
       },
       "dependencies": {
@@ -9991,15 +9991,15 @@
       }
     },
     "@sentry/node": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.13.3.tgz",
-      "integrity": "sha512-ZeZSw+TcPcf4e0j7iEqNMtoVmz+WFW/TEoGokXIwysZqSgchKdAXDHqn+CqUqFan7d76JcJmzztAUK2JruQ2Kg==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.15.0.tgz",
+      "integrity": "sha512-V1GeupWi9ClmoMy5eBWdVTv3k+Yx/JpddT4zCzzYY9QfjYtEvQI7R3SWFtlgXuaQQaZNU0WUoE2UgJV2N/vS8g==",
       "requires": {
-        "@sentry/core": "6.13.3",
-        "@sentry/hub": "6.13.3",
-        "@sentry/tracing": "6.13.3",
-        "@sentry/types": "6.13.3",
-        "@sentry/utils": "6.13.3",
+        "@sentry/core": "6.15.0",
+        "@sentry/hub": "6.15.0",
+        "@sentry/tracing": "6.15.0",
+        "@sentry/types": "6.15.0",
+        "@sentry/utils": "6.15.0",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -10014,14 +10014,14 @@
       }
     },
     "@sentry/tracing": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.13.3.tgz",
-      "integrity": "sha512-yyOFIhqlprPM0g4f35Icear3eZk2mwyYcGEzljJfY2iU6pJwj1lzia5PfSwiCW7jFGMmlBJNhOAIpfhlliZi8Q==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.15.0.tgz",
+      "integrity": "sha512-V5unvX8qNEfdawX+m2n0jKgmH/YR2ItWZLH+3UevBTptO+xyfvRtpgGXYWUCo3iGvFgWb1C+iIC7LViR9rTvBg==",
       "requires": {
-        "@sentry/hub": "6.13.3",
-        "@sentry/minimal": "6.13.3",
-        "@sentry/types": "6.13.3",
-        "@sentry/utils": "6.13.3",
+        "@sentry/hub": "6.15.0",
+        "@sentry/minimal": "6.15.0",
+        "@sentry/types": "6.15.0",
+        "@sentry/utils": "6.15.0",
         "tslib": "^1.9.3"
       },
       "dependencies": {
@@ -10033,16 +10033,16 @@
       }
     },
     "@sentry/types": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.13.3.tgz",
-      "integrity": "sha512-Vrz5CdhaTRSvCQjSyIFIaV9PodjAVFkzJkTRxyY7P77RcegMsRSsG1yzlvCtA99zG9+e6MfoJOgbOCwuZids5A=="
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.15.0.tgz",
+      "integrity": "sha512-zBw5gPUsofXUSpS3ZAXqRNedLRBvirl3sqkj2Lez7X2EkKRgn5D8m9fQIrig/X3TsKcXUpijDW5Buk5zeCVzJA=="
     },
     "@sentry/utils": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.13.3.tgz",
-      "integrity": "sha512-zYFuFH3MaYtBZTeJ4Yajg7pDf0pM3MWs3+9k5my9Fd+eqNcl7dYQYJbT9gyC0HXK1QI4CAMNNlHNl4YXhF91ag==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.15.0.tgz",
+      "integrity": "sha512-gnhKKyFtnNmKWjDizo7VKD0/Vx8cgW1lCusM6WI7jy2jlO3bQA0+Dzgmr4mIReZ74mq4VpOd2Vfrx7ZldW1DMw==",
       "requires": {
-        "@sentry/types": "6.13.3",
+        "@sentry/types": "6.15.0",
         "tslib": "^1.9.3"
       },
       "dependencies": {

--- a/loader/package.json
+++ b/loader/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.39.0",
-    "@sentry/node": "^6.13.3",
+    "@sentry/node": "^6.15.0",
     "csv-parse": "^4.16.3",
     "get-stream": "^6.0.1",
     "got": "^11.8.2",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@sentry/node": "^6.13.3",
-        "@sentry/tracing": "^6.13.3",
+        "@sentry/node": "^6.15.0",
+        "@sentry/tracing": "^6.15.0",
         "ajv": "^8.6.3",
         "ajv-formats": "^2.1.1",
         "ajv-keywords": "^5.0.0",
@@ -1187,14 +1187,14 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.13.3.tgz",
-      "integrity": "sha512-obm3SjgCk8A7nB37b2AU1eq1q7gMoJRrGMv9VRIyfcG0Wlz/5lJ9O3ohUk+YZaaVfZMxXn6hFtsBiOWmlv7IIA==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.15.0.tgz",
+      "integrity": "sha512-mCbKyqvD1G3Re6gv6N8tRkBz84gvVWDfLtC6d1WBArIopzter6ktEbvq0cMT6EOvGI2OLXuJ6mtHA93/Q0gGpw==",
       "dependencies": {
-        "@sentry/hub": "6.13.3",
-        "@sentry/minimal": "6.13.3",
-        "@sentry/types": "6.13.3",
-        "@sentry/utils": "6.13.3",
+        "@sentry/hub": "6.15.0",
+        "@sentry/minimal": "6.15.0",
+        "@sentry/types": "6.15.0",
+        "@sentry/utils": "6.15.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -1202,12 +1202,12 @@
       }
     },
     "node_modules/@sentry/hub": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.13.3.tgz",
-      "integrity": "sha512-eYppBVqvhs5cvm33snW2sxfcw6G20/74RbBn+E4WDo15hozis89kU7ZCJDOPkXuag3v1h9igns/kM6PNBb41dw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.15.0.tgz",
+      "integrity": "sha512-cUbHPeG6kKpGBaEMgbTWeU03Y1Up5T3urGF+cgtrn80PmPYYSUPvVvWlZQWPb8CJZ1yQ0gySWo5RUTatBFrEHA==",
       "dependencies": {
-        "@sentry/types": "6.13.3",
-        "@sentry/utils": "6.13.3",
+        "@sentry/types": "6.15.0",
+        "@sentry/utils": "6.15.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -1215,12 +1215,12 @@
       }
     },
     "node_modules/@sentry/minimal": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.13.3.tgz",
-      "integrity": "sha512-63MlYYRni3fs5Bh8XBAfVZ+ctDdWg0fapSTP1ydIC37fKvbE+5zhyUqwrEKBIiclEApg1VKX7bkKxVdu/vsFdw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.15.0.tgz",
+      "integrity": "sha512-7RJIvZsjBa1qFUfMrAzQsWdfZT6Gm4t6ZTYfkpsXPBA35hkzglKbBrhhsUvkxGIhUGw/PiCUqxBUjcmzQP0vfg==",
       "dependencies": {
-        "@sentry/hub": "6.13.3",
-        "@sentry/types": "6.13.3",
+        "@sentry/hub": "6.15.0",
+        "@sentry/types": "6.15.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -1228,15 +1228,15 @@
       }
     },
     "node_modules/@sentry/node": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.13.3.tgz",
-      "integrity": "sha512-ZeZSw+TcPcf4e0j7iEqNMtoVmz+WFW/TEoGokXIwysZqSgchKdAXDHqn+CqUqFan7d76JcJmzztAUK2JruQ2Kg==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.15.0.tgz",
+      "integrity": "sha512-V1GeupWi9ClmoMy5eBWdVTv3k+Yx/JpddT4zCzzYY9QfjYtEvQI7R3SWFtlgXuaQQaZNU0WUoE2UgJV2N/vS8g==",
       "dependencies": {
-        "@sentry/core": "6.13.3",
-        "@sentry/hub": "6.13.3",
-        "@sentry/tracing": "6.13.3",
-        "@sentry/types": "6.13.3",
-        "@sentry/utils": "6.13.3",
+        "@sentry/core": "6.15.0",
+        "@sentry/hub": "6.15.0",
+        "@sentry/tracing": "6.15.0",
+        "@sentry/types": "6.15.0",
+        "@sentry/utils": "6.15.0",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -1255,14 +1255,14 @@
       }
     },
     "node_modules/@sentry/tracing": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.13.3.tgz",
-      "integrity": "sha512-yyOFIhqlprPM0g4f35Icear3eZk2mwyYcGEzljJfY2iU6pJwj1lzia5PfSwiCW7jFGMmlBJNhOAIpfhlliZi8Q==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.15.0.tgz",
+      "integrity": "sha512-V5unvX8qNEfdawX+m2n0jKgmH/YR2ItWZLH+3UevBTptO+xyfvRtpgGXYWUCo3iGvFgWb1C+iIC7LViR9rTvBg==",
       "dependencies": {
-        "@sentry/hub": "6.13.3",
-        "@sentry/minimal": "6.13.3",
-        "@sentry/types": "6.13.3",
-        "@sentry/utils": "6.13.3",
+        "@sentry/hub": "6.15.0",
+        "@sentry/minimal": "6.15.0",
+        "@sentry/types": "6.15.0",
+        "@sentry/utils": "6.15.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -1270,19 +1270,19 @@
       }
     },
     "node_modules/@sentry/types": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.13.3.tgz",
-      "integrity": "sha512-Vrz5CdhaTRSvCQjSyIFIaV9PodjAVFkzJkTRxyY7P77RcegMsRSsG1yzlvCtA99zG9+e6MfoJOgbOCwuZids5A==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.15.0.tgz",
+      "integrity": "sha512-zBw5gPUsofXUSpS3ZAXqRNedLRBvirl3sqkj2Lez7X2EkKRgn5D8m9fQIrig/X3TsKcXUpijDW5Buk5zeCVzJA==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.13.3.tgz",
-      "integrity": "sha512-zYFuFH3MaYtBZTeJ4Yajg7pDf0pM3MWs3+9k5my9Fd+eqNcl7dYQYJbT9gyC0HXK1QI4CAMNNlHNl4YXhF91ag==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.15.0.tgz",
+      "integrity": "sha512-gnhKKyFtnNmKWjDizo7VKD0/Vx8cgW1lCusM6WI7jy2jlO3bQA0+Dzgmr4mIReZ74mq4VpOd2Vfrx7ZldW1DMw==",
       "dependencies": {
-        "@sentry/types": "6.13.3",
+        "@sentry/types": "6.15.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -9262,47 +9262,47 @@
       }
     },
     "@sentry/core": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.13.3.tgz",
-      "integrity": "sha512-obm3SjgCk8A7nB37b2AU1eq1q7gMoJRrGMv9VRIyfcG0Wlz/5lJ9O3ohUk+YZaaVfZMxXn6hFtsBiOWmlv7IIA==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.15.0.tgz",
+      "integrity": "sha512-mCbKyqvD1G3Re6gv6N8tRkBz84gvVWDfLtC6d1WBArIopzter6ktEbvq0cMT6EOvGI2OLXuJ6mtHA93/Q0gGpw==",
       "requires": {
-        "@sentry/hub": "6.13.3",
-        "@sentry/minimal": "6.13.3",
-        "@sentry/types": "6.13.3",
-        "@sentry/utils": "6.13.3",
+        "@sentry/hub": "6.15.0",
+        "@sentry/minimal": "6.15.0",
+        "@sentry/types": "6.15.0",
+        "@sentry/utils": "6.15.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.13.3.tgz",
-      "integrity": "sha512-eYppBVqvhs5cvm33snW2sxfcw6G20/74RbBn+E4WDo15hozis89kU7ZCJDOPkXuag3v1h9igns/kM6PNBb41dw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.15.0.tgz",
+      "integrity": "sha512-cUbHPeG6kKpGBaEMgbTWeU03Y1Up5T3urGF+cgtrn80PmPYYSUPvVvWlZQWPb8CJZ1yQ0gySWo5RUTatBFrEHA==",
       "requires": {
-        "@sentry/types": "6.13.3",
-        "@sentry/utils": "6.13.3",
+        "@sentry/types": "6.15.0",
+        "@sentry/utils": "6.15.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.13.3.tgz",
-      "integrity": "sha512-63MlYYRni3fs5Bh8XBAfVZ+ctDdWg0fapSTP1ydIC37fKvbE+5zhyUqwrEKBIiclEApg1VKX7bkKxVdu/vsFdw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.15.0.tgz",
+      "integrity": "sha512-7RJIvZsjBa1qFUfMrAzQsWdfZT6Gm4t6ZTYfkpsXPBA35hkzglKbBrhhsUvkxGIhUGw/PiCUqxBUjcmzQP0vfg==",
       "requires": {
-        "@sentry/hub": "6.13.3",
-        "@sentry/types": "6.13.3",
+        "@sentry/hub": "6.15.0",
+        "@sentry/types": "6.15.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/node": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.13.3.tgz",
-      "integrity": "sha512-ZeZSw+TcPcf4e0j7iEqNMtoVmz+WFW/TEoGokXIwysZqSgchKdAXDHqn+CqUqFan7d76JcJmzztAUK2JruQ2Kg==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.15.0.tgz",
+      "integrity": "sha512-V1GeupWi9ClmoMy5eBWdVTv3k+Yx/JpddT4zCzzYY9QfjYtEvQI7R3SWFtlgXuaQQaZNU0WUoE2UgJV2N/vS8g==",
       "requires": {
-        "@sentry/core": "6.13.3",
-        "@sentry/hub": "6.13.3",
-        "@sentry/tracing": "6.13.3",
-        "@sentry/types": "6.13.3",
-        "@sentry/utils": "6.13.3",
+        "@sentry/core": "6.15.0",
+        "@sentry/hub": "6.15.0",
+        "@sentry/tracing": "6.15.0",
+        "@sentry/types": "6.15.0",
+        "@sentry/utils": "6.15.0",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -9317,28 +9317,28 @@
       }
     },
     "@sentry/tracing": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.13.3.tgz",
-      "integrity": "sha512-yyOFIhqlprPM0g4f35Icear3eZk2mwyYcGEzljJfY2iU6pJwj1lzia5PfSwiCW7jFGMmlBJNhOAIpfhlliZi8Q==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.15.0.tgz",
+      "integrity": "sha512-V5unvX8qNEfdawX+m2n0jKgmH/YR2ItWZLH+3UevBTptO+xyfvRtpgGXYWUCo3iGvFgWb1C+iIC7LViR9rTvBg==",
       "requires": {
-        "@sentry/hub": "6.13.3",
-        "@sentry/minimal": "6.13.3",
-        "@sentry/types": "6.13.3",
-        "@sentry/utils": "6.13.3",
+        "@sentry/hub": "6.15.0",
+        "@sentry/minimal": "6.15.0",
+        "@sentry/types": "6.15.0",
+        "@sentry/utils": "6.15.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.13.3.tgz",
-      "integrity": "sha512-Vrz5CdhaTRSvCQjSyIFIaV9PodjAVFkzJkTRxyY7P77RcegMsRSsG1yzlvCtA99zG9+e6MfoJOgbOCwuZids5A=="
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.15.0.tgz",
+      "integrity": "sha512-zBw5gPUsofXUSpS3ZAXqRNedLRBvirl3sqkj2Lez7X2EkKRgn5D8m9fQIrig/X3TsKcXUpijDW5Buk5zeCVzJA=="
     },
     "@sentry/utils": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.13.3.tgz",
-      "integrity": "sha512-zYFuFH3MaYtBZTeJ4Yajg7pDf0pM3MWs3+9k5my9Fd+eqNcl7dYQYJbT9gyC0HXK1QI4CAMNNlHNl4YXhF91ag==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.15.0.tgz",
+      "integrity": "sha512-gnhKKyFtnNmKWjDizo7VKD0/Vx8cgW1lCusM6WI7jy2jlO3bQA0+Dzgmr4mIReZ74mq4VpOd2Vfrx7ZldW1DMw==",
       "requires": {
-        "@sentry/types": "6.13.3",
+        "@sentry/types": "6.15.0",
         "tslib": "^1.9.3"
       }
     },

--- a/server/package.json
+++ b/server/package.json
@@ -31,8 +31,8 @@
     "lint": "eslint --ext .js,.ts ."
   },
   "dependencies": {
-    "@sentry/node": "^6.13.3",
-    "@sentry/tracing": "^6.13.3",
+    "@sentry/node": "^6.15.0",
+    "@sentry/tracing": "^6.15.0",
     "ajv": "^8.6.3",
     "ajv-formats": "^2.1.1",
     "ajv-keywords": "^5.0.0",


### PR DESCRIPTION
Just what it says on the tin. This supersedes #478 and #479.