### PR TITLE
Handle Albertsons "Castle Pines Vaccine Center"

### DIFF
--- a/loader/src/sources/albertsons/index.js
+++ b/loader/src/sources/albertsons/index.js
@@ -187,7 +187,7 @@ const BRANDS = [
     key: "community_clinic",
     name: "Community Clinic",
     locationType: LocationType.clinic,
-    pattern: /Recreation Center/i,
+    pattern: /(Recreation Center|Vaccine Center)/i,
   },
 ];
 


### PR DESCRIPTION
Albertsons added another community clinic with a distinctly different name. This updates our matcher to handle it.