### PR TITLE
Match Albertsons community clinics generically

### DIFF
--- a/loader/src/sources/albertsons/index.js
+++ b/loader/src/sources/albertsons/index.js
@@ -180,14 +180,17 @@ const BRANDS = [
     pattern: /Corporate Office/i,
   },
   // Albertsons is now operating some clinics outside its actual stores, and
-  // this is meant to cover those. The `pattern` may need updating over time to
-  // reflect the variety of location names we might see.
+  // this is meant to cover those. The names don't follow any real pattern, so
+  // we do our best by matching anything that doesn't look like some words
+  // followed by a number (since that usually indicates a store of some sort).
   {
     ...BASE_BRAND,
     key: "community_clinic",
     name: "Community Clinic",
     locationType: LocationType.clinic,
-    pattern: /(Recreation Center|Vaccine Center)/i,
+    pattern: {
+      test: (name) => !/\w+\s+#?\d+$/.test(name),
+    },
   },
 ];
 

--- a/loader/test/albertsons.test.js
+++ b/loader/test/albertsons.test.js
@@ -406,6 +406,32 @@ describe("Albertsons", () => {
     );
   });
 
+  it("does not output locations that don't match a known brand", async () => {
+    nock(API_URL_BASE)
+      .get(API_URL_PATH)
+      .query(true)
+      .reply(
+        200,
+        [
+          {
+            id: "1637101034326",
+            region: "Eastern_-_6",
+            address:
+              "Some unknown store #8134 - 7315 Famous Ave., Nowhere, MD, 20912",
+            lat: "38.98247194054162",
+            long: "-76.9879339600021",
+            coach_url: "https://kordinator.mhealthcoach.net/vcl/1637101034326",
+            availability: "yes",
+            drugName: ["PfizerChild"],
+          },
+        ],
+        { "Last-Modified": "Thu, 28 Oct 2021 07:06:13 GMT" }
+      );
+
+    const result = await checkAvailability(() => {}, { states: "MD" });
+    expect(result).toHaveLength(0);
+  });
+
   it("should throw an error when HTTP requests fail", async () => {
     nock(API_URL_BASE).post(API_URL_PATH).reply(500, {
       errors: "Oh no!",


### PR DESCRIPTION
A few more community clinics popped up today, and I realized a better approach might be to match anything that doesn't look like `Some name ###`, since that is the pattern all the other brands follow. This will hopefully alert us if a new store chain shows up, but treat other things as community clinics.