### PR TITLE
Albertsons name delimiters are definitely entered by hand

### DIFF
--- a/loader/src/sources/albertsons/index.js
+++ b/loader/src/sources/albertsons/index.js
@@ -24,6 +24,7 @@ const {
   httpClient,
   parseUsAddress,
   getUniqueExternalIds,
+  unpadNumber,
 } = require("../../utils");
 const {
   Available,
@@ -252,7 +253,7 @@ async function getData(states) {
     const storeId = location.external_ids.find(
       (id) => id[0] === "albertsons_store_number"
     );
-    return storeId ? storeId[1] : location.name;
+    return storeId ? unpadNumber(storeId[1]) : location.name;
   });
 
   return Object.values(groups)

--- a/loader/src/sources/albertsons/index.js
+++ b/loader/src/sources/albertsons/index.js
@@ -300,7 +300,7 @@ async function getData(states) {
     .filter(Boolean);
 }
 
-const addressFieldParts = /^\s*(?<name>.+?)\s+-\s+(?<address>.+)$/;
+const addressFieldParts = /^\s*(?<name>.+?)\s*-\s+(?<address>.+)$/;
 const pediatricPrefixParts = /^(?<pediatric>Pfizer Child\s*-\s*)?(?<body>.*)$/i;
 
 /**

--- a/loader/src/sources/albertsons/index.js
+++ b/loader/src/sources/albertsons/index.js
@@ -316,7 +316,7 @@ function parseNameAndAddress(text) {
 
   const partMatch = body.match(addressFieldParts);
   if (!partMatch) {
-    throw new ParseError(`Could not separate name and address in "${address}"`);
+    throw new ParseError(`Could not separate name and address in "${body}"`);
   }
   let { name, address } = partMatch.groups;
 
@@ -452,5 +452,6 @@ async function checkAvailability(handler, options) {
 
 module.exports = {
   checkAvailability,
+  formatLocation,
   API_URL,
 };

--- a/loader/test/albertsons.test.js
+++ b/loader/test/albertsons.test.js
@@ -1,8 +1,13 @@
 const nock = require("nock");
-const { API_URL, checkAvailability } = require("../src/sources/albertsons");
+const {
+  API_URL,
+  checkAvailability,
+  formatLocation,
+} = require("../src/sources/albertsons");
 const { Available } = require("../src/model");
 const { expectDatetimeString, splitHostAndPath } = require("./support");
 const { locationSchema } = require("./support/schemas");
+const { ParseError } = require("../src/exceptions");
 
 const [API_URL_BASE, API_URL_PATH] = splitHostAndPath(API_URL);
 
@@ -442,5 +447,20 @@ describe("Albertsons", () => {
       (error) => error
     );
     expect(error).toBeInstanceOf(Error);
+  });
+
+  it("errors when formatting locations with a name and address that can't be separated", () => {
+    expect(() => {
+      formatLocation({
+        id: "1637101034326",
+        region: "Eastern_-_6",
+        address: "Something 7315 Famous Ave., Nowhere, MD, 20912",
+        lat: "38.98247194054162",
+        long: "-76.9879339600021",
+        coach_url: "https://kordinator.mhealthcoach.net/vcl/1637101034326",
+        availability: "yes",
+        drugName: ["PfizerChild"],
+      });
+    }).toThrow(ParseError);
   });
 });


### PR DESCRIPTION
This fixes an error while attempting to throw an error (ha!) that was captured here: https://sentry.io/organizations/usdr/issues/2830164846

And improves parsing to handle the source data that was causing it: a location in Idaha is missing a space before the dash that delimits the name from the address.

```
Albertsons 169- 909 E. Parkcenter Blvd., Boise, ID, 83706
```

It also groups by *unpadded* store number (instead of padded), since it turns out this problematic location is the accompanying pediatric version of another non-pediatric location with a padded store number.