### PR TITLE
Alaska has shingles (vaccines)

### DIFF
--- a/loader/src/sources/prepmod/index.js
+++ b/loader/src/sources/prepmod/index.js
@@ -168,6 +168,13 @@ function formatLocationBookingUrl(host, location) {
   return bookingUrlData.href;
 }
 
+// PrepMod is used lots of public health clinics that provide other, non-COVID
+// services. This pattern matches non-COVID-vaccines that we expect to find so
+// we know they aren't an error.
+// - Flu/Influenza vaccines
+// - Zoster (shingles) vaccines
+const nonCovidProductName = /^influenza|flu|zoster/i;
+
 function formatSlots(smartSlots) {
   let available = Available.no;
   const slots = smartSlots.map((smartSlot) => {
@@ -211,7 +218,7 @@ function formatSlots(smartSlots) {
           }
           if (product) {
             products.add(product);
-          } else if (!/^influenza|flu/i.test(extension.valueCoding.display)) {
+          } else if (!nonCovidProductName.test(extension.valueCoding.display)) {
             warn(`Unparseable product extension: ${JSON.stringify(extension)}`);
           }
         } else if (extension.url === EXTENSIONS.DOSE) {

--- a/loader/src/sources/prepmod/index.js
+++ b/loader/src/sources/prepmod/index.js
@@ -191,10 +191,8 @@ const nonCovidProductName = /^influenza|flu|zoster/i;
  * @returns {{isCovid: boolean, hasNonCovidProducts: boolean, products: Set<string>, doses: Set<string>}}
  */
 function parseSchedule(schedule) {
-  let doses = new Set();
+  const doses = new Set();
   const data = {
-    // We only got here if the schedule claimed to be for COVID, but we may
-    // modify this if it turns out to have only non-covid prdoucts.
     isCovid: true,
     hasNonCovidProducts: false,
     products: new Set(),

--- a/loader/test/prepmod.test.js
+++ b/loader/test/prepmod.test.js
@@ -683,6 +683,32 @@ describe("PrepMod API", () => {
     ]);
   });
 
+  it("does not include shingles (zoster) vaccines", async () => {
+    const testLocation = createSmartLocation({
+      schedules: [
+        {
+          extension: [
+            {
+              url: EXTENSIONS.PRODUCT,
+              valueCoding: {
+                system: "http://hl7.org/fhir/sid/cvx",
+                code: null,
+                display: "Zoster, recombinant",
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = formatLocation(
+      "https://myhealth.alaska.gov",
+      new Date(),
+      testLocation
+    );
+    expect(result).toBeNull();
+  });
+
   it("hides locations not in the API response when --hide-missing-locations is set", async () => {
     const testLocation = createSmartLocation({ id: "abc123" });
     // A UNIVAF-formatted location that matches the above SMART SL data.


### PR DESCRIPTION
This got a lot more complex than expected. Alaska is now including a shingles (zoster) vaccine in PrepMod, so we need to treat it like flu vaccines and ignore it.

While writing a test for that, I realized we weren’t correctly handling locations that only had non-COVID vaccines — we’d still include them, and set `availability` based on the non-COVID slots rather than COVID slots! That’s obviously pretty wrong. So this does a little bit of refactoring to determine whether a schedule is not actually a COVID schedule and skip over it (and its slots) if not, and drop the location if all its schedules are non-COVID ones.