### PR TITLE
Don't include "Adenovirus" vaccines in PrepMod

### DIFF
--- a/loader/src/sources/prepmod/index.js
+++ b/loader/src/sources/prepmod/index.js
@@ -183,7 +183,10 @@ function formatLocationBookingUrl(host, location) {
 // we know they aren't an error.
 // - Flu/Influenza vaccines
 // - Zoster (shingles) vaccines
-const nonCovidProductName = /^influenza|flu|zoster/i;
+// - Adenovirus vaccines (This one has a narrower definition to make sure we
+//   are only matching vaccines against adenovirus, not ones that might be using
+//   modified adenovirus as a vaccine against COVID or other things.)
+const nonCovidProductName = /^influenza|flu|zoster|^\s*adenovirus\s*$/i;
 
 /**
  * Parse useful data about a schedule.


### PR DESCRIPTION
The PrepMod API in Alaska is now surfacing vaccines for "Adenovirus." Based on context, these appear to be vaccines *agains* Adenovirus, not vaccines *using* Adenovirus as a delivery mechanism, so we should be OK to ignore them. Fixes https://sentry.io/organizations/usdr/issues/2876457061.