### PR TITLE
Albertsons data just gets funkier and funkier

### DIFF
--- a/loader/src/sources/albertsons/corrections.js
+++ b/loader/src/sources/albertsons/corrections.js
@@ -1,0 +1,10 @@
+/**
+ * Manual corrections for misformatted/bad source data. The keys are the `id`
+ * property for the location, and the value is any properties that should be
+ * overridden.
+ */
+module.exports.corrections = {
+  1641420736546: {
+    address: "Jewel-Osco 3441 - 2940 N Ashland Ave, Chicago, IL, 60657",
+  },
+};

--- a/loader/src/sources/albertsons/index.js
+++ b/loader/src/sources/albertsons/index.js
@@ -33,6 +33,7 @@ const {
   PediatricVaccineProducts,
 } = require("../../model");
 const { ParseError } = require("../../exceptions");
+const { corrections } = require("./corrections");
 
 const API_URL =
   "https://s3-us-west-2.amazonaws.com/mhc.cdn.content/vaccineAvailability.json";
@@ -374,6 +375,11 @@ function formatProducts(raw) {
 }
 
 function formatLocation(data, validAt, checkedAt) {
+  // Apply corrections for known-bad source data.
+  if (data.id in corrections) {
+    Object.assign(data, corrections[data.id]);
+  }
+
   let { name, storeNumber, storeBrand, address, isPediatric } =
     parseNameAndAddress(data.address);
   if (!storeBrand) {

--- a/loader/src/utils.js
+++ b/loader/src/utils.js
@@ -218,7 +218,15 @@ module.exports = {
    */
   parseUsAddress(address) {
     const match = address.match(ADDRESS_PATTERN);
-    if (!match) {
+
+    // Detect whether we have something formatted like an address, but with
+    // obviously incorrect street/city/zip data, e.g. "., ., CA 90210".
+    const invalidMatch =
+      !match ||
+      match[1].replace(PUNCTUATION_PATTERN, "") === "" ||
+      match[2].replace(PUNCTUATION_PATTERN, "") === "" ||
+      match[4].replace(PUNCTUATION_PATTERN, "") === "";
+    if (invalidMatch) {
       throw new ParseError(`Could not parse address: "${address}"`);
     }
 

--- a/loader/test/utils.test.js
+++ b/loader/test/utils.test.js
@@ -1,10 +1,12 @@
 const nock = require("nock");
+const { ParseError } = require("../src/exceptions");
 const {
   httpClient,
   splitOnce,
   filterObject,
   unpadNumber,
   getUniqueExternalIds,
+  parseUsAddress,
   RateLimit,
 } = require("../src/utils");
 
@@ -127,5 +129,29 @@ describe("RateLimit", () => {
     expect(callTimes[1] - callTimes[0]).toBeLessThan(1050);
     expect(callTimes[2] - callTimes[1]).toBeGreaterThanOrEqual(1000);
     expect(callTimes[2] - callTimes[1]).toBeLessThan(1050);
+  });
+});
+
+describe("parseUsAddress", () => {
+  it("Parses simple addresses", () => {
+    const parsed = parseUsAddress("3524 Somewhere St., Nowhere, NV 90210");
+    expect(parsed).toEqual({
+      lines: ["3524 Somewhere St."],
+      city: "Nowhere",
+      state: "NV",
+      zip: "90210",
+    });
+  });
+
+  it("Throws on invalid addresses", () => {
+    expect(() => {
+      parseUsAddress("Not an address or address-like string");
+    }).toThrow(ParseError);
+  });
+
+  it("Throws on invalid addresses that are structured like addresses", () => {
+    expect(() => {
+      parseUsAddress("., ., TX, 75244");
+    }).toThrow(ParseError);
   });
 });


### PR DESCRIPTION
This makes two changes to resolve issues in Albertsons data right now:

1. Skip over locations with obviously invalid addresses (e.g. `., ., TX 75244`). There are two of these right now, and they currently parse “successfully” because they have an address-like structure. I’m betting they don’t refer to an actual location (the name for both of them is “Dallas ISD” which is probably the Dallas Independent School District), and if someone tried to book them, it’s not really clear where they would actually go (clicking through to the booking screen doesn’t provide any more useful information to clarify what or where this location is supposed to be). This will still emit warnings for bad addresses, but at least we won’t surface them in final data, and the issue is clearer.

2. Add manual corrections for a Jewel-Osco location (and a framework for future corrections). This location doesn’t have correct-enough data to “fix” it algorithmically like we do in some other locations (e.g. with repeated store names). Supporting manual corrections was the best I could think of here.

Fixes these two issues in Sentry right now:
- https://sentry.io/organizations/usdr/issues/2829716008 (1 above — different locations getting conflated because of bad addresses)
- https://sentry.io/organizations/usdr/issues/2809052505 (2 above — manual corrections)