### PR TITLE
Fix error for Safeways named "Peds" in Albertsons

### DIFF
--- a/loader/src/sources/albertsons/corrections.js
+++ b/loader/src/sources/albertsons/corrections.js
@@ -7,4 +7,14 @@ module.exports.corrections = {
   1641420736546: {
     address: "Jewel-Osco 3441 - 2940 N Ashland Ave, Chicago, IL, 60657",
   },
+
+  // Some Safeways have their pediatric vaccines listed as "Peds" instead of
+  // "Safeway". Not sure it's safe to always assume Safeway is the right fix,
+  // though, so we are doing manual corrections for each one.
+  1635962942932: {
+    address: "Safeway 2624 - 3602 W. 144th Ave., Broomfield, CO, 80023",
+  },
+  1635956505599: {
+    address: "Safeway 1614 - 560 Corona Street, Denver, CO, 80218",
+  },
 };


### PR DESCRIPTION
Two Safeway locations recently started showing up with their pediatric listing using "Peds" where we'd normally have a store brand name. For example, instead of this:

    Safeway 2624 - 3602 W. 144th Ave., Broomfield, CO, 80023

We are seeing:

    Peds 2624 - 3602 W. 144th Ave., Broomfield, CO, 80023

It looks like someone lazily put in “peds” as short for “Pediatrics” in the store name. This uses manual corrections to handle the problem, since I'm wary of assuming that this will only ever happened for Safeway and not for other Albertsons brands.

Fixes https://sentry.io/organizations/usdr/issues/2809052505