### PR TITLE
Handle new duplicate Walmart/Sam’s Club entries from CDC gracefully

### DIFF
--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -171,7 +171,8 @@ function formatStore(storeItems, checkedAt) {
 }
 
 /**
- * Get a simplistic, numeric or VTrckS-style location external ID value.
+ * Get a simplistic, numeric location external ID value that should be a store
+ * number for whatever chain a location belongs to.
  */
 function getSimpleId(location) {
   // Handle numeric store numbers

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -74,7 +74,7 @@ async function* queryState(state) {
   }
 }
 
-function formatStore(storeItems) {
+function formatStore(storeItems, checkedAt) {
   if (storeItems.length == 0) {
     return null;
   }
@@ -148,7 +148,7 @@ function formatStore(storeItems) {
 
       availability: {
         source: "cdc",
-        checked_at: new Date().toISOString(),
+        checked_at: checkedAt,
         valid_at: formatValidAt(productList),
         available: formatAvailable(productList),
         products: formatProductTypes(productList),
@@ -460,6 +460,7 @@ async function checkAvailability(handler, options) {
     return [];
   }
 
+  const checkedAt = new Date().toISOString();
   let results = [];
   for (const state of states) {
     const entriesByStoreId = {};
@@ -472,7 +473,7 @@ async function checkAvailability(handler, options) {
 
     const stores = Object.values(entriesByStoreId);
     const formatted = stores
-      .map(formatStore)
+      .map((store) => formatStore(store, checkedAt))
       .filter(Boolean)
       .map(markUnexpectedCvsIds);
 

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -528,4 +528,5 @@ module.exports = {
   API_PATH,
   checkAvailability,
   queryState,
+  formatStore,
 };

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -194,6 +194,16 @@ function getWalmartId(location) {
   if (location.loc_store_no.startsWith("10-")) {
     return location.loc_store_no.slice(3);
   }
+
+  // When the number is not in loc_store_no, it is usually formatted as a normal
+  // store number in the name (i.e. "NNN" instead of "10-NNN").
+  const numberInName = location.loc_name.match(
+    /^(?:Walmart|Sam['\u2019]?s Club) .* #?(\d+)$/i
+  );
+  if (numberInName) {
+    return numberInName[1];
+  }
+
   warn("Unexpected Walmart/Sams ID format", {
     id: location.provider_location_guid,
     storeNumber: location.loc_store_no,

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -193,7 +193,7 @@ function getSimpleId(location) {
 // number. ¯\_(ツ)_/¯
 function getWalmartId(location) {
   if (location.loc_store_no.startsWith("10-")) {
-    return location.loc_store_no.slice(3);
+    return unpadNumber(location.loc_store_no.slice(3));
   }
 
   // When the number is not in loc_store_no, it is usually formatted as a normal
@@ -202,7 +202,7 @@ function getWalmartId(location) {
     /^(?:Walmart|Sam['\u2019]?s Club) .* #?(\d+)$/i
   );
   if (numberInName) {
-    return numberInName[1];
+    return unpadNumber(numberInName[1]);
   }
 
   warn("Unexpected Walmart/Sams ID format", {

--- a/loader/src/sources/njvss/index.js
+++ b/loader/src/sources/njvss/index.js
@@ -1,5 +1,5 @@
 const { Available, LocationType, VaccineProduct } = require("../../model");
-const { parseUsAddress } = require("../../utils");
+const { parseUsAddress, unpadNumber } = require("../../utils");
 const crypto = require("crypto");
 const csvParse = require("csv-parse/lib/sync");
 const getStream = require("get-stream");
@@ -466,15 +466,16 @@ async function checkAvailability(handler, _options) {
     const walmartMatch = location.name.match(walmartPattern);
     if (walmartMatch) {
       location_type = LocationType.pharmacy;
+      const storeNumber = unpadNumber(walmartMatch.groups.storeId);
 
       if (walmartMatch.groups.sams) {
-        external_ids.sams_club = walmartMatch.groups.storeId;
+        external_ids.sams_club = storeNumber;
         provider = PROVIDER.sams;
-        name = `Sam’s Club #${walmartMatch.groups.storeId}`;
+        name = `Sam’s Club #${storeNumber}`;
       } else {
-        external_ids.walmart = walmartMatch.groups.storeId;
+        external_ids.walmart = storeNumber;
         provider = PROVIDER.walmart;
-        name = `Walmart #${walmartMatch.groups.storeId}`;
+        name = `Walmart #${storeNumber}`;
       }
     }
 

--- a/loader/test/cdc.api.test.js
+++ b/loader/test/cdc.api.test.js
@@ -5,6 +5,7 @@ const {
   API_HOST,
   API_PATH,
   checkAvailability,
+  formatStore,
 } = require("../src/sources/cdc/api");
 const { Available } = require("../src/model");
 const { locationSchema } = require("./support/schemas");
@@ -94,5 +95,36 @@ describe("CDC Open Data API", () => {
       Available.unknown
     );
     expect(locations).toContainItemsMatchingSchema(locationSchema);
+  });
+
+  it("supports Walmart data with no `loc_store_no`", () => {
+    const formatted = formatStore(
+      [
+        {
+          provider_location_guid: "fe474d63-41c6-4587-a80b-d8463b8973fa",
+          loc_store_no: "Not applicable",
+          loc_phone: "713-461-2915",
+          loc_name: "Walmart Pharmacy 148",
+          loc_admin_street1: "3855 Lamar Ave",
+          loc_admin_city: "Paris",
+          loc_admin_state: "TX",
+          loc_admin_zip: "75462",
+          ndc: "59267-1000-01",
+          med_name: "Pfizer-BioNTech, COVID-19 Vaccine, 30 mcg/0.3mL",
+          in_stock: false,
+          supply_level: "0",
+          quantity_last_updated: "2022-01-09",
+          latitude: "33.664697",
+          longitude: "-95.505641",
+          category: "covid",
+        },
+      ],
+      new Date()
+    );
+
+    expect(formatted).toHaveProperty("external_ids", [
+      ["vaccines_gov", "fe474d63-41c6-4587-a80b-d8463b8973fa"],
+      ["walmart", "148"],
+    ]);
   });
 });

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -549,15 +549,19 @@ export async function getCurrentAvailabilityByLocation(
 }
 
 /**
- * Updates a given location's availability. If either `checked_at` or `valid_at`
- * are not the same or newer than an existing availibility record for the given
+ * Updates a given location's availability. If neither `checked_at` nor
+ * `valid_at` are newer than an existing availibility record for the given
  * location and source, this will throw `OutOfDateError`.
  *
- * Updates with the same `checked_at` but newer `valid_at` times will succeed
- * (this accomodates sources that may surface multiple records for the same
- * location, but with different valid times). Updates with newer `checked_at`
- * but the same `valid_at` are OK. If *both* `checked_at` and `valid_at` are
- * unchanged, the update will fail.
+ * Specifically:
+ * - Updates with newer `checked_at` but the same `valid_at` are OK. This
+ *   indicates the source was checked, but it hadn't been updated since the last
+ *   check.
+ * - Updates with the same `checked_at` but newer `valid_at` times are also OK.
+ *   This accomodates sources that may surface multiple records for the same
+ *   location, but with different valid times.
+ * - If *both* `checked_at` and `valid_at` are unchanged or if they are older,
+ *   the update will fail.
  * @param id
  * @param availability
  * @returns


### PR DESCRIPTION
Over the weekend, the CDC’s open data on vaccine stock started surfacing duplicate locations for 113+ Walmarts and Sam’s Clubs. We previously saw locations with a `loc_store_no` like `10-NNN`, but are now seeing locations witha `loc_store_no` of `Not applicable`, but a parseable store number is in the name, and that store number is in the format `NNN` (i.e. no `10-` prefix).

Unfortunately, it’s not that the formatting *changed*, just that it’s different, and there are now many stores with two different `provider_location_guid` values for the same actual store (where each GUID has one of the two above formats). This handles the issue by making two major changes:

1. Makes these new store formats parseable in the CDC source.
2. Adjusts the server to allow multiple availability updates for the same `checked_at` time, as long as they have newer `valid_at` times. That way, both records from the CDC data can be sent, and the newest one will wind up winning, regardless of which order they arrived in. (This also adjusts the source so it assigns the same `checked_at` time for every row, which is probably more correct anyhow.)

I originally started writing a deduping routine that is basically the same as in our [`remove-duplicate-locations` script](https://github.com/usdigitalresponse/univaf/blob/378cec39f955858c6b9300cefeb2db249ff5d977/server/scripts/remove-duplicate-locations.js), until I realized a) I was effectively duplicating that code, and b) it was probably simpler to handle this in the server. The server change still makes things a little complicated… but at least it has the side-benefit of sending less data to Postgres when it’s not needed, which should be a performance and load improvement.

Fixes https://sentry.io/organizations/usdr/issues/2771670374