### PR TITLE
Send/store unpadded store numbers for Albertsons

### DIFF
--- a/loader/src/sources/albertsons/index.js
+++ b/loader/src/sources/albertsons/index.js
@@ -254,7 +254,7 @@ async function getData(states) {
     const storeId = location.external_ids.find(
       (id) => id[0] === "albertsons_store_number"
     );
-    return storeId ? unpadNumber(storeId[1]) : location.name;
+    return storeId?.[1] ?? location.name;
   });
 
   return Object.values(groups)
@@ -329,7 +329,7 @@ function parseNameAndAddress(text) {
   );
   let storeNumber;
   if (numberMatch) {
-    storeNumber = numberMatch.groups.number;
+    storeNumber = unpadNumber(numberMatch.groups.number);
     name = `${numberMatch.groups.name} ${storeNumber}`;
   }
 

--- a/loader/test/albertsons.test.js
+++ b/loader/test/albertsons.test.js
@@ -263,12 +263,12 @@ describe("Albertsons", () => {
     expect(result).toContainItemsMatchingSchema(locationSchema);
     expect(result).toEqual([
       {
-        name: "Safeway 0005",
+        name: "Safeway 5",
         external_ids: [
           ["albertsons", "1635993536219"],
           ["albertsons_safeway", "1635993536219"],
-          ["safeway", "0005"],
-          ["albertsons_store_number", "safeway:0005"],
+          ["safeway", "5"],
+          ["albertsons_store_number", "safeway:5"],
           ["albertsons", "1600100807144"],
           ["albertsons_safeway", "1600100807144"],
         ],


### PR DESCRIPTION
While cleaning up duplicate Walmarts in #519, I discovered some duplicate zero-padded/unpadded Albertsons that appear to have been caused by us not unpadding external IDs we send from the Albertsons loader (it turns out some entries are zero-padded and some not, and sometimes the pediatric and non-pediatric entries for the same location have different padding).