### PR TITLE
Change how Albertsons locations qualify as pediatric

### DIFF
--- a/loader/src/sources/albertsons/index.js
+++ b/loader/src/sources/albertsons/index.js
@@ -21,6 +21,7 @@ const Sentry = require("@sentry/node");
 const { groupBy } = require("lodash");
 const { DateTime } = require("luxon");
 const {
+  createWarningLogger,
   httpClient,
   parseUsAddress,
   getUniqueExternalIds,
@@ -196,15 +197,7 @@ const BRANDS = [
   },
 ];
 
-function warn(message, context) {
-  console.warn(`Albertsons: ${message}`, context || "");
-  // Sentry does better fingerprinting with an actual exception object.
-  if (message instanceof Error) {
-    Sentry.captureException(message, { level: Sentry.Severity.Info });
-  } else {
-    Sentry.captureMessage(message, Sentry.Severity.Info);
-  }
-}
+const warn = createWarningLogger("Albertsons");
 
 async function fetchRawData() {
   const response = await httpClient(API_URL, {

--- a/loader/src/sources/albertsons/index.js
+++ b/loader/src/sources/albertsons/index.js
@@ -385,8 +385,7 @@ function formatLocation(data, validAt, checkedAt) {
   const products = formatProducts(data.drugName);
   isPediatric =
     isPediatric ||
-    (products?.length &&
-      products.every((p) => PediatricVaccineProducts.has(p)));
+    (products?.length && products.some((p) => PediatricVaccineProducts.has(p)));
 
   const external_ids = [
     ["albertsons", data.id],

--- a/loader/src/utils.js
+++ b/loader/src/utils.js
@@ -1,3 +1,4 @@
+const nodeUtil = require("util");
 const Sentry = require("@sentry/node");
 const got = require("got");
 const config = require("./config");
@@ -326,7 +327,10 @@ module.exports = {
 
   createWarningLogger(prefix) {
     return function warn(message, context) {
-      console.warn(`${prefix}: ${message}`, context);
+      console.warn(
+        `${prefix}: ${message}`,
+        context !== undefined ? nodeUtil.inspect(context, { depth: 8 }) : ""
+      );
       // Sentry does better fingerprinting with an actual exception object.
       if (message instanceof Error) {
         Sentry.captureException(message, { level: Sentry.Severity.Info });


### PR DESCRIPTION
Albertsons has a system where pediatric and non-pediatric bookings are sometimes separate entries/URLs. Since they represent the same location, We try and merge these, and to sanity check, we stop and warn if we are trying to merge two adult or two pediatric locations.

However, we've been getting a lot of these warnings intermittently, and the core of the problem really seems to be that, in contrast to when pediatric vaccines first showed up, many pediatric entries now list *both* adult and pediatric vaccines, alongside another entry that is adult-only. This fixes the warnings by classifying a location as pediatric if *some* of the vaccines are pediatric, instead of only if *all* are.

While I was at it, I also added some depth to the logging about this situation, since the actual vaccine types were always getting elided in the logs.

Fixes https://sentry.io/organizations/usdr/issues/2829716008