### PR TITLE
Add a whole bunch more exceptions and exception logic to Albertsons

### DIFF
--- a/loader/src/sources/albertsons/corrections.js
+++ b/loader/src/sources/albertsons/corrections.js
@@ -13,6 +13,82 @@ module.exports.corrections = {
   1641421349223: {
     address: "Jewel-Osco 3429 - 8730 W Dempster St, Niles, IL, 60714",
   },
+  1642014209365: {
+    address: "Jewel-Osco 4057 - 10203 W Grand Ave, Franklin Park, IL, 60131",
+    description:
+      "Ages 5-11 Instore Pediatric COVID Vaccination Event. This is held within Jewel-Osco.",
+  },
+  1641421916487: {
+    address:
+      "Jewel-Osco 3461 - 1860 S. Arlington Heights Rd., Arlington Heights, IL, 60005",
+    description:
+      "Ages 5-11 Instore Pediatric COVID Vaccination Event. This is held within Jewel-Osco.",
+  },
+  1636035919071: {
+    address: "Safeway #4002 - 5727 Burke Ctr, Burke, VA, 22015",
+  },
+  1636072576751: {
+    address: "Vons 2071 - 2250 Otay Lakes, Chula Vista, CA, 91915",
+  },
+  1636040926832: {
+    address:
+      "Pavilions 2233 - 7 Peninsula Center, Rolling Hills Estates, CA, 90274",
+  },
+  1640017202147: {
+    address:
+      "Covina Valley USD at The Hanes Center Field - 252 W Puente St 2nd Floor, Covina, CA, 91723",
+  },
+  1636072844592: {
+    address: "Albertsons 758 - 543 Sweetwater Rd, Spring Valley, CA, 91977",
+  },
+  1636040974661: {
+    address: "Albertsons 598 - 2000 E. 17th St., Santa Ana, CA, 92705",
+  },
+  1639432080601: {
+    address:
+      "Safeway 1466 - 1121 North Circle Dr., Colorado Springs, CO, 80909",
+  },
+  1635957678982: {
+    address: "Albertsons 168 - 405 South 8th, Payette, ID, 83661",
+  },
+  1636041009830: {
+    address:
+      "Pavilions 2217 - 22451 Antonio Parkway, Rancho S Margarita, CA, 92688",
+  },
+  1635549531160: {
+    address: "Pavilions 2206 - 16450 Beach Blvd, Westminster, CA, 92683",
+  },
+  1635549499002: {
+    address: "Vons 3519 - 4550 Atlantic Ave, Long Beach, CA, 90807",
+  },
+  1635549466460: {
+    address: "Albertsons 108 - 1735 Artesia Blvd., Gardena, CA, 90248",
+  },
+  1640969604226: {
+    address: "Vons 1638 - 4226 Woodruff Avenue, Lakewood, CA, 90713",
+  },
+  1635964207815: {
+    address: "Vons 2784 - 515 W Washington St, San Diego, CA, 92103",
+  },
+  1640025694701: {
+    address: "Albertsons 331 - 927 S. China Lake Blvd., Ridgecrest, CA, 93555",
+  },
+  1636075700051: {
+    address: "Vons 2724 - 3439 Via Montebello, Carlsbad, CA, 92009",
+  },
+  1639634436428: {
+    address: "Vons 1797 - 4627 Carmel Mountain Road, San Diego, CA, 92130",
+  },
+  1639635348134: {
+    address: "Vons 1797 - 4627 Carmel Mountain Road, San Diego, CA, 92130",
+  },
+  1639635038013: {
+    address: "Vons 1797 - 4627 Carmel Mountain Road, San Diego, CA, 92130",
+  },
+  1638995474243: {
+    address:
+      "Vibrant Minds Charter School - 412 W. Carl Karcher Way, Anaheim, CA, 92801",
+  },
 
   // Some Safeways have their pediatric vaccines listed as "Peds" instead of
   // "Safeway". Not sure it's safe to always assume Safeway is the right fix,

--- a/loader/src/sources/albertsons/index.js
+++ b/loader/src/sources/albertsons/index.js
@@ -295,6 +295,7 @@ async function getData(states) {
     .filter(Boolean);
 }
 
+const urlPattern = /https?:\/\/[^/]+\.\w\w+/i;
 const addressFieldParts = /^\s*(?<name>.+?)\s*-\s+(?<address>.+)$/;
 const pediatricPrefixes = [
   /^Pfizer Child\s*-\s*(?<body>.*)$/i,
@@ -309,6 +310,14 @@ const pediatricPrefixes = [
  * @returns {{name: string, storeBrand: string|undefined, storeNumber: string|undefined, isPediatric: boolean, address: {lines: Array<string>, city: string, state: string, zip?: string}}}
  */
 function parseNameAndAddress(text) {
+  // Some locations have names like:
+  //   https://kordinator.mhealthcoach.net/vcl/1636075700051 - Vons - 3439 Via Montebello, Carlsbad, CA, 92009
+  // We've yet to see any that have enough info to be useful (e.g. no store # in
+  // the example above), so just throw as an error here.
+  if (urlPattern.test(text)) {
+    throw new ParseError(`Found a URL in the name "${text}"`);
+  }
+
   // Some locations have separate pediatric and non-pediatric API locations.
   // The pediatric ones oftne have prefixes like "Pfizer Child".
   let pediatric = false;

--- a/loader/src/sources/albertsons/index.js
+++ b/loader/src/sources/albertsons/index.js
@@ -45,6 +45,10 @@ const API_URL =
 // field, we use this generic URL instead in those cases.
 const GENERIC_BOOKING_URL = "https://www.mhealthappointments.com/covidappt";
 
+// There are test locations in the data; this pattern should match their names
+// so we know to skip over them.
+const TEST_NAME_PATTERN = /^public test$/i;
+
 // Maps Albertsons product names to our product names.
 const PRODUCT_NAMES = {
   pfizer: VaccineProduct.pfizer,
@@ -397,6 +401,12 @@ function formatLocation(data, validAt, checkedAt) {
 
   let { name, storeNumber, storeBrand, address, isPediatric } =
     parseNameAndAddress(data.address);
+
+  // There are test locations in the data, and we should skip them.
+  if (TEST_NAME_PATTERN.test(name)) {
+    return null;
+  }
+
   if (!storeBrand) {
     return null;
   }

--- a/loader/src/sources/albertsons/index.js
+++ b/loader/src/sources/albertsons/index.js
@@ -465,6 +465,9 @@ function formatLocation(data, validAt, checkedAt) {
       [`booking_url_${bookingType}`]: data.coach_url || undefined,
     },
 
+    // The raw data doesn't have a `description`, but some corrections add it.
+    description: data.description,
+
     availability: {
       source: "univaf-albertsons",
       valid_at: validAt,

--- a/loader/src/sources/albertsons/index.js
+++ b/loader/src/sources/albertsons/index.js
@@ -196,7 +196,14 @@ const BRANDS = [
     name: "Community Clinic",
     locationType: LocationType.clinic,
     pattern: {
-      test: (name) => !/\w+\s+#?\d+$/.test(name),
+      test: (name) => {
+        // Teamsters needs explicit support because it looks like "name followed
+        // by store number", which we explicitly disallow for community clinics
+        // in the first pattern.
+        return (
+          !/(\w+\s+#?\d+$)|^\d+\s/.test(name) || /^teamsters local/i.test(name)
+        );
+      },
     },
   },
 ];

--- a/loader/src/sources/albertsons/index.js
+++ b/loader/src/sources/albertsons/index.js
@@ -268,7 +268,11 @@ async function getData(states) {
       const adult = group.find((l) => l.meta.booking_url_adult);
       const pediatric = group.find((l) => l.meta.booking_url_pediatric);
 
-      if (!adult || !pediatric) {
+      // If a location had no available vaccines and had no special naming
+      // prefix, we won't know whether it is adult or pediatric. We can't know
+      // whether this is a problem or not, so always allow it.
+      const unknown = group.find((l) => !l.availability.products);
+      if (!unknown && (!adult || !pediatric)) {
         warn(
           "Trying to merge locations other than an adult and pediatric!",
           group
@@ -279,8 +283,8 @@ async function getData(states) {
       const result = Object.assign({}, ...group);
       result.meta = {
         ...adult.meta,
-        booking_url_adult: adult.booking_url,
-        booking_url_pediatric: pediatric.booking_url,
+        booking_url_adult: adult?.booking_url,
+        booking_url_pediatric: pediatric?.booking_url,
       };
       result.booking_url = GENERIC_BOOKING_URL;
       result.external_ids = getUniqueExternalIds(

--- a/loader/src/sources/albertsons/index.js
+++ b/loader/src/sources/albertsons/index.js
@@ -296,7 +296,11 @@ async function getData(states) {
 }
 
 const addressFieldParts = /^\s*(?<name>.+?)\s*-\s+(?<address>.+)$/;
-const pediatricPrefixParts = /^(?<pediatric>Pfizer Child\s*-\s*)?(?<body>.*)$/i;
+const pediatricPrefixes = [
+  /^Pfizer Child\s*-\s*(?<body>.*)$/i,
+  /^Ages 5\+ welcome\s*-\s*(?<body>.*)$/i,
+  /^All ages welcome 5\+\s+(?<body>.*)$/i,
+];
 
 /**
  * Parse a location name and address from Albertsons (they're both part of
@@ -306,8 +310,17 @@ const pediatricPrefixParts = /^(?<pediatric>Pfizer Child\s*-\s*)?(?<body>.*)$/i;
  */
 function parseNameAndAddress(text) {
   // Some locations have separate pediatric and non-pediatric API locations.
-  // The pediatric ones are prefixed with "Pfizer Child".
-  const { pediatric, body } = text.match(pediatricPrefixParts).groups;
+  // The pediatric ones oftne have prefixes like "Pfizer Child".
+  let pediatric = false;
+  let body = text;
+  for (const pattern of pediatricPrefixes) {
+    const match = text.match(pattern);
+    if (match) {
+      pediatric = true;
+      body = match.groups.body;
+      break;
+    }
+  }
 
   const partMatch = body.match(addressFieldParts);
   if (!partMatch) {

--- a/loader/test/albertsons.test.js
+++ b/loader/test/albertsons.test.js
@@ -226,6 +226,28 @@ describe("Albertsons", () => {
     expect(result[0]).toHaveProperty("availability.products", ["pfizer"]);
   });
 
+  it("skips over test locations", async () => {
+    nock(API_URL_BASE)
+      .get(API_URL_PATH)
+      .query(true)
+      .reply(200, [
+        {
+          id: "1600116808972",
+          region: "Alaska",
+          address: "Public Test  - 1211 Test St, Testville, AK, 99201",
+          lat: "47.66007159999999",
+          long: "-117.4316272",
+          coach_url: "https://kordinator.mhealthcoach.net/vcl/1638566162684",
+          availability: "no",
+          drugName: ["PfizerChild"],
+          availabilityTimeframe: null,
+        },
+      ]);
+
+    const result = await checkAvailability(() => {}, { states: "AK" });
+    expect(result).toHaveLength(0);
+  });
+
   it("handles separate adult and pediatric entries for the same location", async () => {
     nock(API_URL_BASE)
       .get(API_URL_PATH)

--- a/loader/test/albertsons.test.js
+++ b/loader/test/albertsons.test.js
@@ -473,6 +473,22 @@ describe("Albertsons", () => {
     }).toThrow(ParseError);
   });
 
+  it("errors when formatting locations with a URL for a name", () => {
+    expect(() => {
+      formatLocation({
+        id: "1637101034326",
+        region: "Eastern_-_6",
+        address:
+          "https://kordinator.mhealthcoach.net/vcl/1636075700051 - Vons - 3439 Via Montebello, Carlsbad, CA, 92009",
+        lat: "38.98247194054162",
+        long: "-76.9879339600021",
+        coach_url: "https://kordinator.mhealthcoach.net/vcl/1636075700051",
+        availability: "yes",
+        drugName: ["PfizerChild"],
+      });
+    }).toThrow(ParseError);
+  });
+
   it("includes manual corrections to locations", () => {
     // Should replace the provided address with this one.
     corrections["123456789"] = {


### PR DESCRIPTION
Albertsons continues to get messier and with looser naming conventions. 😭

This adds a bunch of manual corrections, plus additional logic to support or throw errors for:
- More pediatric name prefixes.
- A Teamsters union office location.
- Skip non-real/test locations that are in the production data. I think there’s just one.
- Throw errors for locations that have a URL for their name/address (!), e.g. “https://kordinator.mhealthcoach.net/vcl/1636075700051 - Vons - 3439 Via Montebello, Carlsbad, CA, 92009”
- Don’t treat locations starting with numbers as community clinics. We had a lot of bad names we should have been creating exceptions for like "108 Pediatric Pfizer  - 1735 Artesia Blvd., Gardena, CA, 90248" (should be “Albertsons 108 - 1735 Artesia Blvd., Gardena, CA, 90248”). They were matching our pattern for community clinics, but no longer do. **There may be some production data cleanup needed after this.**
- Some location pairs don’t merge because they have no availability and therefore list no vaccine products, and so we can’t tell whether they were adult or pediatric (and merging tries to verify it’s only 1 adult + 1 pediatric). This now allows for “unknown” locations in the merge.

Fixes https://sentry.io/organizations/usdr/issues/2809052505 and https://sentry.io/organizations/usdr/issues/2829716008.