### PR TITLE
Keep trying additional states if Rite Aid API fails on one

### DIFF
--- a/loader/src/cli.js
+++ b/loader/src/cli.js
@@ -176,7 +176,7 @@ function main() {
             type: "number",
             describe: oneLine`
               Only make this many HTTP requests per second. (Only applies to
-              the "riteAidScraper" source for now.)
+              the Rite Aid sources for now.)
             `,
           }),
       handler: run,

--- a/loader/src/utils.js
+++ b/loader/src/utils.js
@@ -326,16 +326,22 @@ module.exports = {
   },
 
   createWarningLogger(prefix) {
-    return function warn(message, context) {
+    return function warn(message, context, sendContextToSentry = false) {
       console.warn(
         `${prefix}: ${message}`,
         context !== undefined ? nodeUtil.inspect(context, { depth: 8 }) : ""
       );
+
+      const sentryInfo = { level: Sentry.Severity.Info };
+      if (context && sendContextToSentry) {
+        sentryInfo.contexts = { context };
+      }
+
       // Sentry does better fingerprinting with an actual exception object.
       if (message instanceof Error) {
-        Sentry.captureException(message, { level: Sentry.Severity.Info });
+        Sentry.captureException(message, sentryInfo);
       } else {
-        Sentry.captureMessage(message, Sentry.Severity.Info);
+        Sentry.captureMessage(message, sentryInfo);
       }
     };
   },


### PR DESCRIPTION
We have an issue where the Rite Aid API loader will often have an error on a request for a state’s data and stop, instead of continuing on to try the rest of the states. This handles that, and sends better error info to Sentry to boot.

It also adds rate limiting support.