### PR TITLE
Fix two more location issues with Albertsons

### DIFF
--- a/loader/src/sources/albertsons/corrections.js
+++ b/loader/src/sources/albertsons/corrections.js
@@ -89,6 +89,13 @@ module.exports.corrections = {
     address:
       "Vibrant Minds Charter School - 412 W. Carl Karcher Way, Anaheim, CA, 92801",
   },
+  1617256794999: {
+    address: "Albertsons 4231 - 215 N Carrier Pkwy, Grand Prairie, TX, 75050",
+  },
+  1643078690834: {
+    address:
+      "Rocketship Public School - 4250 Massachusetts Ave SE, Washington, DC, 20019",
+  },
 
   // Some Safeways have their pediatric vaccines listed as "Peds" instead of
   // "Safeway". Not sure it's safe to always assume Safeway is the right fix,


### PR DESCRIPTION
This fixes two more problematic locations with Albertsons, and solves https://sentry.io/organizations/usdr/issues/2809052505.

One location had a name starting with “12 & Up”. It was a community clinic, and I struggled with whether to allow it in the community clinic brand matcher, but ultimately worried it would be too broad, so I just added a manual correction for it. For posterity in case I need it later, the code I didn’t use was:

```js
{
  ...BASE_BRAND,
  key: "community_clinic",
  name: "Community Clinic",
  locationType: LocationType.clinic,
  pattern: {
    test: (name) => {
      return (
        // Disallow locations that look like "name followed by store number"
        // (these should probably be actual store brands) or that just start
        // with a big block of numbers (these just seem broken).
        !/(\w+\s+#?\d+$)|^\d+\s/.test(name) ||
        // "Teamsters Local 456" looks like the above, so explicitly allow it.
        /^teamsters local/i.test(name) ||
        // Sometimes they start with an age range because reasons.
        /^12(\+| and up | & up )/i.test(name)
      );
    },
  },
}
```

The other started with “Pfizer - Albertsons 4231”, so I added a manual correction there, too. It’s possible there’s some code I could’ve written for it, but it seems to be a one-off, so probably wasn’t worthwhile.