### PR TITLE
Allow for more jitter in RateLimit test

### DIFF
--- a/loader/test/utils.test.js
+++ b/loader/test/utils.test.js
@@ -125,9 +125,9 @@ describe("RateLimit", () => {
     callTimes.push(Date.now());
 
     // Allow for some jitter, but it should be the rate or slower.
-    expect(callTimes[1] - callTimes[0]).toBeGreaterThanOrEqual(1000);
+    expect(callTimes[1] - callTimes[0]).toBeGreaterThanOrEqual(995);
     expect(callTimes[1] - callTimes[0]).toBeLessThan(1050);
-    expect(callTimes[2] - callTimes[1]).toBeGreaterThanOrEqual(1000);
+    expect(callTimes[2] - callTimes[1]).toBeGreaterThanOrEqual(995);
     expect(callTimes[2] - callTimes[1]).toBeLessThan(1050);
   });
 });


### PR DESCRIPTION
This test has been a little flaky and sometimes fails out of the blue because the RateLimit timer resolved in 999 milliseconds instead of 1000. That should really be fine.