### PR TITLE
Add more validation to Rite Aid API

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,4 +17,13 @@ module.exports = {
     ],
     "prefer-const": ["error", { destructuring: "all" }],
   },
+
+  overrides: [
+    {
+      files: ["**/__mocks__/*.{js,ts}"],
+      env: {
+        jest: true,
+      },
+    },
+  ],
 };

--- a/loader/src/__mocks__/utils.js
+++ b/loader/src/__mocks__/utils.js
@@ -1,5 +1,4 @@
 "use strict";
-const { jest } = require("@jest/globals");
 const originalModule = jest.requireActual("../utils");
 
 const warningLoggers = {};

--- a/loader/src/__mocks__/utils.js
+++ b/loader/src/__mocks__/utils.js
@@ -1,0 +1,28 @@
+"use strict";
+const { jest } = require("@jest/globals");
+const originalModule = jest.requireActual("../utils");
+
+const warningLoggers = {};
+const warnings = [];
+
+const mock = {
+  ...originalModule,
+
+  createWarningLogger(prefix) {
+    warningLoggers[prefix] = jest.fn((message) => warnings.push(message));
+    return warningLoggers[prefix];
+  },
+
+  // Only for use in tests: get mock function for a logger.
+  __getWarningLogger(prefix) {
+    prefix = prefix || Object.keys(warningLoggers).pop();
+    return warningLoggers[prefix];
+  },
+
+  // Only for use in tests: get a list of all warnings that were logged.
+  __getWarnings() {
+    return warnings;
+  },
+};
+
+module.exports = mock;

--- a/loader/src/schema-validation.js
+++ b/loader/src/schema-validation.js
@@ -47,8 +47,32 @@ function assertSchema(schema, data, message) {
   }
 }
 
+/**
+ * Update an "object" schema to require every property listed in the
+ * `properties` object. Returns the schema so you can just wrap a schema
+ * definition with it.
+ * @param {any} schema The schema to require all properties on.
+ * @returns {any}
+ *
+ * @example
+ * var mySchema = requireAllProperties({
+ *   type: "object",
+ *   properties: {
+ *     a: { type: "number" },
+ *     b: { type: "string" }
+ *   }
+ * });
+ * // Throws an error:
+ * assertSchema(mySchema, { a: 5 });
+ */
+function requireAllProperties(schema) {
+  schema.required = Object.keys(schema.properties);
+  return schema;
+}
+
 module.exports = {
   SchemaError,
-  getValidator,
   assertSchema,
+  getValidator,
+  requireAllProperties,
 };

--- a/loader/src/sources/riteaid/api.js
+++ b/loader/src/sources/riteaid/api.js
@@ -55,7 +55,7 @@ async function queryState(state, rateLimit = null) {
     throw new Error("RiteAid API request failed");
   }
 
-  return body.Data.providerDetails.map(formatStore);
+  return body.Data.providerDetails;
 }
 
 /**
@@ -187,7 +187,8 @@ async function checkAvailability(handler, options) {
   for (const state of states) {
     let stores;
     try {
-      stores = await queryState(state, rateLimit);
+      const rawData = await queryState(state, rateLimit);
+      stores = rawData.map(formatStore);
     } catch (error) {
       warn(error, { state, source: "Rite Aid API" }, true);
       continue;

--- a/loader/src/sources/riteaid/api.js
+++ b/loader/src/sources/riteaid/api.js
@@ -290,7 +290,7 @@ async function checkAvailability(handler, options) {
 
   if (!states.length) {
     const statesText = Array.from(riteAidStates).join(", ");
-    console.warn(`No states set for riteAidApi (supported: ${statesText})`);
+    warn(`No states set for riteAidApi (supported: ${statesText})`);
   }
 
   if (options.rateLimit != null && isNaN(options.rateLimit)) {

--- a/loader/src/sources/riteaid/common.js
+++ b/loader/src/sources/riteaid/common.js
@@ -1,0 +1,12 @@
+const assert = require("assert/strict");
+const { HttpApiError } = require("../../exceptions");
+
+class RiteAidApiError extends HttpApiError {
+  parse(response) {
+    assert.equal(typeof response.body, "object");
+    this.details = response.body;
+    this.message = `${this.details.Status} ${this.details.ErrCde}: ${this.details.ErrMsg}`;
+  }
+}
+
+module.exports = { RiteAidApiError };

--- a/loader/src/sources/riteaid/common.js
+++ b/loader/src/sources/riteaid/common.js
@@ -1,4 +1,4 @@
-const assert = require("assert/strict");
+const assert = require("assert").strict;
 const { HttpApiError } = require("../../exceptions");
 
 class RiteAidApiError extends HttpApiError {

--- a/loader/src/sources/riteaid/scraper.js
+++ b/loader/src/sources/riteaid/scraper.js
@@ -18,6 +18,7 @@ const {
   RateLimit,
   TIME_ZONE_OFFSET_STRINGS,
   createWarningLogger,
+  parseUsPhoneNumber,
 } = require("../../utils");
 const { RiteAidApiError } = require("./common");
 const { zipCodesCovering100Miles } = require("./zip-codes");
@@ -224,7 +225,7 @@ function formatLocation(apiData) {
     },
 
     booking_url: BOOKING_URL,
-    info_phone: apiData.fullPhone,
+    info_phone: apiData.fullPhone && parseUsPhoneNumber(apiData.fullPhone),
     description: apiData.locationDescription,
 
     meta: {

--- a/loader/src/sources/riteaid/scraper.js
+++ b/loader/src/sources/riteaid/scraper.js
@@ -327,7 +327,7 @@ async function checkAvailability(handler, options) {
   }
 
   if (!states.length) {
-    console.warn(`No states set for riteAidApi`);
+    warn(`No states set for riteAidApi`);
   }
 
   if (options.rateLimit != null && isNaN(options.rateLimit)) {

--- a/loader/src/utils.js
+++ b/loader/src/utils.js
@@ -127,9 +127,9 @@ const PHONE_NUMBER_PATTERN = new RegExp(
   r`^`                           +
   r`(?:\+?1${PHONE_SEPARATOR})?` + // May start with a country code
   r`(\([2-9]\d\d\)|[2-9]\d\d)`   + // Area code, possibly in parentheses
-  PHONE_SEPARATOR                + // Separator
+  PHONE_SEPARATOR                +
   r`([2-9]\d\d)`                 + // Central Office number
-  PHONE_SEPARATOR                + // Separator
+  PHONE_SEPARATOR                +
   r`(\d{1,4})`                   + // Local number
   r`$`
 );

--- a/loader/test/fixtures/riteaid.api.test.json
+++ b/loader/test/fixtures/riteaid.api.test.json
@@ -11,7 +11,17 @@
           "city": "Millville",
           "state": "NJ",
           "zipcode": "08332-3762",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 825-7742",
@@ -127,7 +137,17 @@
           "city": "Willingboro",
           "state": "NJ",
           "zipcode": "08046-1109",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(609) 877-0700",
@@ -278,7 +298,17 @@
           "city": "Bayonne",
           "state": "NJ",
           "zipcode": "07002-4126",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(201) 436-6831",
@@ -429,7 +459,17 @@
           "city": "Denville",
           "state": "NJ",
           "zipcode": "07834-2644",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(973) 627-3312",
@@ -580,7 +620,17 @@
           "city": "Belvidere",
           "state": "NJ",
           "zipcode": "07823-2630",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(908) 475-5747",
@@ -696,7 +746,17 @@
           "city": "Clementon",
           "state": "NJ",
           "zipcode": "08021-5610",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 627-5500",
@@ -847,7 +907,17 @@
           "city": "Bergenfield",
           "state": "NJ",
           "zipcode": "07621-2305",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(201) 384-2789",
@@ -998,7 +1068,17 @@
           "city": "New Brunswick",
           "state": "NJ",
           "zipcode": "08901-2004",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(732) 247-2331",
@@ -1149,7 +1229,17 @@
           "city": "Point Pleasant",
           "state": "NJ",
           "zipcode": "08742-3459",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(732) 892-5673",
@@ -1300,7 +1390,17 @@
           "city": "Camden",
           "state": "NJ",
           "zipcode": "08103-1206",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 963-9311",
@@ -1451,7 +1551,17 @@
           "city": "North Brunswick",
           "state": "NJ",
           "zipcode": "08902-3359",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(732) 545-9487",
@@ -1602,7 +1712,17 @@
           "city": "Oaklyn",
           "state": "NJ",
           "zipcode": "08107-1017",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 869-5410",
@@ -1718,7 +1838,17 @@
           "city": "Hazlet",
           "state": "NJ",
           "zipcode": "07730-1716",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(732) 264-3114",
@@ -1869,7 +1999,17 @@
           "city": "Delran",
           "state": "NJ",
           "zipcode": "08075-2401",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 461-1250",
@@ -2020,7 +2160,17 @@
           "city": "Merchantville",
           "state": "NJ",
           "zipcode": "08109-2203",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 663-1038",
@@ -2171,7 +2321,17 @@
           "city": "Barrington",
           "state": "NJ",
           "zipcode": "08007-1811",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 547-3200",
@@ -2322,7 +2482,17 @@
           "city": "Cinnaminson",
           "state": "NJ",
           "zipcode": "08077-3406",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 829-7200",
@@ -2473,7 +2643,17 @@
           "city": "Haddonfield",
           "state": "NJ",
           "zipcode": "08033-1705",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 429-0252",
@@ -2624,7 +2804,17 @@
           "city": "Bridgeton",
           "state": "NJ",
           "zipcode": "08302-2831",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 455-0777",
@@ -2775,7 +2965,17 @@
           "city": "Somerdale",
           "state": "NJ",
           "zipcode": "08083-1956",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 784-1500",
@@ -2926,7 +3126,17 @@
           "city": "Woodbury",
           "state": "NJ",
           "zipcode": "08096-2406",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 845-1173",
@@ -3077,7 +3287,17 @@
           "city": "Lake Hiawatha",
           "state": "NJ",
           "zipcode": "07034-2511",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(973) 334-4343",
@@ -3228,7 +3448,17 @@
           "city": "Salem",
           "state": "NJ",
           "zipcode": "08079-1234",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 935-7623",
@@ -3379,7 +3609,17 @@
           "city": "Penns Grove",
           "state": "NJ",
           "zipcode": "08069-1443",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 299-9462",
@@ -3530,7 +3770,17 @@
           "city": "Pennsauken",
           "state": "NJ",
           "zipcode": "08110-2952",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 662-3496",
@@ -3681,7 +3931,17 @@
           "city": "Trenton",
           "state": "NJ",
           "zipcode": "08690-3705",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(609) 585-3925",
@@ -3832,7 +4092,17 @@
           "city": "Washington Township",
           "state": "NJ",
           "zipcode": "07676-4809",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(201) 664-7900",
@@ -3983,7 +4253,17 @@
           "city": "Voorhees",
           "state": "NJ",
           "zipcode": "08043-3801",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 782-5125",
@@ -4134,7 +4414,17 @@
           "city": "Fords",
           "state": "NJ",
           "zipcode": "08863-1046",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(732) 225-9655",
@@ -4285,7 +4575,17 @@
           "city": "Jersey City",
           "state": "NJ",
           "zipcode": "07306-3901",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(201) 433-2826",
@@ -4436,7 +4736,17 @@
           "city": "Perth Amboy",
           "state": "NJ",
           "zipcode": "08861-4414",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(732) 826-7690",
@@ -4587,7 +4897,17 @@
           "city": "Cherry Hill",
           "state": "NJ",
           "zipcode": "08002-1722",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 667-6596",
@@ -4738,7 +5058,17 @@
           "city": "Clifton",
           "state": "NJ",
           "zipcode": "07012-1343",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(973) 778-2940",
@@ -4889,7 +5219,17 @@
           "city": "Gibbstown",
           "state": "NJ",
           "zipcode": "08027-1702",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 423-2944",
@@ -5040,7 +5380,17 @@
           "city": "Tinton Falls",
           "state": "NJ",
           "zipcode": "07701-4909",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(732) 741-7904",
@@ -5191,7 +5541,17 @@
           "city": "Tinton Falls",
           "state": "NJ",
           "zipcode": "07753-7700",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(732) 493-0669",
@@ -5342,7 +5702,17 @@
           "city": "Sewell",
           "state": "NJ",
           "zipcode": "08080-2342",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 589-8466",
@@ -5493,7 +5863,17 @@
           "city": "Atco",
           "state": "NJ",
           "zipcode": "08004-2228",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 768-0911",
@@ -5644,7 +6024,17 @@
           "city": "Edgewater Park",
           "state": "NJ",
           "zipcode": "08010-2558",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(609) 877-0013",
@@ -5795,7 +6185,17 @@
           "city": "Whitehouse Station",
           "state": "NJ",
           "zipcode": "08889-3603",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(908) 534-0019",
@@ -5911,7 +6311,17 @@
           "city": "Clayton",
           "state": "NJ",
           "zipcode": "08312-2204",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 881-0667",
@@ -6062,7 +6472,17 @@
           "city": "Haledon",
           "state": "NJ",
           "zipcode": "07508-1555",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(973) 904-0550",
@@ -6213,7 +6633,17 @@
           "city": "Irvington",
           "state": "NJ",
           "zipcode": "07111-1009",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(973) 372-0733",
@@ -6364,7 +6794,17 @@
           "city": "Hackensack",
           "state": "NJ",
           "zipcode": "07601-3215",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(201) 488-7224",
@@ -6515,7 +6955,17 @@
           "city": "Lakewood",
           "state": "NJ",
           "zipcode": "08701-1308",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(732) 363-0880",
@@ -6666,7 +7116,17 @@
           "city": "Lumberton",
           "state": "NJ",
           "zipcode": "08048-2988",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(609) 261-1330",
@@ -6817,7 +7277,17 @@
           "city": "Wrightstown",
           "state": "NJ",
           "zipcode": "08562-1527",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(609) 723-3176",
@@ -6968,7 +7438,17 @@
           "city": "Barnegat",
           "state": "NJ",
           "zipcode": "08005-2121",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(609) 698-2329",
@@ -7119,7 +7599,17 @@
           "city": "Little Egg Harbor",
           "state": "NJ",
           "zipcode": "08087-4032",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(609) 294-0633",
@@ -7270,7 +7760,17 @@
           "city": "Highland Park",
           "state": "NJ",
           "zipcode": "08904-2702",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(732) 572-3773",
@@ -7421,7 +7921,17 @@
           "city": "Newton",
           "state": "NJ",
           "zipcode": "07860-2103",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(973) 383-0292",
@@ -7537,7 +8047,17 @@
           "city": "Camden",
           "state": "NJ",
           "zipcode": "08104-1549",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 541-7648",
@@ -7688,7 +8208,17 @@
           "city": "Somerset",
           "state": "NJ",
           "zipcode": "08873-3102",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(732) 545-2299",
@@ -7839,7 +8369,17 @@
           "city": "East Orange",
           "state": "NJ",
           "zipcode": "07018-1922",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(973) 677-7880",
@@ -7990,7 +8530,17 @@
           "city": "Brick",
           "state": "NJ",
           "zipcode": "08724-1967",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(732) 836-3021",
@@ -8141,7 +8691,17 @@
           "city": "Cherry Hill",
           "state": "NJ",
           "zipcode": "08002-2271",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 663-1021",
@@ -8257,7 +8817,17 @@
           "city": "Williamstown",
           "state": "NJ",
           "zipcode": "08094-9130",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 740-9612",
@@ -8408,7 +8978,17 @@
           "city": "West Deptford",
           "state": "NJ",
           "zipcode": "08086-2216",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 853-2943",
@@ -8559,7 +9139,17 @@
           "city": "Parlin",
           "state": "NJ",
           "zipcode": "08859-1083",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(732) 316-4801",
@@ -8710,7 +9300,17 @@
           "city": "Bridgewater",
           "state": "NJ",
           "zipcode": "08807-2442",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(908) 722-8123",
@@ -8861,7 +9461,17 @@
           "city": "Sicklerville",
           "state": "NJ",
           "zipcode": "08081-9628",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 566-0584",
@@ -9012,7 +9622,17 @@
           "city": "Somerville",
           "state": "NJ",
           "zipcode": "08876-2419",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(908) 722-3444",
@@ -9163,7 +9783,17 @@
           "city": "Jersey City",
           "state": "NJ",
           "zipcode": "07306-6903",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(201) 332-0410",
@@ -9314,7 +9944,17 @@
           "city": "Williamstown",
           "state": "NJ",
           "zipcode": "08094-3464",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 629-0500",
@@ -9465,7 +10105,17 @@
           "city": "Edison",
           "state": "NJ",
           "zipcode": "08820-3906",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(732) 744-0705",
@@ -9616,7 +10266,17 @@
           "city": "Burlington",
           "state": "NJ",
           "zipcode": "08016-2774",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(609) 387-4998",
@@ -9767,7 +10427,17 @@
           "city": "Vineland",
           "state": "NJ",
           "zipcode": "08360-7079",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 405-0962",
@@ -9883,7 +10553,17 @@
           "city": "Burlington",
           "state": "NJ",
           "zipcode": "08016-9748",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(609) 499-5781",
@@ -10034,7 +10714,17 @@
           "city": "Edison",
           "state": "NJ",
           "zipcode": "08817-4418",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(732) 985-1431",
@@ -10185,7 +10875,17 @@
           "city": "Newark",
           "state": "NJ",
           "zipcode": "07107-3004",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(973) 621-0580",
@@ -10336,7 +11036,17 @@
           "city": "Waldwick",
           "state": "NJ",
           "zipcode": "07463-1805",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(201) 670-1022",
@@ -10487,7 +11197,17 @@
           "city": "Neptune",
           "state": "NJ",
           "zipcode": "07753-5032",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(732) 775-9083",
@@ -10638,7 +11358,17 @@
           "city": "Port Monmouth",
           "state": "NJ",
           "zipcode": "07758-1228",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(732) 495-0156",
@@ -10789,7 +11519,17 @@
           "city": "Blairstown",
           "state": "NJ",
           "zipcode": "07825-2114",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(908) 362-6963",
@@ -10905,7 +11645,17 @@
           "city": "Hackettstown",
           "state": "NJ",
           "zipcode": "07840-2408",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(908) 852-2223",
@@ -11021,7 +11771,17 @@
           "city": "Washington",
           "state": "NJ",
           "zipcode": "07882-4335",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(908) 689-8561",
@@ -11137,7 +11897,17 @@
           "city": "Morristown",
           "state": "NJ",
           "zipcode": "07960-5336",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(973) 540-9599",
@@ -11288,7 +12058,17 @@
           "city": "Berlin",
           "state": "NJ",
           "zipcode": "08009-1932",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 768-0440",
@@ -11404,7 +12184,17 @@
           "city": "Laurel Springs",
           "state": "NJ",
           "zipcode": "08021-2797",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 401-1900",
@@ -11555,7 +12345,17 @@
           "city": "Glassboro",
           "state": "NJ",
           "zipcode": "08028-1447",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 863-0695",
@@ -11706,7 +12506,17 @@
           "city": "Haddonfield",
           "state": "NJ",
           "zipcode": "08033-2802",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 858-4012",
@@ -11857,7 +12667,17 @@
           "city": "Cherry Hill",
           "state": "NJ",
           "zipcode": "08034-3215",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 428-1333",
@@ -12008,7 +12828,17 @@
           "city": "Voorhees",
           "state": "NJ",
           "zipcode": "08043-4394",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 783-2201",
@@ -12159,7 +12989,17 @@
           "city": "Voorhees",
           "state": "NJ",
           "zipcode": "08043-9532",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 768-1801",
@@ -12310,7 +13150,17 @@
           "city": "Mantua",
           "state": "NJ",
           "zipcode": "08051-1915",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 468-5513",
@@ -12461,7 +13311,17 @@
           "city": "Marlton",
           "state": "NJ",
           "zipcode": "08053-9461",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 985-3200",
@@ -12612,7 +13472,17 @@
           "city": "Medford",
           "state": "NJ",
           "zipcode": "08055-8806",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 983-9393",
@@ -12763,7 +13633,17 @@
           "city": "Medford",
           "state": "NJ",
           "zipcode": "08055-8475",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(609) 654-0440",
@@ -12914,7 +13794,17 @@
           "city": "Moorestown",
           "state": "NJ",
           "zipcode": "08057-2431",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 866-1533",
@@ -13065,7 +13955,17 @@
           "city": "Mullica Hill",
           "state": "NJ",
           "zipcode": "08062-1800",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 223-0177",
@@ -13216,7 +14116,17 @@
           "city": "Paulsboro",
           "state": "NJ",
           "zipcode": "08066-1451",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 224-0533",
@@ -13367,7 +14277,17 @@
           "city": "Sewell",
           "state": "NJ",
           "zipcode": "08080-4574",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 582-4300",
@@ -13518,7 +14438,17 @@
           "city": "Sicklerville",
           "state": "NJ",
           "zipcode": "08081-1833",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 875-8156",
@@ -13669,7 +14599,17 @@
           "city": "Logan Township",
           "state": "NJ",
           "zipcode": "08085-1421",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 467-4242",
@@ -13820,7 +14760,17 @@
           "city": "West Berlin",
           "state": "NJ",
           "zipcode": "08091-2505",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 767-9090",
@@ -13971,7 +14921,17 @@
           "city": "Sicklerville",
           "state": "NJ",
           "zipcode": "08081-9564",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 629-0690",
@@ -14122,7 +15082,17 @@
           "city": "Deptford",
           "state": "NJ",
           "zipcode": "08096-2598",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 848-5402",
@@ -14273,7 +15243,17 @@
           "city": "Pilesgrove",
           "state": "NJ",
           "zipcode": "08098-2819",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 769-4252",
@@ -14424,7 +15404,17 @@
           "city": "Pennsauken",
           "state": "NJ",
           "zipcode": "08109-3395",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 663-6655",
@@ -14575,7 +15565,17 @@
           "city": "Bridgeton",
           "state": "NJ",
           "zipcode": "08302-1215",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 455-7020",
@@ -14726,7 +15726,17 @@
           "city": "Millville",
           "state": "NJ",
           "zipcode": "08332-3512",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 825-7866",
@@ -14877,7 +15887,17 @@
           "city": "Vineland",
           "state": "NJ",
           "zipcode": "08360-8106",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 691-5151",
@@ -15028,7 +16048,17 @@
           "city": "Vineland",
           "state": "NJ",
           "zipcode": "08360-8266",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 563-1599",
@@ -15179,7 +16209,17 @@
           "city": "Vineland",
           "state": "NJ",
           "zipcode": "08361-7286",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(856) 696-0111",
@@ -15330,7 +16370,17 @@
           "city": "Jackson",
           "state": "NJ",
           "zipcode": "08527-1354",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(732) 905-4420",
@@ -15481,7 +16531,17 @@
           "city": "Manasquan",
           "state": "NJ",
           "zipcode": "08736-3544",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(732) 223-3900",
@@ -15632,7 +16692,17 @@
           "city": "Toms River",
           "state": "NJ",
           "zipcode": "08753-4605",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(732) 929-3440",
@@ -15748,7 +16818,17 @@
           "city": "Whiting",
           "state": "NJ",
           "zipcode": "08759-1851",
-          "county": null
+          "county": null,
+          "identifiers": null,
+          "resourceType": null,
+          "id": null,
+          "identifier": null,
+          "name": null,
+          "telecom": null,
+          "address": null,
+          "position": null,
+          "meta": null,
+          "description": null
         },
         "contact": {
           "booking_phone": "(732) 716-0342",

--- a/loader/test/riteaid.api.test.js
+++ b/loader/test/riteaid.api.test.js
@@ -51,14 +51,14 @@ describe("Rite Aid Source", () => {
   });
 
   it("throws on failing API response", async () => {
-    nock(API_URL).get("?stateCode=NJ").reply(500, {
+    nock(API_URL).get("?stateCode=NJ").reply(200, {
       Status: "ERROR",
       ErrCde: "1234",
       ErrMsg: "RiteAid API timed out",
       ErrMsgDtl: "Timed out because things are pretty crazy over here!",
     });
 
-    await expect(queryState("NJ")).rejects.toThrow();
+    await expect(queryState("NJ")).rejects.toThrow("API timed out");
   });
 
   it("processes response correctly", async () => {

--- a/loader/test/riteaid.api.test.js
+++ b/loader/test/riteaid.api.test.js
@@ -9,24 +9,8 @@ const {
 const { locationSchema } = require("./support/schemas");
 const responseFixture = require("./fixtures/riteaid.api.test.json");
 
-// Capture warnings. After this mock, you can call `utils.getWarningLogger()`
-// to get Jest mock you can make assertions on, e.g:
-//     expect(utils.getWarningLogger()).toHaveBeenCalledWith("Some string");
-jest.mock("../src/utils", () => {
-  const originalModule = jest.requireActual("../src/utils");
-
-  let warningLogger;
-  return {
-    ...originalModule,
-    createWarningLogger() {
-      warningLogger = jest.fn();
-      return warningLogger;
-    },
-    getWarningLogger() {
-      return warningLogger;
-    },
-  };
-});
+// Mock utils so we can track logs.
+jest.mock("../src/utils");
 
 function createMockApiLocation() {
   return {
@@ -260,10 +244,8 @@ describe("Rite Aid Source", () => {
     };
 
     formatStore(badData);
-    expect(utils.getWarningLogger()).toBeCalledWith(
-      expect.stringContaining("slot count"),
-      expect.anything(),
-      expect.anything()
+    expect(utils.__getWarnings()).toContainEqual(
+      expect.stringContaining("slot count")
     );
   });
 });

--- a/loader/test/riteaid.api.test.js
+++ b/loader/test/riteaid.api.test.js
@@ -1,7 +1,39 @@
 const { DateTime } = require("luxon");
 const nock = require("nock");
-const { checkAvailability, queryState } = require("../src/sources/riteaid/api");
+const utils = require("../src/utils");
+const {
+  checkAvailability,
+  queryState,
+  formatStore,
+} = require("../src/sources/riteaid/api");
 const { locationSchema } = require("./support/schemas");
+const responseFixture = require("./fixtures/riteaid.api.test.json");
+
+// Capture warnings. After this mock, you can call `utils.getWarningLogger()`
+// to get Jest mock you can make assertions on, e.g:
+//     expect(utils.getWarningLogger()).toHaveBeenCalledWith("Some string");
+jest.mock("../src/utils", () => {
+  const originalModule = jest.requireActual("../src/utils");
+
+  let warningLogger;
+  return {
+    ...originalModule,
+    createWarningLogger() {
+      warningLogger = jest.fn();
+      return warningLogger;
+    },
+    getWarningLogger() {
+      return warningLogger;
+    },
+  };
+});
+
+function createMockApiLocation() {
+  return {
+    ...responseFixture.Data.providerDetails[0],
+    last_updated: DateTime.utc().toFormat("yyyy/MM/dd HH:mm:ss"),
+  };
+}
 
 describe("Rite Aid Source", () => {
   const API_URL = "https://api.riteaid.com/test";
@@ -30,17 +62,15 @@ describe("Rite Aid Source", () => {
   });
 
   it("processes response correctly", async () => {
-    const apiResponse = require("./fixtures/riteaid.api.test.json");
-
     // Set last_updated to a current time, rounded to the second.
     const timestamp = Math.floor(Date.now() / 1000);
     const now = DateTime.fromSeconds(timestamp, { zone: "UTC" });
     const riteAidTime = now.toFormat("yyyy/MM/dd HH:mm:ss");
-    for (const record of apiResponse.Data.providerDetails) {
+    for (const record of responseFixture.Data.providerDetails) {
       record.last_updated = riteAidTime;
     }
 
-    nock(API_URL).get("?stateCode=NJ").reply(200, apiResponse);
+    nock(API_URL).get("?stateCode=NJ").reply(200, responseFixture);
 
     const locations = await checkAvailability(() => {}, { states: "NJ" });
     expect(locations.length).toBe(108);
@@ -190,5 +220,50 @@ describe("Rite Aid Source", () => {
     nock(API_URL).get("?stateCode=AK").reply(403, "uhoh");
     const results = await checkAvailability(() => {}, { states: "AK" });
     expect(results).toHaveLength(0);
+  });
+
+  it("throws errors for inconsistent slot counts", async () => {
+    const badData = {
+      ...createMockApiLocation(),
+      availability: [
+        {
+          date: "2021-04-23",
+          total_slots: 200,
+          available_slots: 8,
+        },
+        {
+          date: "2021-04-24",
+          total_slots: 200,
+          available_slots: 201,
+        },
+      ],
+    };
+
+    expect(() => formatStore(badData)).toThrow(/slots/);
+  });
+
+  it("warns for unreasonable slot counts", async () => {
+    const badData = {
+      ...createMockApiLocation(),
+      availability: [
+        {
+          date: "2021-04-23",
+          total_slots: 200,
+          available_slots: 8,
+        },
+        {
+          date: "2021-04-24",
+          total_slots: 1000,
+          available_slots: 10,
+        },
+      ],
+    };
+
+    formatStore(badData);
+    expect(utils.getWarningLogger()).toBeCalledWith(
+      expect.stringContaining("slot count"),
+      expect.anything(),
+      expect.anything()
+    );
   });
 });

--- a/loader/test/riteaid.api.test.js
+++ b/loader/test/riteaid.api.test.js
@@ -42,7 +42,7 @@ describe("Rite Aid Source", () => {
 
     nock(API_URL).get("?stateCode=NJ").reply(200, apiResponse);
 
-    const locations = await queryState("NJ");
+    const locations = await checkAvailability(() => {}, { states: "NJ" });
     expect(locations.length).toBe(108);
 
     expect(locations[0]).toStrictEqual({

--- a/loader/test/riteaid.scraper.test.js
+++ b/loader/test/riteaid.scraper.test.js
@@ -2,7 +2,6 @@ const nock = require("nock");
 const { Available } = require("../src/model");
 const {
   API_URL,
-  RiteAidXhrError,
   checkAvailability,
 } = require("../src/sources/riteaid/scraper");
 const { expectDatetimeString, splitHostAndPath } = require("./support");
@@ -239,7 +238,7 @@ describe("Rite Aid Scraper", () => {
     expect(result).toHaveProperty("0.availability.available", Available.no);
   });
 
-  it("raises RiteAidXhrError on API error responses", async () => {
+  it("raises RiteAidApiError on API error responses", async () => {
     nock(API_URL_BASE).get(API_URL_PATH).query(true).reply(200, {
       Data: null,
       Status: "ERROR",
@@ -248,8 +247,8 @@ describe("Rite Aid Scraper", () => {
       ErrMsgDtl: null,
     });
 
-    expect(async () => {
-      await checkAvailability(() => {}, { states: "NJ" });
-    }).rejects.toThrow(RiteAidXhrError);
+    await expect(checkAvailability(() => {}, { states: "NJ" })).rejects.toThrow(
+      "Something went wrong"
+    );
   });
 });

--- a/loader/test/riteaid.scraper.test.js
+++ b/loader/test/riteaid.scraper.test.js
@@ -7,6 +7,9 @@ const {
 const { expectDatetimeString, splitHostAndPath } = require("./support");
 const { locationSchema } = require("./support/schemas");
 
+// Mock utils so we can track logs.
+jest.mock("../src/utils");
+
 const [API_URL_BASE, API_URL_PATH] = splitHostAndPath(API_URL);
 
 const basicLocation = {

--- a/loader/test/utils.test.js
+++ b/loader/test/utils.test.js
@@ -8,6 +8,7 @@ const {
   getUniqueExternalIds,
   parseUsAddress,
   RateLimit,
+  parseUsPhoneNumber,
 } = require("../src/utils");
 
 describe("splitOnce", () => {
@@ -153,5 +154,34 @@ describe("parseUsAddress", () => {
     expect(() => {
       parseUsAddress("., ., TX, 75244");
     }).toThrow(ParseError);
+  });
+});
+
+describe("parseUsPhoneNumber", () => {
+  it("Parses phone numbers", () => {
+    expect(parseUsPhoneNumber("(213) 456-7890")).toEqual("(213) 456-7890");
+  });
+
+  it("Handles country codes", () => {
+    expect(parseUsPhoneNumber("+1 (213) 456-7890")).toEqual("(213) 456-7890");
+    expect(parseUsPhoneNumber("1 (213) 456-7890")).toEqual("(213) 456-7890");
+  });
+
+  it("Works with or without parentheses for the area code", () => {
+    expect(parseUsPhoneNumber("213 456-7890")).toEqual("(213) 456-7890");
+  });
+
+  it("Handles different separators", () => {
+    expect(parseUsPhoneNumber("213.456.7890")).toEqual("(213) 456-7890");
+  });
+
+  it("Handles missing leading zeroes", () => {
+    expect(parseUsPhoneNumber("213.456.789")).toEqual("(213) 456-0789");
+  });
+
+  it("throws for invalid numbers", () => {
+    expect(() => parseUsPhoneNumber("123.456.7890")).toThrow(ParseError);
+    expect(() => parseUsPhoneNumber("213.456.78901")).toThrow(ParseError);
+    expect(() => parseUsPhoneNumber("Not a number")).toThrow(ParseError);
   });
 });

--- a/loader/test/utils.test.js
+++ b/loader/test/utils.test.js
@@ -180,8 +180,11 @@ describe("parseUsPhoneNumber", () => {
   });
 
   it("throws for invalid numbers", () => {
+    // US area codes cannot start with "1".
     expect(() => parseUsPhoneNumber("123.456.7890")).toThrow(ParseError);
+    // Too many numbers.
     expect(() => parseUsPhoneNumber("213.456.78901")).toThrow(ParseError);
+
     expect(() => parseUsPhoneNumber("Not a number")).toThrow(ParseError);
   });
 });


### PR DESCRIPTION
I thought this wouldn’t be too complex, but alas, I was wrong, as usual.

This is a follow-on to the Rite Aid API issues discovered while counting slots last week in https://github.com/usdigitalresponse/appointment-data-insights/pull/3. The main idea was to check the number of slots the API is reporting to make sure it’s reasonable (since it was reporting thousands per store for a couple months). Of course, as I got into it, it expanded:

- Check the number of slots to make sure the total is reasonable (this only triggers a warning, since it’s possible our definition of “reasonable” could be bad).

- Check the slots to make sure it’s not reporting mismatching values, i.e. where the available slots are more than the total slots. This causes an actual error, since this would seem to indicate things are wrong enough we don’t want to try and read this data.

- Clean up the workflow slightly so an error formatting a single store doesn’t break all the other stores, more like how some of the more recent sources work.

- Check the schema of the response to make sure it hasn’t changed (spoiler: it has changed).

- Clean up phone numbers. I foolishly thought I should check the phone number format in the schema, and discovered that Rite Aid’s API removes leading zeroes from the local part of the phone number!!! For example, this is an actual phone number the API is currently surfacing: “(203) 382-9”

- Clean up the error parsing issue in #537 since we’re mucking about in Rite Aid code anyway.

Fixes #537.