### PR TITLE
Ignore Dallas ISD locations with nonsense addresses

### DIFF
--- a/loader/src/sources/albertsons/index.js
+++ b/loader/src/sources/albertsons/index.js
@@ -49,6 +49,12 @@ const GENERIC_BOOKING_URL = "https://www.mhealthappointments.com/covidappt";
 // so we know to skip over them.
 const TEST_NAME_PATTERN = /^public test$/i;
 
+// There are locations with addresses we should ignore, since these seem wrong
+// enough to be intentional, and even show up this way in their booking UI!
+// (The only instances of this we've seen are for "Dallas ISD"; our best guess
+// is that they are used to manage vaccinations across Dallas public schools.)
+const IGNORE_ADDRESS_PATTERN = / \., \., [A-Z]{2}, \d{5}/;
+
 // Maps Albertsons product names to our product names.
 const PRODUCT_NAMES = {
   pfizer: VaccineProduct.pfizer,
@@ -408,6 +414,10 @@ function formatLocation(data, validAt, checkedAt) {
   // Apply corrections for known-bad source data.
   if (data.id in corrections) {
     Object.assign(data, corrections[data.id]);
+  }
+
+  if (IGNORE_ADDRESS_PATTERN.test(data.address)) {
+    return null;
   }
 
   let { name, storeNumber, storeBrand, address, isPediatric } =


### PR DESCRIPTION
We've been logging errors for two Albertsons/MHealth locations with the nonsense addresses:

    ., ., TX, 75211
    ., ., TX, 75244

I left them as an error under the assumption they were a mistyped entry that would get corrected (you can even see it when you search for appointments by zip code in their UI!), but it never did. At this point, I assume it's intentional (Dallas ISD is probably the school district -- Dallas Independent School District -- and I'm guessing these are for tracking vaccinations across the district, so someone probably did this because a particular address was not releveant).

It's filling up our error logs and charts and making it hard to see less common errors, so this change just makes us skip the location before we even try to parse these nonsense addresses.