### PR TITLE
Switch to use new aws_s3_bucket_acl config style

### DIFF
--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -8,6 +8,6 @@ terraform {
 }
 
 provider "aws" {
-  profile = "default"
+  profile = ""
   region  = var.aws_region
 }

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -8,6 +8,5 @@ terraform {
 }
 
 provider "aws" {
-  profile = ""
   region  = var.aws_region
 }

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -2,6 +2,10 @@
 
 resource "aws_s3_bucket" "data_snapshots" {
   bucket = "univaf-data-snapshots"
+}
+
+resource "aws_s3_bucket_acl" "data_snapshots_acl" {
+  bucket = aws_s3_bucket.data_snapshots.id
   acl    = "public-read"
 }
 


### PR DESCRIPTION
It looks like the default version of the AWS provider for Terraform was updated since our last deploy, and there were breaking changes (there may have deprecation warnings we missed before; I’m not really sure). The `acl` property was made read-only, so now we need to use a more verbose syntax to apply the same standard "read-only" ACL to our bucket. See also https://registry.terraform.io/providers/hashicorp%20%20/aws/latest/docs/resources/s3_bucket#using-acl-policy-grants