### PR TITLE
Explicitly specify AWS Terraform provider version

### DIFF
--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,4 +1,5 @@
 provider "aws" {
   profile = "default"
   region  = var.aws_region
+  version = "3.74.2"
 }


### PR DESCRIPTION
Our current deployment is failing because Terraform upgraded the default release of the AWS provider, and that upgrade included breaking changes. This locks our version for now so we can deploy, and we'll remediate separately.