### PR TITLE
Set up Terraform dependencies correctly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "terraform"
+    directory: "/terraform"
+    schedule:
+      interval: "weekly"

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,5 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.74"
+    }
+  }
+}
+
 provider "aws" {
   profile = "default"
   region  = var.aws_region
-  version = "3.74.2"
 }


### PR DESCRIPTION
This is a follow-on to #569. It turns out we were using an old method of configuring Terraform dependencies and versions that is deprecated. This updates it and adds Dependabot for for Terraform and actions (but not for NPM, where we are still using Snyk for now).