### PR TITLE
HOTFIX: duplicate products in Rite Aid scraper

### DIFF
--- a/loader/src/sources/riteaid/scraper.js
+++ b/loader/src/sources/riteaid/scraper.js
@@ -309,7 +309,9 @@ function formatSlots(location) {
             products: [],
           };
         }
-        actualSlot.products.push(product);
+        if (!actualSlot.products.includes(product)) {
+          actualSlot.products.push(product);
+        }
       }
     }
   }


### PR DESCRIPTION
I should have written a test for #592! I fixed one error, but wound up outputting duplicate entries in the list of products for slots that got repeated, which is invalid. This fixes the issue.