### PR TITLE
Ensure locations’ `state` is a two letter postal abbreviation

### DIFF
--- a/server/migrations/20220315003750_correct_invalid_state_abbreviations.js
+++ b/server/migrations/20220315003750_correct_invalid_state_abbreviations.js
@@ -1,17 +1,83 @@
 /**
  * Update the `state` field to always be a correct USPS state abbreviation.
- * We have some bad values that need cleaning up.
+ * We have some bad values that need cleaning up. All the existing bad values
+ * are full state names.
+ *
+ * (Exception: there are some non-public locations with NULL states, but they
+ * have lots of bad values and aren't worth repairing.)
  */
 
-exports.up = async function (knex) {
-  // These are all the bad values we currently have, excepting a few non-public
-  // locations with null states (and lots of other fields that probably
-  // shouldn't be null). Those ones aren't worth trying to repair.
-  const states = [
-    ["alaska", "AK"],
-    ["washington", "WA"],
-  ];
+const states = [
+  ["Alabama", "AL"],
+  ["Alaska", "AK"],
+  ["Arizona", "AZ"],
+  ["Arkansas", "AR"],
+  ["California", "CA"],
+  ["Colorado", "CO"],
+  ["Connecticut", "CT"],
+  ["Delaware", "DE"],
+  ["District of Columbia", "DC"],
+  ["Florida", "FL"],
+  ["Georgia", "GA"],
+  ["Hawaii", "HI"],
+  ["Idaho", "ID"],
+  ["Illinois", "IL"],
+  ["Indiana", "IN"],
+  ["Iowa", "IA"],
+  ["Kansas", "KS"],
+  ["Kentucky", "KY"],
+  ["Louisiana", "LA"],
+  ["Maine", "ME"],
+  ["Maryland", "MD"],
+  ["Massachusetts", "MA"],
+  ["Michigan", "MI"],
+  ["Minnesota", "MN"],
+  ["Mississippi", "MS"],
+  ["Missouri", "MO"],
+  ["Montana", "MT"],
+  ["Nebraska", "NE"],
+  ["Nevada", "NV"],
+  ["New Hampshire", "NH"],
+  ["New Jersey", "NJ"],
+  ["New Mexico", "NM"],
+  ["New York", "NY"],
+  ["North Carolina", "NC"],
+  ["North Dakota", "ND"],
+  ["Ohio", "OH"],
+  ["Oklahoma", "OK"],
+  ["Oregon", "OR"],
+  ["Pennsylvania", "PA"],
+  ["Rhode Island", "RI"],
+  ["South Carolina", "SC"],
+  ["South Dakota", "SD"],
+  ["Tennessee", "TN"],
+  ["Texas", "TX"],
+  ["Utah", "UT"],
+  ["Vermont", "VT"],
+  ["Virginia", "VA"],
+  ["Washington", "WA"],
+  ["West Virginia", "WV"],
+  ["Wisconsin", "WI"],
+  ["Wyoming", "WY"],
+  ["American Samoa", "AS"],
+  ["Guam", "GU"],
+  ["Northern Mariana Islands", "MP"],
+  ["Puerto Rico", "PR"],
+  ["U.S. Virgin Islands", "VI"],
+  ["U.S. Minor Outlying Islands", "FM"],
+  ["Marshall Islands", "MH"],
+  ["Palau", "PW"],
+  ["U.S. Armed Forces \u2013 Americas[d]", "AA"],
+  ["U.S. Armed Forces \u2013 Europe[e]", "AE"],
+  ["U.S. Armed Forces \u2013 Pacific[f]", "AP"],
+  ["Northern Mariana Islands", "CM"],
+  ["Panama Canal Zone", "CZ"],
+  ["Nebraska", "NB"],
+  ["Philippine Islands", "PI"],
+  ["Trust Territory of the Pacific Islands", "TT"],
+];
 
+exports.up = async function (knex) {
   let count = 0;
   for (const [badText, goodText] of states) {
     count += await knex("provider_locations")

--- a/server/migrations/20220315003750_correct_invalid_state_abbreviations.js
+++ b/server/migrations/20220315003750_correct_invalid_state_abbreviations.js
@@ -1,0 +1,29 @@
+/**
+ * Update the `state` field to always be a correct USPS state abbreviation.
+ * We have some bad values that need cleaning up.
+ */
+
+exports.up = async function (knex) {
+  // These are all the bad values we currently have, excepting a few non-public
+  // locations with null states (and lots of other fields that probably
+  // shouldn't be null). Those ones aren't worth trying to repair.
+  const states = [
+    ["alaska", "AK"],
+    ["washington", "WA"],
+  ];
+
+  let count = 0;
+  for (const [badText, goodText] of states) {
+    count += await knex("provider_locations")
+      .where("state", "ILIKE", badText)
+      .update({ state: goodText });
+  }
+
+  console.log("Updated", count, "bad state abbreviations.");
+};
+
+exports.down = async function () {
+  console.log(
+    "20220315003750_correct_invalid_state_abbreviations: No migrated rows changed."
+  );
+};

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -10,7 +10,7 @@ import {
 } from "./interfaces";
 import { NotFoundError, OutOfDateError, ValueError } from "./exceptions";
 import Knex from "knex";
-import { validateAvailabilityInput } from "./validation";
+import { validateAvailabilityInput, validateLocationInput } from "./validation";
 import { loadDbConfig } from "./config";
 import { UUID_PATTERN } from "./utils";
 import { logger, logStackTrace } from "./logger";
@@ -81,7 +81,7 @@ function selectSqlPoint(column: string): string {
  * @param data ProviderLocation-like object with data to insert
  */
 export async function createLocation(data: any): Promise<ProviderLocation> {
-  if (!data.name) throw new ValueError("Locations must have a `name`");
+  data = validateLocationInput(data, true);
 
   const now = new Date();
   const sqlData: { [index: string]: string } = {
@@ -159,6 +159,7 @@ export async function updateLocation(
   data: any,
   { mergeSubfields = true } = {}
 ): Promise<void> {
+  data = validateLocationInput(data);
   const sqlData: any = { updated_at: new Date() };
 
   for (let [key, value] of Object.entries(data)) {

--- a/server/src/interfaces.ts
+++ b/server/src/interfaces.ts
@@ -66,6 +66,10 @@ export interface ProviderLocation {
   availability?: any;
 }
 
+export type ProviderLocationInput = Partial<
+  Omit<ProviderLocation, "created_at" | "updated_at" | "availability">
+>;
+
 export interface LocationAvailability {
   id: number;
   location_id: string;

--- a/server/src/validation.ts
+++ b/server/src/validation.ts
@@ -9,6 +9,7 @@ import {
   SlotRecord,
   CapacityRecord,
 } from "./interfaces";
+import states from "./states.json";
 
 const AVAILABLE_OPTIONS = new Set(Object.values(Availability));
 
@@ -315,4 +316,30 @@ export function validateAvailabilityInput(data: any): AvailabilityInput {
   if (data.is_public == null) data.is_public = true;
 
   return data;
+}
+
+let stateLookup: Map<Lowercase<string>, typeof states[number]>;
+
+/**
+ * Get the correct state abbreviation given the full name or some type of
+ * well-known abbreviation for the state. If no matching state can be found,
+ * this will throw `ValueError`.
+ */
+export function validateState(input: string): string {
+  if (!stateLookup) {
+    stateLookup = new Map();
+    for (const state of states) {
+      for (const reference of Object.values(state)) {
+        if (typeof reference === "string") {
+          stateLookup.set(reference.toLowerCase(), state);
+        }
+      }
+    }
+  }
+
+  const state = stateLookup.get(input.trim().toLowerCase());
+  if (state) {
+    return state.usps;
+  }
+  throw new ValueError(`Unknown state: "${input}"`);
 }

--- a/server/src/validation.ts
+++ b/server/src/validation.ts
@@ -8,6 +8,7 @@ import {
   AvailabilityInput,
   SlotRecord,
   CapacityRecord,
+  ProviderLocationInput,
 } from "./interfaces";
 import states from "./states.json";
 
@@ -350,4 +351,32 @@ export function validateState(input: string): string {
     return state.usps;
   }
   throw new ValueError(`Unknown state: "${input}"`);
+}
+
+export function validateLocationInput(
+  data: any,
+  requiredFields = false
+): ProviderLocationInput {
+  const result = { ...data };
+  delete result.availability;
+  delete result.created_at;
+  delete result.updated_at;
+
+  if (result.state) {
+    result.state = validateState(data.state);
+  }
+
+  // TODO: Validate rest of schema
+  if (requiredFields) {
+    const missing = ["name", "provider", "state"].filter(
+      (field) => !result[field]
+    );
+    if (missing.length) {
+      throw new ValueError(
+        `The location is missing values for: ${missing.join(", ")}`
+      );
+    }
+  }
+
+  return result;
 }

--- a/server/src/validation.ts
+++ b/server/src/validation.ts
@@ -328,9 +328,17 @@ let stateLookup: Map<Lowercase<string>, typeof states[number]>;
 export function validateState(input: string): string {
   if (!stateLookup) {
     stateLookup = new Map();
+    const references: Array<keyof typeof states[number]> = [
+      "name",
+      "iso",
+      "usps",
+      "gpo",
+      "ap",
+    ];
     for (const state of states) {
-      for (const reference of Object.values(state)) {
-        if (typeof reference === "string") {
+      for (const key of references) {
+        const reference = state[key] as string;
+        if (reference) {
           stateLookup.set(reference.toLowerCase(), state);
         }
       }

--- a/server/test/api.edge.test.ts
+++ b/server/test/api.edge.test.ts
@@ -568,13 +568,11 @@ describe("POST /api/edge/update", () => {
     expect(response.statusCode).toBe(200);
 
     const result = await getLocationById(location.id);
-    expect(new Set(result.external_ids)).toEqual(
-      new Set([
-        ...TestLocation.external_ids,
-        ["testid", "this is a test"],
-        ["testid2", "another test"],
-      ])
-    );
+    expect(result.external_ids).toEqualUnordered([
+      ...TestLocation.external_ids,
+      ["testid", "this is a test"],
+      ["testid2", "another test"],
+    ]);
   });
 
   it("allows multiple values for a single external_id system", async () => {

--- a/server/test/api.edge.test.ts
+++ b/server/test/api.edge.test.ts
@@ -454,6 +454,8 @@ describe("POST /api/edge/update", () => {
           ["vtrcks", systemValue(TestLocation.external_ids, "vtrcks")],
         ],
         name: newName,
+        provider: TestLocation.provider,
+        state: TestLocation.state,
       },
     });
     expect(res.statusCode).toBe(201);
@@ -472,6 +474,8 @@ describe("POST /api/edge/update", () => {
       json: {
         external_ids: [["npi_usa", "test"]],
         name: newName,
+        provider: TestLocation.provider,
+        state: TestLocation.state,
       },
     });
     expect(res.statusCode).toBe(201);
@@ -564,11 +568,13 @@ describe("POST /api/edge/update", () => {
     expect(response.statusCode).toBe(200);
 
     const result = await getLocationById(location.id);
-    expect(result.external_ids).toEqual([
-      ...TestLocation.external_ids,
-      ["testid", "this is a test"],
-      ["testid2", "another test"],
-    ]);
+    expect(new Set(result.external_ids)).toEqual(
+      new Set([
+        ...TestLocation.external_ids,
+        ["testid", "this is a test"],
+        ["testid2", "another test"],
+      ])
+    );
   });
 
   it("allows multiple values for a single external_id system", async () => {

--- a/server/test/api.legacy.test.ts
+++ b/server/test/api.legacy.test.ts
@@ -158,6 +158,8 @@ describe("POST /update", () => {
       json: {
         external_ids: [["vtrcks", vtrcksId]],
         name: newName,
+        provider: TestLocation.provider,
+        state: TestLocation.state,
       },
     });
     expect(res.statusCode).toBe(201);

--- a/server/test/validation.test.ts
+++ b/server/test/validation.test.ts
@@ -163,4 +163,10 @@ describe("validateState", () => {
   it("throws if no matching state is found", () => {
     expect(() => validateState("whatever")).toThrow(ValueError);
   });
+
+  it("can only look up by valid fields from state data", () => {
+    // Some values in the states.json file shouldn't be look-up-able.
+    expect(() => validateState("State")).toThrow(ValueError);
+    expect(() => validateState("")).toThrow(ValueError);
+  });
 });

--- a/server/test/validation.test.ts
+++ b/server/test/validation.test.ts
@@ -1,5 +1,5 @@
 import "./matchers";
-import { validateAvailabilityInput } from "../src/validation";
+import { validateAvailabilityInput, validateState } from "../src/validation";
 import { Availability } from "../src/interfaces";
 import { ValueError } from "../src/exceptions";
 
@@ -143,5 +143,24 @@ describe("validateAvailabilityInput", () => {
         },
       ],
     });
+  });
+});
+
+describe("validateState", () => {
+  it("gets the postal abbreviation given a state name", () => {
+    expect(validateState("Oklahoma")).toEqual("OK");
+  });
+
+  it("gets the postal abbreviation given a postal abbreviation", () => {
+    expect(validateState("AL")).toEqual("AL");
+  });
+
+  it("ignores case", () => {
+    expect(validateState("OkLaHoMa")).toEqual("OK");
+    expect(validateState("oK")).toEqual("OK");
+  });
+
+  it("throws if no matching state is found", () => {
+    expect(() => validateState("whatever")).toThrow(ValueError);
   });
 });

--- a/server/test/validation.test.ts
+++ b/server/test/validation.test.ts
@@ -1,5 +1,9 @@
 import "./matchers";
-import { validateAvailabilityInput, validateState } from "../src/validation";
+import {
+  validateAvailabilityInput,
+  validateLocationInput,
+  validateState,
+} from "../src/validation";
 import { Availability } from "../src/interfaces";
 import { ValueError } from "../src/exceptions";
 
@@ -168,5 +172,70 @@ describe("validateState", () => {
     // Some values in the states.json file shouldn't be look-up-able.
     expect(() => validateState("State")).toThrow(ValueError);
     expect(() => validateState("")).toThrow(ValueError);
+  });
+});
+
+describe("validateLocationInput", () => {
+  it("returns a new object", () => {
+    const input = {
+      name: "A Place",
+      provider: "CVS",
+      state: "NJ",
+    };
+    const output = validateLocationInput(input);
+    expect(output).not.toBe(input);
+  });
+
+  it("removes location fields that aren't allowed", () => {
+    const input = {
+      name: "A Place",
+      provider: "CVS",
+      state: "NJ",
+      created_at: "2022-01-01T00:00:00Z",
+      updated_at: "2022-01-01T00:00:00Z",
+      availability: {},
+    };
+    const output = validateLocationInput(input);
+    expect(output).not.toHaveProperty("created_at");
+    expect(output).not.toHaveProperty("updated_at");
+    expect(output).not.toHaveProperty("availability");
+  });
+
+  it("throws on invalid data", () => {
+    const input = {
+      name: "A Place",
+      provider: "CVS",
+      state: "somewhere",
+    };
+    expect(() => validateLocationInput(input)).toThrow(ValueError);
+  });
+
+  it("fixes state abbreviations", () => {
+    const input = {
+      name: "A Place",
+      provider: "CVS",
+      state: "alaska",
+    };
+    expect(validateLocationInput(input)).toEqual({
+      name: "A Place",
+      provider: "CVS",
+      state: "AK",
+    });
+  });
+
+  it("checks required fields on demand", () => {
+    // Should pass without required fields by default.
+    validateLocationInput({ name: "Somewhere" });
+
+    // Should pass with required fields if requested.
+    validateLocationInput(
+      { name: "Somewhere", provider: "CVS", state: "AK" },
+      true
+    );
+
+    // Should fail if required fields are missing when requested.
+    expect(() =>
+      validateLocationInput({ name: "Somewhere" }, true)
+    ).toThrowError(ValueError);
   });
 });


### PR DESCRIPTION
This adds some validation logic to the server that ensures we always store states in the form of a two-letter postal abbreviation (e.g. “AK” for Alaska). This is already what we mostly have, but there are a handful of locations that have come in from PrepMod with different names (e.g. “alaska” or “Alaska”; PrepMod appears to allow free-form data in the state field). The basic premise here is to accept any known identifier for the state (it‘s full name, a postal abbreviation, an ISO name, etc.) and replace that with the postal abbreviation, or return a 422 error if we don’t recognize the state that was passed in.

While I was at it, I went ahead and wrote a more generalized `validateLocationInput()` function that does a few other minor validations (it handles one we already had, and adds a few others for safety). It stops short of validating the complete schema of the location input object, but I’ll add that in if anyone thinks we should just go ahead and do it.

This also includes a migration to clean out the existing bad data.

Fixes #444.