### PR TITLE
Handle Albertsons pharmacies with "Sav-On" brand

### DIFF
--- a/loader/src/sources/albertsons/corrections.js
+++ b/loader/src/sources/albertsons/corrections.js
@@ -103,6 +103,18 @@ module.exports.corrections = {
     address: "Jewel-Osco #1190 - 13460 S. Route 59, Plainfield, IL, 60544",
   },
 
+  // These two are the adult and pediatric versions of a single location, but
+  // one is labeled in the raw data as "Albertsons Pharmacy 4706" and the
+  // other is "Sav-On Pharmacy #4706" (we've verified they are really the same.)
+  1646603430085: {
+    address:
+      "Sav-On Pharmacy #4706 - 30530 Rancho California Rd., Temecula, CA, 92591",
+  },
+  1600119436879: {
+    address:
+      "Sav-On Pharmacy #4706 - 30530 Rancho California Rd., Temecula, CA, 92591",
+  },
+
   // Some Safeways have their pediatric vaccines listed as "Peds" instead of
   // "Safeway". Not sure it's safe to always assume Safeway is the right fix,
   // though, so we are doing manual corrections for each one.

--- a/loader/src/sources/albertsons/index.js
+++ b/loader/src/sources/albertsons/index.js
@@ -367,7 +367,7 @@ function parseNameAndAddress(text) {
   // Most store names are in the form "<Brand Name> NNNN", e.g. "Safeway 3189".
   // Sometimes names repeat after the store number, e.g. "Safeway 3189 Safeway".
   const numberMatch = name.match(
-    /^(?<name>.*?)\s+(?<number>\d{3,6})(?:\s+\1)?/
+    /^(?<name>.*?)\s+#?(?<number>\d{3,6})(?:\s+\1)?/
   );
   let storeNumber;
   if (numberMatch) {

--- a/loader/src/sources/albertsons/index.js
+++ b/loader/src/sources/albertsons/index.js
@@ -158,6 +158,12 @@ const BRANDS = [
   },
   {
     ...BASE_BRAND,
+    key: "sav_on",
+    name: "Sav-On Pharmacy",
+    pattern: /Sav-?On/i,
+  },
+  {
+    ...BASE_BRAND,
     key: "shaws",
     name: "Shaw's",
     pattern: /Shaw/i,


### PR DESCRIPTION
Albertsons has traditionally named all Sav-On pharmacies "Albertsons Pharmacy" in their data, but now some are surfacing as "Sav-On Pharmacy". This adds support for the new (old) branding.

The `sav_on` system name is the one we’re already using when we get these from CDC: https://github.com/usdigitalresponse/univaf/blob/d0477b1eb9e80d5b941ebc03e792d3fa99ac2656/loader/src/sources/cdc/api.js#L248-L250

One other thing worth noting here is that the above points to some de-duplication we might want to do: there are probably a lot of "Sav-On" locations from CDC that we have under a different name and ID from Albertsons.