### PR TITLE
Upgrade Node.js to v16.14.2 (latest LTS version)

### DIFF
--- a/loader/Dockerfile
+++ b/loader/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14
+FROM node:16.14.1-slim
 # Name for the version/release of the software. (Optional)
 ARG RELEASE
 
@@ -23,4 +23,3 @@ ENV API_KEY=""
 
 # run our built server
 ENTRYPOINT ["node", "./bin/univaf-loader", "--send", "--compact"]
-

--- a/loader/Dockerfile
+++ b/loader/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.14.1-slim
+FROM node:16.14.2-slim
 # Name for the version/release of the software. (Optional)
 ARG RELEASE
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.14.1-slim
+FROM node:16.14.2-slim
 
 # Upgrade to NPM 7
 RUN npm install -g npm

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14
+FROM node:16.14.1-slim
 
 # Upgrade to NPM 7
 RUN npm install -g npm

--- a/server/Dockerfile.seed-db
+++ b/server/Dockerfile.seed-db
@@ -4,7 +4,7 @@ FROM ubuntu:20.04
 RUN apt-get update
 RUN apt-get install -qy postgresql-client-12 curl
 
-RUN curl -fsSL https://deb.nodesource.com/setup_14.x | bash -
+RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
 RUN apt-get install -y nodejs
 
 # copy our files

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -42,7 +42,7 @@
         "@types/jest": "27.0.2",
         "@types/lodash": "4.14.171",
         "@types/luxon": "^1.27.1",
-        "@types/node": "14.14.31",
+        "@types/node": "16.11.26",
         "@types/pg": "^8.6.1",
         "@types/winston": "2.4.4",
         "@typescript-eslint/eslint-plugin": "4.32.0",
@@ -1490,9 +1490,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.19.tgz",
-      "integrity": "sha512-DJOSHzX7pCiSElWaGR8kCprwibCB/3yW6vcT8VG3P0SJjnv19gnWG/AZMfM60Xj/YJIp/YCaDHyvzsFVeniARA==",
+      "version": "4.17.28",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
+      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
@@ -1583,9 +1583,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.14.31",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
-      "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g==",
+      "version": "16.11.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.26.tgz",
+      "integrity": "sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -9608,9 +9608,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.19.tgz",
-      "integrity": "sha512-DJOSHzX7pCiSElWaGR8kCprwibCB/3yW6vcT8VG3P0SJjnv19gnWG/AZMfM60Xj/YJIp/YCaDHyvzsFVeniARA==",
+      "version": "4.17.28",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
+      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -9701,9 +9701,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.31",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
-      "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g==",
+      "version": "16.11.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.26.tgz",
+      "integrity": "sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/server/package.json
+++ b/server/package.json
@@ -64,7 +64,7 @@
     "@types/jest": "27.0.2",
     "@types/lodash": "4.14.171",
     "@types/luxon": "^1.27.1",
-    "@types/node": "14.14.31",
+    "@types/node": "16.11.26",
     "@types/pg": "^8.6.1",
     "@types/winston": "2.4.4",
     "@typescript-eslint/eslint-plugin": "4.32.0",

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "compilerOptions": {
-    // We require Node.js 14.x, so we can rely on recent ECMAScript support.
-    "lib": ["es2020"],
-    "target": "es2020",
+    // We require Node.js 16.x, so we can rely on recent ECMAScript support.
+    // See also https://github.com/tsconfig/bases for recommended values.
+    "lib": ["es2021"],
+    "target": "es2021",
 
     "module": "commonjs",
     "esModuleInterop": true,


### PR DESCRIPTION
This upgrades us from v14 to v16 of Node.js, which adds some nice new JS/TS language features. I’ve also switched to `-slim` Docker images, but have not really tested out that they work yet. Need to do that before merging.