### PR TITLE
Repair not-quite-valid URLs from CDC data

### DIFF
--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -27,7 +27,13 @@
 const Sentry = require("@sentry/node");
 
 const { Available, VaccineProduct } = require("../../model");
-const { httpClient, oneLine, titleCase, unpadNumber } = require("../../utils");
+const {
+  httpClient,
+  oneLine,
+  titleCase,
+  unpadNumber,
+  cleanUrl,
+} = require("../../utils");
 
 const API_HOST = "https://data.cdc.gov";
 const API_PATH = "/resource/5jp2-pgaw.json";
@@ -143,7 +149,7 @@ function formatStore(storeItems, checkedAt) {
       state: base.loc_admin_state,
       postal_code: base.loc_admin_zip,
       info_phone: base.loc_phone,
-      info_url: base.web_address,
+      info_url: cleanUrl(base.web_address),
       meta,
 
       availability: {

--- a/loader/src/utils.js
+++ b/loader/src/utils.js
@@ -542,7 +542,7 @@ module.exports = {
     let result = text?.trim();
     if (!result) return undefined;
 
-    const urlPattern = /^(https?:\/\/)?[^/\s]+\.[^/\s]{2,}(?:\/.*)?$/i;
+    const urlPattern = /^(https?:\/\/)?[^/\s]+\.[^/\s]{2,}(?:\/[^\s]*)?$/i;
     const urlParts = result.match(urlPattern);
     if (urlParts) {
       if (!urlParts[1]) {

--- a/loader/src/utils.js
+++ b/loader/src/utils.js
@@ -523,4 +523,34 @@ module.exports = {
 
     return undefined;
   },
+
+  /**
+   * Ensure a string is a complete URL. If it is already a valid URL, the input
+   * string is returned as-is. If it's missing a scheme (e.g. "www.kroger.com"),
+   * the returned value will have a scheme added. If null, undefined, or an
+   * empty string are passed in, `undefined` will be returned.
+   *
+   * If the input doesn't look like it's really a URL (e.g. "Not a URL!"), this
+   * will throw a `ParseError`.
+   *
+   * This is meant for fairly simple scenarios; more we should use an external
+   * dependency if our needs get much more complex.
+   * @param {string} text Something that should be a URL.
+   * @returns {string|undefined}
+   */
+  cleanUrl(text) {
+    let result = text?.trim();
+    if (!result) return undefined;
+
+    const urlPattern = /^(https?:\/\/)?[^/\s]+\.[^/\s]{2,}(?:\/.*)?$/i;
+    const urlParts = result.match(urlPattern);
+    if (urlParts) {
+      if (!urlParts[1]) {
+        result = `http://${result}`;
+      }
+      return result;
+    }
+
+    throw new ParseError(`Text is not a URL: "${text}"`);
+  },
 };

--- a/loader/test/cdc.api.test.js
+++ b/loader/test/cdc.api.test.js
@@ -127,4 +127,19 @@ describe("CDC Open Data API", () => {
       ["walmart", "148"],
     ]);
   });
+
+  it("cleans up not-quite-valid URLs", async () => {
+    const baseEntry = JSON.parse(await fs.readFile(fixturePath, "utf8"))[0];
+    const formatted = formatStore(
+      [
+        {
+          ...baseEntry,
+          web_address: "www.cvs.com/covid/",
+        },
+      ],
+      new Date()
+    );
+
+    expect(formatted).toHaveProperty("info_url", "http://www.cvs.com/covid/");
+  });
 });

--- a/loader/test/utils.test.js
+++ b/loader/test/utils.test.js
@@ -216,5 +216,8 @@ describe("cleanUrl", () => {
   it("throws for values that are not URL-like", () => {
     expect(() => cleanUrl("not a URL")).toThrow(ParseError);
     expect(() => cleanUrl("http://no-second-level-domain")).toThrow(ParseError);
+    expect(() =>
+      cleanUrl("http://example.com/path with some other text after the URL")
+    ).toThrow(ParseError);
   });
 });

--- a/loader/test/utils.test.js
+++ b/loader/test/utils.test.js
@@ -9,6 +9,7 @@ const {
   parseUsAddress,
   RateLimit,
   parseUsPhoneNumber,
+  cleanUrl,
 } = require("../src/utils");
 
 describe("splitOnce", () => {
@@ -186,5 +187,34 @@ describe("parseUsPhoneNumber", () => {
     expect(() => parseUsPhoneNumber("213.456.78901")).toThrow(ParseError);
 
     expect(() => parseUsPhoneNumber("Not a number")).toThrow(ParseError);
+  });
+});
+
+describe("cleanUrl", () => {
+  it("returns valid URLs as-is", () => {
+    let url = "https://something.com/yeah";
+    expect(cleanUrl(url)).toBe(url);
+
+    url = "https://deep.deep.subdomain.something.com/yeah?ok=sure";
+    expect(cleanUrl(url)).toBe(url);
+  });
+
+  it("adds a scheme to URLs that are missing one", () => {
+    expect(cleanUrl("whatever.com")).toBe("http://whatever.com");
+  });
+
+  it("strips leading and trailing spaces", () => {
+    expect(cleanUrl("  http://whatever.com ")).toBe("http://whatever.com");
+  });
+
+  it("returns undefined for empty input values", () => {
+    expect(cleanUrl(null)).toBe(undefined);
+    expect(cleanUrl("")).toBe(undefined);
+    expect(cleanUrl("    ")).toBe(undefined);
+  });
+
+  it("throws for values that are not URL-like", () => {
+    expect(() => cleanUrl("not a URL")).toThrow(ParseError);
+    expect(() => cleanUrl("http://no-second-level-domain")).toThrow(ParseError);
   });
 });


### PR DESCRIPTION
In #598 we added more robust schema checking for location data, and it turns out we were importing lots of not-quite-valid URLs from the CDC's dataset. Mainly these are just missing a scheme, e.g. "www.kroger.com" instead of "http://www.kroger.com". This adds a pretty simple routine for cleaning those up (and also handling leading/trailing spaces, etc.). It's simple enough that I didn't think an external dependency was worthwhile, but if we wanted to do more, then we should probably use something pre-built.

Fixes https://sentry.io/organizations/usdr/issues/3106483109 and https://sentry.io/organizations/usdr/issues/3106483083.