### PR TITLE
Support Chicago Fire Department community clinics

### DIFF
--- a/loader/src/sources/albertsons/index.js
+++ b/loader/src/sources/albertsons/index.js
@@ -209,9 +209,9 @@ const BRANDS = [
     locationType: LocationType.clinic,
     pattern: {
       test: (name) => {
-        // Some locations explicit support because they look like "name followed
-        // by store number", which we explicitly disallow for community clinics
-        // in the first pattern.
+        // Some locations need explicit support because they look like "name
+        // followed by store number", which we explicitly disallow for community
+        // clinics in the first pattern.
         return (
           !/(\w+\s+#?\d+$)|^\d+\s/.test(name) ||
           /^teamsters local/i.test(name) ||

--- a/loader/src/sources/albertsons/index.js
+++ b/loader/src/sources/albertsons/index.js
@@ -209,11 +209,13 @@ const BRANDS = [
     locationType: LocationType.clinic,
     pattern: {
       test: (name) => {
-        // Teamsters needs explicit support because it looks like "name followed
+        // Some locations explicit support because they look like "name followed
         // by store number", which we explicitly disallow for community clinics
         // in the first pattern.
         return (
-          !/(\w+\s+#?\d+$)|^\d+\s/.test(name) || /^teamsters local/i.test(name)
+          !/(\w+\s+#?\d+$)|^\d+\s/.test(name) ||
+          /^teamsters local/i.test(name) ||
+          /^chicago fire department/i.test(name)
         );
       },
     },


### PR DESCRIPTION
Albertsons now has a clinic at a Chicago Fire Department location, which uses a number (the firehouse number?), so it doesn't auto-identify as a community clinic. This adds a special case to support it, much like we did with the Teamsters Union hall.

Fixes https://sentry.io/organizations/usdr/issues/2809052505.