### PR TITLE
HOTFIX: Change external_ids primary key to bigint

### DIFF
--- a/server/migrations/20220415193103_change_external_id_pk_to_bigint.js
+++ b/server/migrations/20220415193103_change_external_id_pk_to_bigint.js
@@ -1,0 +1,25 @@
+/**
+ * Change the primary key type on `external_ids` from integer to bigint.
+ *
+ * We have an issue where we frequently do `INSERT INTO ... ON CONFLICT UPDATE`,
+ * and it turns out that increments the sequence for the primary key every time
+ * it runs. Even though we have relatively few rows, we've completely exhaused
+ * all possible integers! Changing the type to bigint gives us some breathing
+ * room to do something better (bigint is also big enough that we could just
+ * not solve the fundamental problem and still probably be fine for the lifetime
+ * of this project).
+ */
+
+exports.up = async function (knex) {
+  await knex.raw(`
+    ALTER TABLE external_ids ALTER COLUMN id TYPE bigint;
+    ALTER SEQUENCE external_ids_id_seq AS bigint;
+  `);
+};
+
+exports.down = async function (knex) {
+  await knex.raw(`
+    ALTER SEQUENCE external_ids_id_seq AS integer;
+    ALTER TABLE external_ids ALTER COLUMN id TYPE integer;
+  `);
+};


### PR DESCRIPTION
We've exhausted every possible integer for the primary key to the `external_ids` table, and as a result, and no longer insert or update any rows in it. Changing the type from integer to bigint gives us some breathing room for the system to keep operating, although we should ideally follow this up with a solution that doesn't run through sequence values so fast.

The fundamental problem here is that we manage external IDs by atomically upserting them (i.e. using a `INSERT INTO ... ON CONFLICT DO UPDATE ...` query), and requiring that they be unique by `(provider_location_id, system, value)`. Before PG can check for conflicts, evaluate constraints, etc. to validate an upsert and check for conflicts, it has to fill in all the default values, etc. on a column. If a column is based on a sequence, that means it has to increment the sequence before checking whether it will insert the column. Since the `id` column on `external_ids` is an integer sequence, that means every upsert call increments the sequence, even if it doesn’t actually insert a new row. So of course it blows through the entire set of all possible integers pretty quick.

Fixes https://sentry.io/organizations/usdr/issues/3195943236 and https://sentry.io/organizations/usdr/issues/3155794613