### PR TITLE
Fail CI if Nock.back recordings are missing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,8 @@ jobs:
           DB_PASSWORD: test-password
 
       - name: Run loader tests
+        env:
+          NOCK_BACK_MODE: lockdown
         run: |
           cd loader
           npm run test

--- a/loader/test/fixtures/nock/h-e-b_should_output_valid_data.json
+++ b/loader/test/fixtures/nock/h-e-b_should_output_valid_data.json
@@ -1,0 +1,7577 @@
+[
+    {
+        "scope": "https://heb-ecom-covid-vaccine.hebdigital-prd.com:443",
+        "method": "GET",
+        "path": "/vaccine_locations.json?v=853979742455.3682",
+        "body": "",
+        "status": 200,
+        "response": {
+            "locations": [
+                {
+                    "zip": "78664-4677",
+                    "url": null,
+                    "type": "store",
+                    "street": "1700 EAST PALM VALLEY BLVD",
+                    "storeNumber": 591,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Round Rock H-E-B plus!",
+                    "longitude": -97.65978,
+                    "latitude": 30.5177,
+                    "fluUrl": "",
+                    "city": "ROUND ROCK"
+                },
+                {
+                    "zip": "76574-7059",
+                    "url": null,
+                    "type": "store",
+                    "street": "100 N.W.CARLOS G.PARKER BL#101",
+                    "storeNumber": 593,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Taylor H-E-B",
+                    "longitude": -97.4167,
+                    "latitude": 30.6007,
+                    "fluUrl": "",
+                    "city": "TAYLOR"
+                },
+                {
+                    "zip": "78654-4902",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueXQAS",
+                    "type": "store",
+                    "street": "1503 FM 1431",
+                    "storeNumber": 735,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 14,
+                            "openAppointmentSlots": 14,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 22,
+                            "openAppointmentSlots": 22,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 36,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 36,
+                    "name": "Marble Falls H-E-B",
+                    "longitude": -98.27972,
+                    "latitude": 30.58301,
+                    "fluUrl": "",
+                    "city": "MARBLE FALLS"
+                },
+                {
+                    "zip": "78660-3153",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubQQAS",
+                    "type": "store",
+                    "street": "1434 WELLS BRANCH PKWY",
+                    "storeNumber": 236,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 79,
+                            "openAppointmentSlots": 79,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 62,
+                            "openAppointmentSlots": 62,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 141,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 141,
+                    "name": "Wells Branch H-E-B",
+                    "longitude": -97.66419,
+                    "latitude": 30.44263,
+                    "fluUrl": "",
+                    "city": "PFLUGERVILLE"
+                },
+                {
+                    "zip": "78664-7186",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucgQAC",
+                    "type": "store",
+                    "street": "603 LOUIS HENNA BLVD. BLDG A",
+                    "storeNumber": 495,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 10,
+                            "openAppointmentSlots": 10,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 11,
+                            "openAppointmentSlots": 11,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 21,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 21,
+                    "name": "Louis Henna Blvd H-E-B",
+                    "longitude": -97.65938,
+                    "latitude": 30.48179,
+                    "fluUrl": "",
+                    "city": "ROUND ROCK"
+                },
+                {
+                    "zip": "78641-0",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h6P0000004CWMQA2",
+                    "type": "store",
+                    "street": "19348 RONALD W.REAGAN BLVD",
+                    "storeNumber": 774,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 49,
+                            "openAppointmentSlots": 49,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 42,
+                            "openAppointmentSlots": 42,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 111,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 111,
+                    "name": "H-E-B at Ronald Reagan Blvd",
+                    "longitude": -97.82446,
+                    "latitude": 30.63307,
+                    "fluUrl": "",
+                    "city": "LEANDER"
+                },
+                {
+                    "zip": "77598-0",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h6P0000004ChoQAE",
+                    "type": "store",
+                    "street": "18611 EASTFIELD DR",
+                    "storeNumber": 769,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 185,
+                            "openAppointmentSlots": 185,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 208,
+                            "openAppointmentSlots": 208,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 210,
+                            "openAppointmentSlots": 210,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 210,
+                            "openAppointmentSlots": 210,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 603,
+                    "openFluTimeslots": 210,
+                    "openFluAppointmentSlots": 210,
+                    "openAppointmentSlots": 603,
+                    "name": "El Dorado H-E-B",
+                    "longitude": -95.14874,
+                    "latitude": 29.55117,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h6P0000004ChkQAE",
+                    "city": "WEBSTER"
+                },
+                {
+                    "zip": "78045-2802",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucLQAS",
+                    "type": "store",
+                    "street": "7811 MCPHERSON RD.",
+                    "storeNumber": 449,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 14,
+                            "openAppointmentSlots": 14,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 15,
+                            "openAppointmentSlots": 15,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 10,
+                            "openAppointmentSlots": 10,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 39,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 39,
+                    "name": "McPherson Rd H-E-B",
+                    "longitude": -99.4733,
+                    "latitude": 27.5754,
+                    "fluUrl": "",
+                    "city": "LAREDO"
+                },
+                {
+                    "zip": "78355-4365",
+                    "url": null,
+                    "type": "store",
+                    "street": "700 S SAINT MARYS ST",
+                    "storeNumber": 200,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Falfurrias H-E-B",
+                    "longitude": -98.14572,
+                    "latitude": 27.22043,
+                    "fluUrl": "",
+                    "city": "FALFURRIAS"
+                },
+                {
+                    "zip": "78756-1100",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gub9QAC",
+                    "type": "store",
+                    "street": "5808 BURNET RD",
+                    "storeNumber": 202,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 65,
+                            "openAppointmentSlots": 65,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 37,
+                            "openAppointmentSlots": 37,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 122,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 122,
+                    "name": "Burnet Rd H-E-B",
+                    "longitude": -97.74016,
+                    "latitude": 30.33374,
+                    "fluUrl": "",
+                    "city": "AUSTIN"
+                },
+                {
+                    "zip": "78237-3134",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubAQAS",
+                    "type": "store",
+                    "street": "721 CASTROVILLE RD",
+                    "storeNumber": 205,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 159,
+                            "openAppointmentSlots": 159,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 167,
+                            "openAppointmentSlots": 167,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 139,
+                            "openAppointmentSlots": 139,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 465,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 465,
+                    "name": "Las Palmas H-E-B",
+                    "longitude": -98.55132,
+                    "latitude": 29.41734,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "78040-5343",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubBQAS",
+                    "type": "store",
+                    "street": "1301 GUADALUPE ST.",
+                    "storeNumber": 207,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 16,
+                            "openAppointmentSlots": 16,
+                            "manufacturer": "Other"
+                        },
+                        {
+                            "openTimeslots": 7,
+                            "openAppointmentSlots": 7,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 18,
+                            "openAppointmentSlots": 18,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 4,
+                            "openAppointmentSlots": 4,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 29,
+                    "openFluTimeslots": 16,
+                    "openFluAppointmentSlots": 16,
+                    "openAppointmentSlots": 29,
+                    "name": "Guadalupe and Stone H-E-B",
+                    "longitude": -99.48344,
+                    "latitude": 27.50656,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF18QAE",
+                    "city": "LAREDO"
+                },
+                {
+                    "zip": "78412-2412",
+                    "url": null,
+                    "type": "store",
+                    "street": "4320 S. ALAMEDA ST.",
+                    "storeNumber": 210,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Alameda and Robert H-E-B",
+                    "longitude": -97.37175,
+                    "latitude": 27.73002,
+                    "fluUrl": "",
+                    "city": "CORPUS CHRISTI"
+                },
+                {
+                    "zip": "78202-3050",
+                    "url": null,
+                    "type": "store",
+                    "street": "415 N. NEW BRAUNFELS",
+                    "storeNumber": 211,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "New Braunfels and Houston H-E-B",
+                    "longitude": -98.46143,
+                    "latitude": 29.42444,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "78501-1926",
+                    "url": null,
+                    "type": "store",
+                    "street": "3200 N. 10TH STREET",
+                    "storeNumber": 212,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "N 10th and Fern H-E-B",
+                    "longitude": -98.22523,
+                    "latitude": 26.23246,
+                    "fluUrl": "",
+                    "city": "MCALLEN"
+                },
+                {
+                    "zip": "78758-2475",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubFQAS",
+                    "type": "store",
+                    "street": "12407 N. MOPAC EXPWY",
+                    "storeNumber": 218,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 149,
+                            "openAppointmentSlots": 149,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 30,
+                            "openAppointmentSlots": 30,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 179,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 179,
+                    "name": "Parmer and Mopac H-E-B",
+                    "longitude": -97.70326,
+                    "latitude": 30.41883,
+                    "fluUrl": "",
+                    "city": "AUSTIN"
+                },
+                {
+                    "zip": "78064-4221",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubyQAC",
+                    "type": "store",
+                    "street": "219 W OAKLAWN",
+                    "storeNumber": 411,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 62,
+                            "openAppointmentSlots": 62,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 126,
+                            "openAppointmentSlots": 126,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 130,
+                            "openAppointmentSlots": 130,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 130,
+                            "openAppointmentSlots": 130,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 448,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 448,
+                    "name": "Pleasanton H-E-B",
+                    "longitude": -98.48567,
+                    "latitude": 28.95696,
+                    "fluUrl": "",
+                    "city": "PLEASANTON"
+                },
+                {
+                    "zip": "78102-5613",
+                    "url": null,
+                    "type": "store",
+                    "street": "100 EAST HOUSTON ST.",
+                    "storeNumber": 412,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Beeville H-E-B",
+                    "longitude": -97.74667,
+                    "latitude": 28.40071,
+                    "fluUrl": "",
+                    "city": "BEEVILLE"
+                },
+                {
+                    "zip": "78404-2505",
+                    "url": null,
+                    "type": "store",
+                    "street": "3133 S. ALAMEDA",
+                    "storeNumber": 413,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Alameda / Texan Trail (Medical District)",
+                    "longitude": -97.3912,
+                    "latitude": 27.75745,
+                    "fluUrl": "",
+                    "city": "CORPUS CHRISTI"
+                },
+                {
+                    "zip": "77833-5521",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Guc1QAC",
+                    "type": "store",
+                    "street": "2508 S. DAY ST.",
+                    "storeNumber": 414,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 60,
+                            "openAppointmentSlots": 60,
+                            "manufacturer": "Other"
+                        },
+                        {
+                            "openTimeslots": 93,
+                            "openAppointmentSlots": 93,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 69,
+                            "openAppointmentSlots": 69,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 70,
+                            "openAppointmentSlots": 70,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 232,
+                    "openFluTimeslots": 60,
+                    "openFluAppointmentSlots": 60,
+                    "openAppointmentSlots": 232,
+                    "name": "Brenham H-E-B",
+                    "longitude": -96.39591,
+                    "latitude": 30.14381,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2XQAU",
+                    "city": "BRENHAM"
+                },
+                {
+                    "zip": "78154-1264",
+                    "url": null,
+                    "type": "store",
+                    "street": "17460 I.H. 35 NORTH",
+                    "storeNumber": 415,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Schertz H-E-B plus!",
+                    "longitude": -98.27742,
+                    "latitude": 29.59717,
+                    "fluUrl": "",
+                    "city": "SCHERTZ"
+                },
+                {
+                    "zip": "78945-2655",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Guc3QAC",
+                    "type": "store",
+                    "street": "450 E. TRAVIS",
+                    "storeNumber": 416,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 150,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 150,
+                    "name": "La Grange H-E-B",
+                    "longitude": -96.87264,
+                    "latitude": 29.9073,
+                    "fluUrl": "",
+                    "city": "LA GRANGE"
+                },
+                {
+                    "zip": "78840-4658",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Guc4QAC",
+                    "type": "store",
+                    "street": "200 VETERAN'S BLVD",
+                    "storeNumber": 418,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 11,
+                            "openAppointmentSlots": 11,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 2,
+                            "openAppointmentSlots": 2,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 11,
+                            "openAppointmentSlots": 11,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 24,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 24,
+                    "name": "Avenue F and Gibbs H-E-B",
+                    "longitude": -100.8998,
+                    "latitude": 29.36632,
+                    "fluUrl": "",
+                    "city": "DEL RIO"
+                },
+                {
+                    "zip": "78852-4718",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Guc5QAC",
+                    "type": "store",
+                    "street": "2135 E. MAIN",
+                    "storeNumber": 419,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 18,
+                            "openAppointmentSlots": 18,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 1,
+                            "openAppointmentSlots": 1,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 23,
+                            "openAppointmentSlots": 23,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 42,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 42,
+                    "name": "Eagle Pass H-E-B",
+                    "longitude": -100.48583,
+                    "latitude": 28.70894,
+                    "fluUrl": "",
+                    "city": "EAGLE PASS"
+                },
+                {
+                    "zip": "78516-2315",
+                    "url": null,
+                    "type": "store",
+                    "street": "1211 EAST FRONTAGE RD.",
+                    "storeNumber": 421,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Alamo H-E-B",
+                    "longitude": -98.12414,
+                    "latitude": 26.19073,
+                    "fluUrl": "",
+                    "city": "ALAMO"
+                },
+                {
+                    "zip": "76710-4437",
+                    "url": null,
+                    "type": "store",
+                    "street": "1301 WOODED ACRES",
+                    "storeNumber": 423,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Wooded Acres H-E-B",
+                    "longitude": -97.1894,
+                    "latitude": 31.53274,
+                    "fluUrl": "",
+                    "city": "WACO"
+                },
+                {
+                    "zip": "78861-2504",
+                    "url": null,
+                    "type": "store",
+                    "street": "609 19TH STREET",
+                    "storeNumber": 424,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Hondo H-E-B",
+                    "longitude": -99.13501,
+                    "latitude": 29.34784,
+                    "fluUrl": "",
+                    "city": "HONDO"
+                },
+                {
+                    "zip": "78751-4810",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Guc9QAC",
+                    "type": "store",
+                    "street": "1000 EAST 41 ST.",
+                    "storeNumber": 425,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 24,
+                            "openAppointmentSlots": 24,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 115,
+                            "openAppointmentSlots": 115,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 98,
+                            "openAppointmentSlots": 98,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 30,
+                            "openAppointmentSlots": 30,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 267,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 267,
+                    "name": "Hancock Center H-E-B",
+                    "longitude": -97.71973,
+                    "latitude": 30.30057,
+                    "fluUrl": "",
+                    "city": "AUSTIN"
+                },
+                {
+                    "zip": "75165-1884",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucAQAS",
+                    "type": "store",
+                    "street": "800 HWY 77",
+                    "storeNumber": 426,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 47,
+                            "openAppointmentSlots": 47,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 80,
+                            "openAppointmentSlots": 80,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 93,
+                            "openAppointmentSlots": 93,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 49,
+                            "openAppointmentSlots": 49,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 269,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 269,
+                    "name": "Waxahachie H-E-B",
+                    "longitude": -96.83983,
+                    "latitude": 32.41159,
+                    "fluUrl": "",
+                    "city": "WAXAHACHIE"
+                },
+                {
+                    "zip": "78221-1642",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucBQAS",
+                    "type": "store",
+                    "street": "735 SW MILITARY",
+                    "storeNumber": 427,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 93,
+                            "openAppointmentSlots": 93,
+                            "manufacturer": "Other"
+                        },
+                        {
+                            "openTimeslots": 80,
+                            "openAppointmentSlots": 80,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 62,
+                            "openAppointmentSlots": 62,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 36,
+                            "openAppointmentSlots": 36,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 178,
+                    "openFluTimeslots": 93,
+                    "openFluAppointmentSlots": 93,
+                    "openAppointmentSlots": 178,
+                    "name": "Military and Pleasanton H-E-B",
+                    "longitude": -98.50277,
+                    "latitude": 29.35666,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2hQAE",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "78213-1343",
+                    "url": null,
+                    "type": "store",
+                    "street": "11551 WEST AVE.",
+                    "storeNumber": 195,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Blanco and West Ave H-E-B",
+                    "longitude": -98.51025,
+                    "latitude": 29.54526,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "78660-8045",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucYQAS",
+                    "type": "store",
+                    "street": "201 N FM 685",
+                    "storeNumber": 479,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 3,
+                            "openAppointmentSlots": 3,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 134,
+                            "openAppointmentSlots": 134,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 139,
+                            "openAppointmentSlots": 139,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 141,
+                            "openAppointmentSlots": 141,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 140,
+                            "openAppointmentSlots": 140,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 417,
+                    "openFluTimeslots": 140,
+                    "openFluAppointmentSlots": 140,
+                    "openAppointmentSlots": 417,
+                    "name": "Pflugerville H-E-B",
+                    "longitude": -97.6133,
+                    "latitude": 30.4373,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF34QAE",
+                    "city": "PFLUGERVILLE"
+                },
+                {
+                    "zip": "78230-2212",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucZQAS",
+                    "type": "store",
+                    "street": "9900 WURZBACH",
+                    "storeNumber": 480,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 150,
+                            "openAppointmentSlots": 150,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 146,
+                            "openAppointmentSlots": 146,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 346,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 346,
+                    "name": "I10 and Wurzbach H-E-B",
+                    "longitude": -98.5595,
+                    "latitude": 29.5336,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "78596-2700",
+                    "url": null,
+                    "type": "store",
+                    "street": "310 N. WESTGATE DRIVE",
+                    "storeNumber": 485,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "83 and Westgate H-E-B",
+                    "longitude": -97.98934,
+                    "latitude": 26.17109,
+                    "fluUrl": "",
+                    "city": "WESLACO"
+                },
+                {
+                    "zip": "78628-0",
+                    "url": null,
+                    "type": "store",
+                    "street": "4500 WILLIAMS DRIVE",
+                    "storeNumber": 487,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Williams Drive H-E-B",
+                    "longitude": -97.71873,
+                    "latitude": 30.68312,
+                    "fluUrl": "",
+                    "city": "GEORGETOWN"
+                },
+                {
+                    "zip": "78543-9800",
+                    "url": null,
+                    "type": "store",
+                    "street": "512 E. EDINBURG AVE.",
+                    "storeNumber": 677,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Elsa H-E-B",
+                    "longitude": -97.99272,
+                    "latitude": 26.29384,
+                    "fluUrl": "",
+                    "city": "ELSA"
+                },
+                {
+                    "zip": "78227-4602",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudyQAC",
+                    "type": "store",
+                    "street": "368 VALLEY HI DRIVE",
+                    "storeNumber": 678,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 69,
+                            "openAppointmentSlots": 69,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 132,
+                            "openAppointmentSlots": 132,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 64,
+                            "openAppointmentSlots": 64,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 1242,
+                            "openAppointmentSlots": 1242,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 265,
+                    "openFluTimeslots": 1242,
+                    "openFluAppointmentSlots": 1242,
+                    "openAppointmentSlots": 265,
+                    "name": "Valley Hi H-E-B",
+                    "longitude": -98.64021,
+                    "latitude": 29.38099,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF59QAE",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "76033-4830",
+                    "url": null,
+                    "type": "store",
+                    "street": "600 W HENDERSON",
+                    "storeNumber": 679,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Cleburne H-E-B",
+                    "longitude": -97.39485,
+                    "latitude": 32.3478,
+                    "fluUrl": "",
+                    "city": "CLEBURNE"
+                },
+                {
+                    "zip": "77375-1478",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gue0QAC",
+                    "type": "store",
+                    "street": "26500 KUYKENDAHL RD",
+                    "storeNumber": 686,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 36,
+                            "openAppointmentSlots": 36,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 85,
+                            "openAppointmentSlots": 85,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 18,
+                            "openAppointmentSlots": 18,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 228,
+                            "openAppointmentSlots": 228,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 139,
+                    "openFluTimeslots": 228,
+                    "openFluAppointmentSlots": 228,
+                    "openAppointmentSlots": 139,
+                    "name": "Creekside Park H-E-B",
+                    "longitude": -95.55072,
+                    "latitude": 30.14362,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF5BQAU",
+                    "city": "TOMBALL"
+                },
+                {
+                    "zip": "77057-3061",
+                    "url": null,
+                    "type": "store",
+                    "street": "5895 SAN FELIPE STREET",
+                    "storeNumber": 687,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "San Felipe H-E-B",
+                    "longitude": -95.48512,
+                    "latitude": 29.74797,
+                    "fluUrl": "",
+                    "city": "HOUSTON"
+                },
+                {
+                    "zip": "78332-5046",
+                    "url": null,
+                    "type": "store",
+                    "street": "1115 E. MAIN",
+                    "storeNumber": 223,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Alice H-E-B",
+                    "longitude": -98.06425,
+                    "latitude": 27.75141,
+                    "fluUrl": "",
+                    "city": "ALICE"
+                },
+                {
+                    "zip": "78250-3232",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubHQAS",
+                    "type": "store",
+                    "street": "7951 GUILBEAU RD.",
+                    "storeNumber": 224,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 147,
+                            "openAppointmentSlots": 147,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 153,
+                            "openAppointmentSlots": 153,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 52,
+                            "openAppointmentSlots": 52,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 352,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 352,
+                    "name": "Bandera and Guilbeau H-E-B",
+                    "longitude": -98.64364,
+                    "latitude": 29.51985,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "78736-8300",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubIQAS",
+                    "type": "store",
+                    "street": "7901 US-290",
+                    "storeNumber": 765,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 15,
+                            "openAppointmentSlots": 15,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 15,
+                            "openAppointmentSlots": 15,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 4,
+                            "openAppointmentSlots": 4,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 34,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 34,
+                    "name": "Oak Hill H-E-B",
+                    "longitude": -97.88755,
+                    "latitude": 30.22696,
+                    "fluUrl": "",
+                    "city": "AUSTIN"
+                },
+                {
+                    "zip": "78611-3201",
+                    "url": null,
+                    "type": "store",
+                    "street": "105 S BOUNDARY",
+                    "storeNumber": 433,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Burnet H-E-B",
+                    "longitude": -98.22452,
+                    "latitude": 30.7588,
+                    "fluUrl": "",
+                    "city": "BURNET"
+                },
+                {
+                    "zip": "77979-2423",
+                    "url": null,
+                    "type": "store",
+                    "street": "101 CALHOUN PLAZA",
+                    "storeNumber": 434,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Port Lavaca H-E-B",
+                    "longitude": -96.64126,
+                    "latitude": 28.62096,
+                    "fluUrl": "",
+                    "city": "PORT LAVACA"
+                },
+                {
+                    "zip": "78801-5638",
+                    "url": null,
+                    "type": "store",
+                    "street": "201 EAST MAIN",
+                    "storeNumber": 441,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Uvalde H-E-B",
+                    "longitude": -99.78378,
+                    "latitude": 29.21013,
+                    "fluUrl": "",
+                    "city": "UVALDE"
+                },
+                {
+                    "zip": "78223-3814",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucHQAS",
+                    "type": "store",
+                    "street": "3323 SE MILITARY DR.",
+                    "storeNumber": 444,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 120,
+                            "openAppointmentSlots": 120,
+                            "manufacturer": "Other"
+                        },
+                        {
+                            "openTimeslots": 120,
+                            "openAppointmentSlots": 120,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 120,
+                            "openAppointmentSlots": 120,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 120,
+                            "openAppointmentSlots": 120,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 360,
+                    "openFluTimeslots": 120,
+                    "openFluAppointmentSlots": 120,
+                    "openAppointmentSlots": 360,
+                    "name": "Military and Goliad H-E-B",
+                    "longitude": -98.4362,
+                    "latitude": 29.35194,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2nQAE",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "78644-2702",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucIQAS",
+                    "type": "store",
+                    "street": "403 SOUTH COLORADO STREET",
+                    "storeNumber": 445,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 77,
+                            "openAppointmentSlots": 77,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 79,
+                            "openAppointmentSlots": 79,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 156,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 156,
+                    "name": "Lockhart H-E-B",
+                    "longitude": -97.66994,
+                    "latitude": 29.88213,
+                    "fluUrl": "",
+                    "city": "LOCKHART"
+                },
+                {
+                    "zip": "78521-1609",
+                    "url": null,
+                    "type": "store",
+                    "street": "2155 PAREDES LINE RD",
+                    "storeNumber": 446,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Paredes and Torres H-E-B plus!",
+                    "longitude": -97.48904,
+                    "latitude": 25.95015,
+                    "fluUrl": "",
+                    "city": "BROWNSVILLE"
+                },
+                {
+                    "zip": "78572-5362",
+                    "url": null,
+                    "type": "store",
+                    "street": "820 S. CONWAY",
+                    "storeNumber": 226,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Conway and 9th St H-E-B",
+                    "longitude": -98.3262,
+                    "latitude": 26.21354,
+                    "fluUrl": "",
+                    "city": "MISSION"
+                },
+                {
+                    "zip": "78374-2816",
+                    "url": null,
+                    "type": "store",
+                    "street": "1600 WILDCAT DRIVE",
+                    "storeNumber": 488,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Portland H-E-B",
+                    "longitude": -97.31836,
+                    "latitude": 27.88722,
+                    "fluUrl": "",
+                    "city": "PORTLAND"
+                },
+                {
+                    "zip": "78521-2216",
+                    "url": null,
+                    "type": "store",
+                    "street": "2250 BOCA CHICA",
+                    "storeNumber": 489,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Boca Chica H-E-B",
+                    "longitude": -97.48722,
+                    "latitude": 25.92214,
+                    "fluUrl": "",
+                    "city": "BROWNSVILLE"
+                },
+                {
+                    "zip": "77084-5813",
+                    "url": null,
+                    "type": "store",
+                    "street": "1550 FRY RD",
+                    "storeNumber": 492,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Fry Rd and I10 H-E-B",
+                    "longitude": -95.7189,
+                    "latitude": 29.7898,
+                    "fluUrl": "",
+                    "city": "HOUSTON"
+                },
+                {
+                    "zip": "78251-1320",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucfQAC",
+                    "type": "store",
+                    "street": "10660 WEST FM 471",
+                    "storeNumber": 494,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 45,
+                            "openAppointmentSlots": 45,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 17,
+                            "openAppointmentSlots": 17,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 259,
+                            "openAppointmentSlots": 259,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 43,
+                            "openAppointmentSlots": 43,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 259,
+                            "openAppointmentSlots": 259,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 364,
+                    "openFluTimeslots": 259,
+                    "openFluAppointmentSlots": 259,
+                    "openAppointmentSlots": 364,
+                    "name": "Culebra and 1604 H-E-B",
+                    "longitude": -98.70445,
+                    "latitude": 29.49292,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3BQAU",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "77701-0",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gue2QAC",
+                    "type": "store",
+                    "street": "3590 COLLEGE ST",
+                    "storeNumber": 692,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 119,
+                            "openAppointmentSlots": 119,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 103,
+                            "openAppointmentSlots": 103,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 222,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 222,
+                    "name": "Beaumont 6 H-E-B",
+                    "longitude": -94.12834,
+                    "latitude": 30.06853,
+                    "fluUrl": "",
+                    "city": "BEAUMONT"
+                },
+                {
+                    "zip": "78119-0",
+                    "url": null,
+                    "type": "store",
+                    "street": "107 N. SUNSET STRIP",
+                    "storeNumber": 693,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Kenedy H-E-B",
+                    "longitude": -97.85797,
+                    "latitude": 28.81419,
+                    "fluUrl": "",
+                    "city": "KENEDY"
+                },
+                {
+                    "zip": "78130-4678",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gue4QAC",
+                    "type": "store",
+                    "street": "2965 IH35 NORTH",
+                    "storeNumber": 694,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 78,
+                            "openAppointmentSlots": 78,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 621,
+                            "openAppointmentSlots": 621,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 699,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 699,
+                    "name": "New Braunfels H-E-B plus!",
+                    "longitude": -98.0782,
+                    "latitude": 29.731,
+                    "fluUrl": "",
+                    "city": "NEW BRAUNFELS"
+                },
+                {
+                    "zip": "78634-2025",
+                    "url": null,
+                    "type": "store",
+                    "street": "5000 GATTIS SCHOOL RD",
+                    "storeNumber": 696,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Hutto 130 and Gattis School H-E-B plus!",
+                    "longitude": -97.58284,
+                    "latitude": 30.50112,
+                    "fluUrl": "",
+                    "city": "HUTTO"
+                },
+                {
+                    "zip": "77573-3360",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gue6QAC",
+                    "type": "store",
+                    "street": "2755 E.LEAGUE CITY PARKWAY",
+                    "storeNumber": 697,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 103,
+                            "openAppointmentSlots": 103,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 102,
+                            "openAppointmentSlots": 102,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 28,
+                            "openAppointmentSlots": 28,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 225,
+                    "openFluTimeslots": 28,
+                    "openFluAppointmentSlots": 28,
+                    "openAppointmentSlots": 225,
+                    "name": "League City H-E-B",
+                    "longitude": -95.04131,
+                    "latitude": 29.50588,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF0uQAE",
+                    "city": "LEAGUE CITY"
+                },
+                {
+                    "zip": "79764-7155",
+                    "url": null,
+                    "type": "store",
+                    "street": "2501 W UNIVERSITY BLVD",
+                    "storeNumber": 711,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "University Blvd H-E-B",
+                    "longitude": -102.41008,
+                    "latitude": 31.86213,
+                    "fluUrl": "",
+                    "city": "ODESSA"
+                },
+                {
+                    "zip": "77954-2126",
+                    "url": null,
+                    "type": "store",
+                    "street": "909 E BROADWAY",
+                    "storeNumber": 712,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Cuero H-E-B",
+                    "longitude": -97.28051,
+                    "latitude": 29.08949,
+                    "fluUrl": "",
+                    "city": "CUERO"
+                },
+                {
+                    "zip": "77059-2511",
+                    "url": null,
+                    "type": "store",
+                    "street": "3501 CLEAR LAKE CITY BLVD",
+                    "storeNumber": 713,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Clear Lake Marketplace H-E-B",
+                    "longitude": -95.12473,
+                    "latitude": 29.60563,
+                    "fluUrl": "",
+                    "city": "HOUSTON"
+                },
+                {
+                    "zip": "78734-6238",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueJQAS",
+                    "type": "store",
+                    "street": "2000 RANCH ROAD 620 S",
+                    "storeNumber": 714,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 14,
+                            "openAppointmentSlots": 14,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 14,
+                            "openAppointmentSlots": 14,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 28,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 28,
+                    "name": "Lakeway H-E-B",
+                    "longitude": -97.96662,
+                    "latitude": 30.34368,
+                    "fluUrl": "",
+                    "city": "LAKEWAY"
+                },
+                {
+                    "zip": "77536-5404",
+                    "url": null,
+                    "type": "store",
+                    "street": "4701 EAST BLVD",
+                    "storeNumber": 715,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Deer Park H-E-B",
+                    "longitude": -95.09805,
+                    "latitude": 29.6652,
+                    "fluUrl": "",
+                    "city": "DEER PARK"
+                },
+                {
+                    "zip": "78041-2205",
+                    "url": null,
+                    "type": "store",
+                    "street": "210 WEST DEL MAR BOULEVARD",
+                    "storeNumber": 570,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "35 and Del Mar H-E-B",
+                    "longitude": -99.49676,
+                    "latitude": 27.56786,
+                    "fluUrl": "",
+                    "city": "LAREDO"
+                },
+                {
+                    "zip": "78572-2912",
+                    "url": null,
+                    "type": "store",
+                    "street": "200 EAST GRIFFIN",
+                    "storeNumber": 571,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Conway & Griffin Pkwy H-E-B",
+                    "longitude": -98.32225,
+                    "latitude": 26.22834,
+                    "fluUrl": "",
+                    "city": "MISSION"
+                },
+                {
+                    "zip": "77375-4546",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gud3QAC",
+                    "type": "store",
+                    "street": "28520 TOMBALL PARKWAY",
+                    "storeNumber": 574,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 97,
+                            "openAppointmentSlots": 97,
+                            "manufacturer": "Other"
+                        },
+                        {
+                            "openTimeslots": 42,
+                            "openAppointmentSlots": 42,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 35,
+                            "openAppointmentSlots": 35,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 127,
+                    "openFluTimeslots": 97,
+                    "openFluAppointmentSlots": 97,
+                    "openAppointmentSlots": 127,
+                    "name": "Tomball Pkwy and Graham H-E-B",
+                    "longitude": -95.63218,
+                    "latitude": 30.08868,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3ZQAU",
+                    "city": "TOMBALL"
+                },
+                {
+                    "zip": "77379-7234",
+                    "url": null,
+                    "type": "store",
+                    "street": "7310 LOUETTA",
+                    "storeNumber": 576,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Louetta and Stuebner H-E-B",
+                    "longitude": -95.5243,
+                    "latitude": 30.0209,
+                    "fluUrl": "",
+                    "city": "SPRING"
+                },
+                {
+                    "zip": "77043-1803",
+                    "url": null,
+                    "type": "store",
+                    "street": "10251 KEMPWOOD",
+                    "storeNumber": 577,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Kempwood and Gessner H-E-B",
+                    "longitude": -95.5468,
+                    "latitude": 29.8226,
+                    "fluUrl": "",
+                    "city": "HOUSTON"
+                },
+                {
+                    "zip": "77380-1531",
+                    "url": null,
+                    "type": "store",
+                    "street": "9595 SIX PINES RD",
+                    "storeNumber": 579,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Woodlands Market H-E-B",
+                    "longitude": -95.46575,
+                    "latitude": 30.16409,
+                    "fluUrl": "",
+                    "city": "THE WOODLANDS"
+                },
+                {
+                    "zip": "78613-7273",
+                    "url": null,
+                    "type": "store",
+                    "street": "2800 EAST WHITESTONE",
+                    "storeNumber": 580,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Parmer and Whitestone H-E-B",
+                    "longitude": -97.78545,
+                    "latitude": 30.5328,
+                    "fluUrl": "",
+                    "city": "CEDAR PARK"
+                },
+                {
+                    "zip": "76401-3928",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaDQAS",
+                    "type": "store",
+                    "street": "2150 W. WASHINGTON",
+                    "storeNumber": 6,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 17,
+                            "openAppointmentSlots": 17,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 18,
+                            "openAppointmentSlots": 18,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 6,
+                            "openAppointmentSlots": 6,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 18,
+                            "openAppointmentSlots": 18,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 41,
+                    "openFluTimeslots": 18,
+                    "openFluAppointmentSlots": 18,
+                    "openAppointmentSlots": 41,
+                    "name": "Stephenville H-E-B",
+                    "longitude": -98.22569,
+                    "latitude": 32.20975,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3tQAE",
+                    "city": "STEPHENVILLE"
+                },
+                {
+                    "zip": "78748-5992",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubKQAS",
+                    "type": "store",
+                    "street": "2110 WEST SLAUGHTER LN",
+                    "storeNumber": 227,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 96,
+                            "openAppointmentSlots": 96,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 57,
+                            "openAppointmentSlots": 57,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 34,
+                            "openAppointmentSlots": 34,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 40,
+                            "openAppointmentSlots": 40,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 187,
+                    "openFluTimeslots": 40,
+                    "openFluAppointmentSlots": 40,
+                    "openAppointmentSlots": 187,
+                    "name": "Slaughter and Manchaca H-E-B",
+                    "longitude": -97.82509,
+                    "latitude": 30.17524,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF1WQAU",
+                    "city": "AUSTIN"
+                },
+                {
+                    "zip": "78744-3410",
+                    "url": null,
+                    "type": "store",
+                    "street": "6607 SOUTH IH 35",
+                    "storeNumber": 229,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "I 35 and William Cannon H-E-B",
+                    "longitude": -97.76922,
+                    "latitude": 30.19107,
+                    "fluUrl": "",
+                    "city": "AUSTIN"
+                },
+                {
+                    "zip": "78247-1979",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubMQAS",
+                    "type": "store",
+                    "street": "14087 O'CONNOR RD",
+                    "storeNumber": 230,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 100,
+                            "openAppointmentSlots": 100,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 366,
+                            "openAppointmentSlots": 366,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 461,
+                            "openAppointmentSlots": 461,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 46,
+                            "openAppointmentSlots": 46,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 973,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 973,
+                    "name": "Nacogdoches and O'Connor H-E-B",
+                    "longitude": -98.3856,
+                    "latitude": 29.56937,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "78596-4511",
+                    "url": null,
+                    "type": "store",
+                    "street": "1004 N. TEXAS",
+                    "storeNumber": 231,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "83 and N Texas H-E-B",
+                    "longitude": -97.99096,
+                    "latitude": 26.17103,
+                    "fluUrl": "",
+                    "city": "WESLACO"
+                },
+                {
+                    "zip": "77488-3204",
+                    "url": null,
+                    "type": "store",
+                    "street": "1616 N ALABAMA",
+                    "storeNumber": 233,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Wharton H-E-B",
+                    "longitude": -96.08492,
+                    "latitude": 29.32162,
+                    "fluUrl": "",
+                    "city": "WHARTON"
+                },
+                {
+                    "zip": "77450-4564",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuchQAC",
+                    "type": "store",
+                    "street": "1621 MASON ROAD",
+                    "storeNumber": 497,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 71,
+                            "openAppointmentSlots": 71,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 66,
+                            "openAppointmentSlots": 66,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 70,
+                            "openAppointmentSlots": 70,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 137,
+                    "openFluTimeslots": 70,
+                    "openFluAppointmentSlots": 70,
+                    "openAppointmentSlots": 137,
+                    "name": "Mason Rd H-E-B",
+                    "longitude": -95.75102,
+                    "latitude": 29.75787,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3DQAU",
+                    "city": "KATY"
+                },
+                {
+                    "zip": "77346-3128",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuciQAC",
+                    "type": "store",
+                    "street": "7405 FM 1960 EAST",
+                    "storeNumber": 498,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 45,
+                            "openAppointmentSlots": 45,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 25,
+                            "openAppointmentSlots": 25,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 70,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 70,
+                    "name": "Atascocita H-E-B",
+                    "longitude": -95.1642,
+                    "latitude": 29.9983,
+                    "fluUrl": "",
+                    "city": "HUMBLE"
+                },
+                {
+                    "zip": "77087-2558",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucjQAC",
+                    "type": "store",
+                    "street": "3111 WOODRIDGE, SUITE 500",
+                    "storeNumber": 540,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 151,
+                            "openAppointmentSlots": 151,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 65,
+                            "openAppointmentSlots": 65,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 156,
+                            "openAppointmentSlots": 156,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 108,
+                            "openAppointmentSlots": 108,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 480,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 480,
+                    "name": "Gulfgate H-E-B",
+                    "longitude": -95.2968,
+                    "latitude": 29.6994,
+                    "fluUrl": "",
+                    "city": "HOUSTON"
+                },
+                {
+                    "zip": "77072-5000",
+                    "url": null,
+                    "type": "store",
+                    "street": "10100 BEECHNUT",
+                    "storeNumber": 541,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Beechnut H-E-B",
+                    "longitude": -95.5604,
+                    "latitude": 29.6896,
+                    "fluUrl": "",
+                    "city": "HOUSTON"
+                },
+                {
+                    "zip": "77840-3914",
+                    "url": null,
+                    "type": "store",
+                    "street": "1900 TEXAS AVENUE SOUTH",
+                    "storeNumber": 543,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Texas Avenue H-E-B",
+                    "longitude": -96.3165,
+                    "latitude": 30.6131,
+                    "fluUrl": "",
+                    "city": "COLLEGE STATION"
+                },
+                {
+                    "zip": "77429-6286",
+                    "url": null,
+                    "type": "store",
+                    "street": "14100 SPRING CYPRESS RD",
+                    "storeNumber": 698,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Grant and Spring Cypress H-E-B",
+                    "longitude": -95.63698,
+                    "latitude": 30.00365,
+                    "fluUrl": "",
+                    "city": "CYPRESS"
+                },
+                {
+                    "zip": "78204-2427",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gue8QAC",
+                    "type": "store",
+                    "street": "1601 NOGALITOS",
+                    "storeNumber": 699,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 150,
+                            "openAppointmentSlots": 150,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 150,
+                            "openAppointmentSlots": 150,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 300,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 300,
+                    "name": "Nogalitos H-E-B",
+                    "longitude": -98.51485,
+                    "latitude": 29.39799,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "79761-5034",
+                    "url": null,
+                    "type": "store",
+                    "street": "540 W.5TH",
+                    "storeNumber": 700,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "H-E-B Pharmacy at the Medical Center Hospital",
+                    "longitude": -102.37476,
+                    "latitude": 31.84625,
+                    "fluUrl": "",
+                    "city": "ODESSA"
+                },
+                {
+                    "zip": "78201-3848",
+                    "url": null,
+                    "type": "store",
+                    "street": "3485 FREDERICKSBURG RD,SUITE 4",
+                    "storeNumber": 701,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "H-E-B SPECIALTY PHARMACY",
+                    "longitude": -98.53904,
+                    "latitude": 29.47602,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "78501-2951",
+                    "url": null,
+                    "type": "store",
+                    "street": "200 US EXPRESSWAY 83",
+                    "storeNumber": 702,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "South 2nd Street H-E-B",
+                    "longitude": -98.22546,
+                    "latitude": 26.18953,
+                    "fluUrl": "",
+                    "city": "MCALLEN"
+                },
+                {
+                    "zip": "77386-4343",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueCQAS",
+                    "type": "store",
+                    "street": "3540 RAYFORD RD",
+                    "storeNumber": 705,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 79,
+                            "openAppointmentSlots": 79,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 199,
+                            "openAppointmentSlots": 199,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 200,
+                            "openAppointmentSlots": 200,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 478,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 478,
+                    "name": "Spring Creek Market H-E-B",
+                    "longitude": -95.38801,
+                    "latitude": 30.11036,
+                    "fluUrl": "",
+                    "city": "SPRING"
+                },
+                {
+                    "zip": "78155-5131",
+                    "url": null,
+                    "type": "store",
+                    "street": "1340 E COURT ST",
+                    "storeNumber": 716,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Seguin H-E-B",
+                    "longitude": -97.94366,
+                    "latitude": 29.57065,
+                    "fluUrl": "",
+                    "city": "SEGUIN"
+                },
+                {
+                    "zip": "79706-2851",
+                    "url": null,
+                    "type": "store",
+                    "street": "5407 ANDREWS HIGHWAY",
+                    "storeNumber": 717,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Midland Loop 250 H-E-B",
+                    "longitude": -102.15509,
+                    "latitude": 31.99588,
+                    "fluUrl": "",
+                    "city": "MIDLAND"
+                },
+                {
+                    "zip": "77345-2621",
+                    "url": null,
+                    "type": "store",
+                    "street": "4517 KINGWOOD DRIVE",
+                    "storeNumber": 720,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Kingwood Market H-E-B",
+                    "longitude": -95.18375,
+                    "latitude": 30.05329,
+                    "fluUrl": "",
+                    "city": "KINGWOOD"
+                },
+                {
+                    "zip": "76542-0",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueOQAS",
+                    "type": "store",
+                    "street": "1101 W. STAN SCHLUETER LOOP",
+                    "storeNumber": 721,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 30,
+                            "openAppointmentSlots": 30,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 30,
+                            "openAppointmentSlots": 30,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 27,
+                            "openAppointmentSlots": 27,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 87,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 87,
+                    "name": "Fort Hood Stan Schlueter H-E-B",
+                    "longitude": -97.75988,
+                    "latitude": 31.07989,
+                    "fluUrl": "",
+                    "city": "KILLEEN"
+                },
+                {
+                    "zip": "77354-1611",
+                    "url": null,
+                    "type": "store",
+                    "street": "7988 FM 1488",
+                    "storeNumber": 722,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Magnolia Market H-E-B",
+                    "longitude": -95.5837,
+                    "latitude": 30.2217,
+                    "fluUrl": "",
+                    "city": "MAGNOLIA"
+                },
+                {
+                    "zip": "77407-8643",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueQQAS",
+                    "type": "store",
+                    "street": "10161 W GRAND PARKWAY S",
+                    "storeNumber": 724,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 140,
+                            "openAppointmentSlots": 140,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 140,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 140,
+                    "name": "Aliana Market H-E-B",
+                    "longitude": -95.7137,
+                    "latitude": 29.6597,
+                    "fluUrl": "",
+                    "city": "RICHMOND"
+                },
+                {
+                    "zip": "78572-9139",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucKQAS",
+                    "type": "store",
+                    "street": "6010 W EXPRESSWAY 83",
+                    "storeNumber": 448,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 112,
+                            "openAppointmentSlots": 112,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 112,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 112,
+                    "name": "Palmview H-E-B",
+                    "longitude": -98.38385,
+                    "latitude": 26.23538,
+                    "fluUrl": "",
+                    "city": "PALMVIEW"
+                },
+                {
+                    "zip": "78726-4539",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucMQAS",
+                    "type": "store",
+                    "street": "7301 N FM 620",
+                    "storeNumber": 451,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 51,
+                            "openAppointmentSlots": 51,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 101,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 101,
+                    "name": "Four Points H-E-B",
+                    "longitude": -97.85202,
+                    "latitude": 30.40458,
+                    "fluUrl": "",
+                    "city": "AUSTIN"
+                },
+                {
+                    "zip": "78666-5615",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucNQAS",
+                    "type": "store",
+                    "street": "200 WEST HOPKINS ST.",
+                    "storeNumber": 455,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 6,
+                            "openAppointmentSlots": 6,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 18,
+                            "openAppointmentSlots": 18,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 6,
+                            "openAppointmentSlots": 6,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 30,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 30,
+                    "name": "West Hopkins H-E-B",
+                    "longitude": -97.94292,
+                    "latitude": 29.88305,
+                    "fluUrl": "",
+                    "city": "SAN MARCOS"
+                },
+                {
+                    "zip": "78405-2040",
+                    "url": null,
+                    "type": "store",
+                    "street": "3033 SOUTH PORT ST.",
+                    "storeNumber": 462,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "S Port and Tarlton H-E-B",
+                    "longitude": -97.42137,
+                    "latitude": 27.76687,
+                    "fluUrl": "",
+                    "city": "CORPUS CHRISTI"
+                },
+                {
+                    "zip": "78248-4552",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucPQAS",
+                    "type": "store",
+                    "street": "1150 NW LOOP 1604",
+                    "storeNumber": 463,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 238,
+                            "openAppointmentSlots": 238,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 273,
+                            "openAppointmentSlots": 273,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 244,
+                            "openAppointmentSlots": 244,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 755,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 755,
+                    "name": "Loop 1604 and Blanco Rd H-E-B plus!",
+                    "longitude": -98.50968,
+                    "latitude": 29.60792,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "78702-3907",
+                    "url": null,
+                    "type": "store",
+                    "street": "2701 EAST 7TH",
+                    "storeNumber": 465,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "7th Street H-E-B",
+                    "longitude": -97.71143,
+                    "latitude": 30.26046,
+                    "fluUrl": "",
+                    "city": "AUSTIN"
+                },
+                {
+                    "zip": "78207-3706",
+                    "url": null,
+                    "type": "store",
+                    "street": "108 N ROSILLO",
+                    "storeNumber": 466,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Commerce and Rosillo H-E-B",
+                    "longitude": -98.5256,
+                    "latitude": 29.4281,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "76667-2445",
+                    "url": null,
+                    "type": "store",
+                    "street": "701 E. MILAM STREET",
+                    "storeNumber": 467,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Mexia H-E-B",
+                    "longitude": -96.47858,
+                    "latitude": 31.68434,
+                    "fluUrl": "",
+                    "city": "MEXIA"
+                },
+                {
+                    "zip": "77505-4027",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucTQAS",
+                    "type": "store",
+                    "street": "6210 FAIRMONT PKWY",
+                    "storeNumber": 473,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 182,
+                            "openAppointmentSlots": 182,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 182,
+                            "openAppointmentSlots": 182,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 364,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 364,
+                    "name": "Fairmont Pkwy H-E-B",
+                    "longitude": -95.14512,
+                    "latitude": 29.6497,
+                    "fluUrl": "",
+                    "city": "PASADENA"
+                },
+                {
+                    "zip": "77459-4180",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucUQAS",
+                    "type": "store",
+                    "street": "4724 HWY 6",
+                    "storeNumber": 474,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 51,
+                            "openAppointmentSlots": 51,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 48,
+                            "openAppointmentSlots": 48,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 99,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 99,
+                    "name": "Lake Colony H-E-B",
+                    "longitude": -95.58244,
+                    "latitude": 29.58032,
+                    "fluUrl": "",
+                    "city": "MISSOURI CITY"
+                },
+                {
+                    "zip": "78621-2519",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucVQAS",
+                    "type": "store",
+                    "street": "1080 EAST HWY 290",
+                    "storeNumber": 475,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 57,
+                            "openAppointmentSlots": 57,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 100,
+                            "openAppointmentSlots": 100,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 157,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 157,
+                    "name": "Elgin H-E-B",
+                    "longitude": -97.38258,
+                    "latitude": 30.34701,
+                    "fluUrl": "",
+                    "city": "ELGIN"
+                },
+                {
+                    "zip": "78753-1632",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucWQAS",
+                    "type": "store",
+                    "street": "500 CANYON RIDGE DR.",
+                    "storeNumber": 476,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 33,
+                            "openAppointmentSlots": 33,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 33,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 33,
+                    "name": "Tech Ridge H-E-B",
+                    "longitude": -97.67201,
+                    "latitude": 30.40443,
+                    "fluUrl": "",
+                    "city": "AUSTIN"
+                },
+                {
+                    "zip": "78610-9703",
+                    "url": null,
+                    "type": "store",
+                    "street": "15300 S IH-35",
+                    "storeNumber": 477,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Buda H-E-B",
+                    "longitude": -97.82074,
+                    "latitude": 30.08769,
+                    "fluUrl": "",
+                    "city": "BUDA"
+                },
+                {
+                    "zip": "78251-2805",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubPQAS",
+                    "type": "store",
+                    "street": "9255 GRISSOM RD",
+                    "storeNumber": 235,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 129,
+                            "openAppointmentSlots": 129,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 114,
+                            "openAppointmentSlots": 114,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 124,
+                            "openAppointmentSlots": 124,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 367,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 367,
+                    "name": "Grissom and Tezel H-E-B",
+                    "longitude": -98.66574,
+                    "latitude": 29.48432,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "78626-5400",
+                    "url": null,
+                    "type": "store",
+                    "street": "1100 SOUTH IH35",
+                    "storeNumber": 237,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "35 and West University H-E-B",
+                    "longitude": -97.69028,
+                    "latitude": 30.63446,
+                    "fluUrl": "",
+                    "city": "GEORGETOWN"
+                },
+                {
+                    "zip": "75110-5138",
+                    "url": null,
+                    "type": "store",
+                    "street": "201 S. 15TH STREET",
+                    "storeNumber": 238,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Corsicana H-E-B",
+                    "longitude": -96.46827,
+                    "latitude": 32.09005,
+                    "fluUrl": "",
+                    "city": "CORSICANA"
+                },
+                {
+                    "zip": "78666-7055",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubTQAS",
+                    "type": "store",
+                    "street": "641 EAST HOPKINS STREET",
+                    "storeNumber": 243,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 24,
+                            "openAppointmentSlots": 24,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 58,
+                            "openAppointmentSlots": 58,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 152,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 152,
+                    "name": "East Hopkins H-E-B",
+                    "longitude": -97.93132,
+                    "latitude": 29.88489,
+                    "fluUrl": "",
+                    "city": "SAN MARCOS"
+                },
+                {
+                    "zip": "78408-3204",
+                    "url": null,
+                    "type": "store",
+                    "street": "3500 LEOPARD",
+                    "storeNumber": 253,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Leopard and Nueces Bay H-E-B",
+                    "longitude": -97.42774,
+                    "latitude": 27.79695,
+                    "fluUrl": "",
+                    "city": "CORPUS CHRISTI"
+                },
+                {
+                    "zip": "77802-5320",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucmQAC",
+                    "type": "store",
+                    "street": "725 E VILLA MARIA RD STE 1300",
+                    "storeNumber": 544,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 83,
+                            "openAppointmentSlots": 83,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 128,
+                            "openAppointmentSlots": 128,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 261,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 261,
+                    "name": "Tejas Center H-E-B",
+                    "longitude": -96.3513,
+                    "latitude": 30.64506,
+                    "fluUrl": "",
+                    "city": "BRYAN"
+                },
+                {
+                    "zip": "77077-6860",
+                    "url": null,
+                    "type": "store",
+                    "street": "11815 WESTHEIMER",
+                    "storeNumber": 551,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Westheimer and Kirkwood H-E-B",
+                    "longitude": -95.587,
+                    "latitude": 29.7363,
+                    "fluUrl": "",
+                    "city": "HOUSTON"
+                },
+                {
+                    "zip": "77084-2718",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucoQAC",
+                    "type": "store",
+                    "street": "4955 HWY 6 N",
+                    "storeNumber": 553,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 44,
+                            "openAppointmentSlots": 44,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 53,
+                            "openAppointmentSlots": 53,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 30,
+                            "openAppointmentSlots": 30,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 127,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 127,
+                    "name": "Bear Creek H-E-B",
+                    "longitude": -95.6457,
+                    "latitude": 29.8487,
+                    "fluUrl": "",
+                    "city": "HOUSTON"
+                },
+                {
+                    "zip": "77901-6220",
+                    "url": null,
+                    "type": "store",
+                    "street": "1505 EAST RIO GRANDE",
+                    "storeNumber": 554,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "59 and Laurent H-E-B",
+                    "longitude": -96.9896,
+                    "latitude": 28.8062,
+                    "fluUrl": "",
+                    "city": "VICTORIA"
+                },
+                {
+                    "zip": "78148-3806",
+                    "url": null,
+                    "type": "store",
+                    "street": "910 KITTY HAWK ROAD",
+                    "storeNumber": 555,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Kitty Hawk H-E-B",
+                    "longitude": -98.31298,
+                    "latitude": 29.54766,
+                    "fluUrl": "",
+                    "city": "UNIVERSAL CITY"
+                },
+                {
+                    "zip": "78201-4407",
+                    "url": null,
+                    "type": "store",
+                    "street": "2118 FREDERICKSBURG RD",
+                    "storeNumber": 556,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Deco District H-E-B",
+                    "longitude": -98.5261,
+                    "latitude": 29.4646,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "76705-2874",
+                    "url": null,
+                    "type": "store",
+                    "street": "801 NORTH I-H 35",
+                    "storeNumber": 557,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "35 and 84 H-E-B plus!",
+                    "longitude": -97.10723,
+                    "latitude": 31.58764,
+                    "fluUrl": "",
+                    "city": "BELLMEAD"
+                },
+                {
+                    "zip": "77546-5405",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuctQAC",
+                    "type": "store",
+                    "street": "701 WEST PARKWOOD",
+                    "storeNumber": 558,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 470,
+                            "openAppointmentSlots": 470,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 472,
+                            "openAppointmentSlots": 472,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 452,
+                            "openAppointmentSlots": 452,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 942,
+                    "openFluTimeslots": 452,
+                    "openFluAppointmentSlots": 452,
+                    "openAppointmentSlots": 942,
+                    "name": "Friendswood H-E-B",
+                    "longitude": -95.1912,
+                    "latitude": 29.5066,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3PQAU",
+                    "city": "FRIENDSWOOD"
+                },
+                {
+                    "zip": "77566-4622",
+                    "url": null,
+                    "type": "store",
+                    "street": "97 OYSTER CREEK DRIV",
+                    "storeNumber": 707,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Lake Jackson H-E-B",
+                    "longitude": -95.44554,
+                    "latitude": 29.04151,
+                    "fluUrl": "",
+                    "city": "LAKE JACKSON"
+                },
+                {
+                    "zip": "78676-6215",
+                    "url": null,
+                    "type": "store",
+                    "street": "14501 RR12",
+                    "storeNumber": 708,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Wimberley H-E-B",
+                    "longitude": -98.10174,
+                    "latitude": 30.00144,
+                    "fluUrl": "",
+                    "city": "WIMBERLEY"
+                },
+                {
+                    "zip": "77433-4847",
+                    "url": null,
+                    "type": "store",
+                    "street": "9722 FRY ROAD",
+                    "storeNumber": 709,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 10,
+                            "openAppointmentSlots": 10,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 10,
+                    "openFluAppointmentSlots": 10,
+                    "openAppointmentSlots": 0,
+                    "name": "H-E-B Market at Tuckerton",
+                    "longitude": -95.72501,
+                    "latitude": 29.92737,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF13QAE",
+                    "city": "CYPRESS"
+                },
+                {
+                    "zip": "77379-8693",
+                    "url": null,
+                    "type": "store",
+                    "street": "20311 CHAMPION FOREST DRIVE",
+                    "storeNumber": 725,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Champion Forest Market H-E-B",
+                    "longitude": -95.57475,
+                    "latitude": 30.0551,
+                    "fluUrl": "",
+                    "city": "SPRING"
+                },
+                {
+                    "zip": "77469-2509",
+                    "url": null,
+                    "type": "store",
+                    "street": "23500 CIRCLE OAK PARKWAY",
+                    "storeNumber": 727,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Richmond Market H-E-B",
+                    "longitude": -95.74781,
+                    "latitude": 29.55142,
+                    "fluUrl": "",
+                    "city": "RICHMOND"
+                },
+                {
+                    "zip": "77340-3723",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueTQAS",
+                    "type": "store",
+                    "street": "1702 11TH ST.",
+                    "storeNumber": 728,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 150,
+                            "openAppointmentSlots": 150,
+                            "manufacturer": "Other"
+                        },
+                        {
+                            "openTimeslots": 24,
+                            "openAppointmentSlots": 24,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 25,
+                            "openAppointmentSlots": 25,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 25,
+                            "openAppointmentSlots": 25,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 25,
+                            "openAppointmentSlots": 25,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 99,
+                    "openFluTimeslots": 150,
+                    "openFluAppointmentSlots": 150,
+                    "openAppointmentSlots": 99,
+                    "name": "Huntsville H-E-B",
+                    "longitude": -95.56075,
+                    "latitude": 30.72274,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF1TQAU",
+                    "city": "HUNTSVILLE"
+                },
+                {
+                    "zip": "78247-0",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueUQAS",
+                    "type": "store",
+                    "street": "17238 BULVERDE ROAD",
+                    "storeNumber": 732,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 274,
+                            "openAppointmentSlots": 274,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 369,
+                            "openAppointmentSlots": 369,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 260,
+                            "openAppointmentSlots": 260,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 903,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 903,
+                    "name": "Bulverde and 1604 H-E-B",
+                    "longitude": -98.41746,
+                    "latitude": 29.59497,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "78041-5754",
+                    "url": null,
+                    "type": "store",
+                    "street": "4801 SAN DARIO",
+                    "storeNumber": 255,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "35 and Calton H-E-B",
+                    "longitude": -99.50182,
+                    "latitude": 27.54172,
+                    "fluUrl": "",
+                    "city": "LAREDO"
+                },
+                {
+                    "zip": "78238-1986",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubWQAS",
+                    "type": "store",
+                    "street": "5601 BANDERA ROAD",
+                    "storeNumber": 262,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 128,
+                            "openAppointmentSlots": 128,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 124,
+                            "openAppointmentSlots": 124,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 252,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 252,
+                    "name": "Marketplace H-E-B",
+                    "longitude": -98.59477,
+                    "latitude": 29.48119,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "78520-8327",
+                    "url": null,
+                    "type": "store",
+                    "street": "1628 CENTRAL BLVD",
+                    "storeNumber": 263,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Central Blvd H-E-B",
+                    "longitude": -97.51093,
+                    "latitude": 25.92849,
+                    "fluUrl": "",
+                    "city": "BROWNSVILLE"
+                },
+                {
+                    "zip": "78613-1900",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubYQAS",
+                    "type": "store",
+                    "street": "170 E WHITESTONE BLVD",
+                    "storeNumber": 265,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 18,
+                            "openAppointmentSlots": 18,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 12,
+                            "openAppointmentSlots": 12,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 30,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 30,
+                    "name": "Hwy 183 and Whitestone Blvd H-E-B",
+                    "longitude": -97.82911,
+                    "latitude": 30.5225,
+                    "fluUrl": "",
+                    "city": "CEDAR PARK"
+                },
+                {
+                    "zip": "78759-5780",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubZQAS",
+                    "type": "store",
+                    "street": "10710 RESEARCH BLVD. STE 200",
+                    "storeNumber": 269,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 21,
+                            "openAppointmentSlots": 21,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 23,
+                            "openAppointmentSlots": 23,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 44,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 44,
+                    "name": "North Hills H-E-B",
+                    "longitude": -97.74832,
+                    "latitude": 30.39868,
+                    "fluUrl": "",
+                    "city": "AUSTIN"
+                },
+                {
+                    "zip": "78411-5301",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubaQAC",
+                    "type": "store",
+                    "street": "5425 S.P.I.D. AT STAPLES",
+                    "storeNumber": 270,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 16,
+                            "openAppointmentSlots": 16,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 10,
+                            "openAppointmentSlots": 10,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 54,
+                            "openAppointmentSlots": 54,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 26,
+                    "openFluTimeslots": 54,
+                    "openFluAppointmentSlots": 54,
+                    "openAppointmentSlots": 26,
+                    "name": "Moore Plaza H-E-B",
+                    "longitude": -97.37238,
+                    "latitude": 27.70605,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF21QAE",
+                    "city": "CORPUS CHRISTI"
+                },
+                {
+                    "zip": "78624-4146",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucuQAC",
+                    "type": "store",
+                    "street": "407 SOUTH ADAMS",
+                    "storeNumber": 561,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 93,
+                            "openAppointmentSlots": 93,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 98,
+                            "openAppointmentSlots": 98,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 191,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 191,
+                    "name": "Fredericksburg H-E-B",
+                    "longitude": -98.87538,
+                    "latitude": 30.27006,
+                    "fluUrl": "",
+                    "city": "FREDERICKSBURG"
+                },
+                {
+                    "zip": "78382-3314",
+                    "url": null,
+                    "type": "store",
+                    "street": "1409 HWY 35 NORTH BUSINESS",
+                    "storeNumber": 562,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Rockport H-E-B",
+                    "longitude": -97.0425,
+                    "latitude": 28.0378,
+                    "fluUrl": "",
+                    "city": "ROCKPORT"
+                },
+                {
+                    "zip": "77479-6505",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucwQAC",
+                    "type": "store",
+                    "street": "19900 SOUTHWEST FWY",
+                    "storeNumber": 563,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 44,
+                            "openAppointmentSlots": 44,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 40,
+                            "openAppointmentSlots": 40,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 12,
+                            "openAppointmentSlots": 12,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 134,
+                    "openFluTimeslots": 12,
+                    "openFluAppointmentSlots": 12,
+                    "openAppointmentSlots": 134,
+                    "name": "Riverpark H-E-B",
+                    "longitude": -95.6815,
+                    "latitude": 29.5636,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3SQAU",
+                    "city": "SUGAR LAND"
+                },
+                {
+                    "zip": "77380-2272",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucxQAC",
+                    "type": "store",
+                    "street": "130 SAWDUST ROAD",
+                    "storeNumber": 564,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 69,
+                            "openAppointmentSlots": 69,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 129,
+                            "openAppointmentSlots": 129,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 198,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 198,
+                    "name": "Sawdust Rd and 45 H-E-B",
+                    "longitude": -95.44512,
+                    "latitude": 30.12684,
+                    "fluUrl": "",
+                    "city": "SPRING"
+                },
+                {
+                    "zip": "78257-1161",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucyQAC",
+                    "type": "store",
+                    "street": "24165 I-H 10 WEST, SUITE 300",
+                    "storeNumber": 566,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 76,
+                            "openAppointmentSlots": 76,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 146,
+                            "openAppointmentSlots": 146,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 140,
+                            "openAppointmentSlots": 140,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 76,
+                            "openAppointmentSlots": 76,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 438,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 438,
+                    "name": "Leon Springs H-E-B",
+                    "longitude": -98.63218,
+                    "latitude": 29.6659,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "78209-1804",
+                    "url": null,
+                    "type": "store",
+                    "street": "999 EAST BASSE ROAD",
+                    "storeNumber": 567,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Lincoln Heights Market H-E-B",
+                    "longitude": -98.4682,
+                    "latitude": 29.4967,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "78217-2116",
+                    "url": null,
+                    "type": "store",
+                    "street": "12018 PERRIN BEITEL ROAD",
+                    "storeNumber": 568,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Perrin Beitel and Thousand Oaks H-E-B",
+                    "longitude": -98.4082,
+                    "latitude": 29.5491,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "78582-4815",
+                    "url": null,
+                    "type": "store",
+                    "street": "4031 EAST HWY 83",
+                    "storeNumber": 13,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Rio Grande City H-E-B plus!",
+                    "longitude": -98.80031,
+                    "latitude": 26.37244,
+                    "fluUrl": "",
+                    "city": "RIO GRANDE CITY"
+                },
+                {
+                    "zip": "78550-5905",
+                    "url": null,
+                    "type": "store",
+                    "street": "613 S EXPWY 83",
+                    "storeNumber": 291,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "83 and Lincoln H-E-B",
+                    "longitude": -97.71403,
+                    "latitude": 26.18328,
+                    "fluUrl": "",
+                    "city": "HARLINGEN"
+                },
+                {
+                    "zip": "77414-5305",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubcQAC",
+                    "type": "store",
+                    "street": "2700 SEVENTH",
+                    "storeNumber": 292,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 24,
+                            "openAppointmentSlots": 24,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 26,
+                            "openAppointmentSlots": 26,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 26,
+                            "openAppointmentSlots": 26,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 50,
+                    "openFluTimeslots": 26,
+                    "openFluAppointmentSlots": 26,
+                    "openAppointmentSlots": 50,
+                    "name": "Bay City H-E-B",
+                    "longitude": -95.95804,
+                    "latitude": 28.98306,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF23QAE",
+                    "city": "BAY CITY"
+                },
+                {
+                    "zip": "78244-1300",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubdQAC",
+                    "type": "store",
+                    "street": "6580 F.M. 78",
+                    "storeNumber": 294,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 23,
+                            "openAppointmentSlots": 23,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 25,
+                            "openAppointmentSlots": 25,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 23,
+                            "openAppointmentSlots": 23,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 48,
+                    "openFluTimeslots": 23,
+                    "openFluAppointmentSlots": 23,
+                    "openAppointmentSlots": 48,
+                    "name": "Foster Rd H-E-B",
+                    "longitude": -98.3591,
+                    "latitude": 29.48109,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF24QAE",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "78521-4787",
+                    "url": null,
+                    "type": "store",
+                    "street": "2950 SOUTHMOST ROAD",
+                    "storeNumber": 332,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Southmost and 30th H-E-B",
+                    "longitude": -97.46481,
+                    "latitude": 25.90552,
+                    "fluUrl": "",
+                    "city": "BROWNSVILLE"
+                },
+                {
+                    "zip": "78336-1919",
+                    "url": null,
+                    "type": "store",
+                    "street": "101 E. GOODNIGHT",
+                    "storeNumber": 333,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Aransas Pass H-E-B",
+                    "longitude": -97.14616,
+                    "latitude": 27.90255,
+                    "fluUrl": "",
+                    "city": "ARANSAS PASS"
+                },
+                {
+                    "zip": "78501-3512",
+                    "url": null,
+                    "type": "store",
+                    "street": "3601 PECAN",
+                    "storeNumber": 334,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Pecan and Ware H-E-B",
+                    "longitude": -98.25799,
+                    "latitude": 26.21925,
+                    "fluUrl": "",
+                    "city": "MCALLEN"
+                },
+                {
+                    "zip": "78640-6038",
+                    "url": null,
+                    "type": "store",
+                    "street": "5401 SOUTH FM 1626",
+                    "storeNumber": 14,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 5,
+                            "openAppointmentSlots": 5,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 5,
+                    "openFluAppointmentSlots": 5,
+                    "openAppointmentSlots": 0,
+                    "name": "Kyle H-E-B plus!",
+                    "longitude": -97.86258,
+                    "latitude": 30.01533,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3vQAE",
+                    "city": "KYLE"
+                },
+                {
+                    "zip": "76028-5154",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaGQAS",
+                    "type": "store",
+                    "street": "165 N.W.JOHN JONES DR.",
+                    "storeNumber": 16,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 66,
+                            "openAppointmentSlots": 66,
+                            "manufacturer": "Moderna"
+                        }
+                    ],
+                    "openTimeslots": 66,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 66,
+                    "name": "Burleson H-E-B plus!",
+                    "longitude": -97.34901,
+                    "latitude": 32.52083,
+                    "fluUrl": "",
+                    "city": "BURLESON"
+                },
+                {
+                    "zip": "78052-3622",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaHQAS",
+                    "type": "store",
+                    "street": "19337 MCDONALD STREET",
+                    "storeNumber": 19,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 161,
+                            "openAppointmentSlots": 161,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 152,
+                            "openAppointmentSlots": 152,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 111,
+                            "openAppointmentSlots": 111,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 103,
+                            "openAppointmentSlots": 103,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 424,
+                    "openFluTimeslots": 103,
+                    "openFluAppointmentSlots": 103,
+                    "openAppointmentSlots": 424,
+                    "name": "Lytle H-E-B plus!",
+                    "longitude": -98.78924,
+                    "latitude": 29.23224,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3xQAE",
+                    "city": "LYTLE"
+                },
+                {
+                    "zip": "77429-5683",
+                    "url": null,
+                    "type": "store",
+                    "street": "24224 NORTHWEST FREEWAY",
+                    "storeNumber": 20,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Cypress Market H-E-B",
+                    "longitude": -95.6765,
+                    "latitude": 29.95569,
+                    "fluUrl": "",
+                    "city": "CYPRESS"
+                },
+                {
+                    "zip": "78726-1168",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaJQAS",
+                    "type": "store",
+                    "street": "11521 NORTH FM620, BUILDING A",
+                    "storeNumber": 24,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 7,
+                            "openAppointmentSlots": 7,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 12,
+                            "openAppointmentSlots": 12,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 17,
+                            "openAppointmentSlots": 17,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 19,
+                    "openFluTimeslots": 17,
+                    "openFluAppointmentSlots": 17,
+                    "openAppointmentSlots": 19,
+                    "name": "Anderson Mill H-E-B plus!",
+                    "longitude": -97.82626,
+                    "latitude": 30.45495,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3zQAE",
+                    "city": "AUSTIN"
+                },
+                {
+                    "zip": "76542-1910",
+                    "url": null,
+                    "type": "store",
+                    "street": "2511 TRIMMIER RD, SUITE 100",
+                    "storeNumber": 581,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Trimmier H-E-B plus!",
+                    "longitude": -97.7338,
+                    "latitude": 31.0909,
+                    "fluUrl": "",
+                    "city": "KILLEEN"
+                },
+                {
+                    "zip": "78602-3740",
+                    "url": null,
+                    "type": "store",
+                    "street": "104 N HASLER BLVD",
+                    "storeNumber": 582,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Bastrop H-E-B plus!",
+                    "longitude": -97.33458,
+                    "latitude": 30.10981,
+                    "fluUrl": "",
+                    "city": "BASTROP"
+                },
+                {
+                    "zip": "76712-3371",
+                    "url": null,
+                    "type": "store",
+                    "street": "9100 WOODWAY DRIVE",
+                    "storeNumber": 583,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Woodway H-E-B plus!",
+                    "longitude": -97.22132,
+                    "latitude": 31.49664,
+                    "fluUrl": "",
+                    "city": "WOODWAY"
+                },
+                {
+                    "zip": "77437-4420",
+                    "url": null,
+                    "type": "store",
+                    "street": "306 N. MECHANIC",
+                    "storeNumber": 584,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "El Campo H-E-B",
+                    "longitude": -96.26988,
+                    "latitude": 29.19683,
+                    "fluUrl": "",
+                    "city": "EL CAMPO"
+                },
+                {
+                    "zip": "78218-6039",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudCQAS",
+                    "type": "store",
+                    "street": "1520 AUSTIN HWY",
+                    "storeNumber": 585,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 44,
+                            "openAppointmentSlots": 44,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 57,
+                            "openAppointmentSlots": 57,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 70,
+                            "openAppointmentSlots": 70,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 78,
+                            "openAppointmentSlots": 78,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 249,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 249,
+                    "name": "Austin Highway H-E-B",
+                    "longitude": -98.43132,
+                    "latitude": 29.4937,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "78046-6563",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudDQAS",
+                    "type": "store",
+                    "street": "2314 SOUTH ZAPATA HIGHWAY",
+                    "storeNumber": 586,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 10,
+                            "openAppointmentSlots": 10,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 10,
+                            "openAppointmentSlots": 10,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 20,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 20,
+                    "name": "Zapata Highway H-E-B",
+                    "longitude": -99.47479,
+                    "latitude": 27.47673,
+                    "fluUrl": "",
+                    "city": "LAREDO"
+                },
+                {
+                    "zip": "78253-0",
+                    "url": null,
+                    "type": "store",
+                    "street": "12125 ALAMO RANCH PKWY",
+                    "storeNumber": 733,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Alamo Ranch H-E-B",
+                    "longitude": -98.73294,
+                    "latitude": 29.48572,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "76901-0",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueWQAS",
+                    "type": "store",
+                    "street": "5502 SHERWOOD WAY",
+                    "storeNumber": 734,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 16,
+                            "openAppointmentSlots": 16,
+                            "manufacturer": "Other"
+                        },
+                        {
+                            "openTimeslots": 15,
+                            "openAppointmentSlots": 15,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 16,
+                            "openAppointmentSlots": 16,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 16,
+                            "openAppointmentSlots": 16,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 47,
+                    "openFluTimeslots": 16,
+                    "openFluAppointmentSlots": 16,
+                    "openAppointmentSlots": 47,
+                    "name": "Sherwood & FM 2288 H-E-B",
+                    "longitude": -100.51103,
+                    "latitude": 31.43158,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF1lQAE",
+                    "city": "SAN ANGELO"
+                },
+                {
+                    "zip": "77494-5426",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueYQAS",
+                    "type": "store",
+                    "street": "4950 FM 1463",
+                    "storeNumber": 736,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 14,
+                            "openAppointmentSlots": 14,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 48,
+                            "openAppointmentSlots": 48,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 13,
+                            "openAppointmentSlots": 13,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 75,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 75,
+                    "name": "Cross Creek Ranch H-E-B",
+                    "longitude": -95.84788,
+                    "latitude": 29.71936,
+                    "fluUrl": "",
+                    "city": "KATY"
+                },
+                {
+                    "zip": "77008-0",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueZQAS",
+                    "type": "store",
+                    "street": "2300 N. SHEPHERD DR.",
+                    "storeNumber": 737,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 66,
+                            "openAppointmentSlots": 66,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 67,
+                            "openAppointmentSlots": 67,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 133,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 133,
+                    "name": "The Heights H-E-B",
+                    "longitude": -95.40865,
+                    "latitude": 29.80735,
+                    "fluUrl": "",
+                    "city": "HOUSTON"
+                },
+                {
+                    "zip": "77401-4019",
+                    "url": null,
+                    "type": "store",
+                    "street": "5106 BISSONNET",
+                    "storeNumber": 738,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Bellaire Market H-E-B",
+                    "longitude": -95.46938,
+                    "latitude": 29.70764,
+                    "fluUrl": "",
+                    "city": "BELLAIRE"
+                },
+                {
+                    "zip": "77523-0",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuebQAC",
+                    "type": "store",
+                    "street": "13401 I-10 EAST",
+                    "storeNumber": 741,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 69,
+                            "openAppointmentSlots": 69,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 8,
+                            "openAppointmentSlots": 8,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 77,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 77,
+                    "name": "Mont Belvieu H-E-B",
+                    "longitude": -94.84973,
+                    "latitude": 29.82755,
+                    "fluUrl": "",
+                    "city": "MONT BELVIEU"
+                },
+                {
+                    "zip": "78114-1851",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaKQAS",
+                    "type": "store",
+                    "street": "925 10TH STREET",
+                    "storeNumber": 25,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 8,
+                            "openAppointmentSlots": 8,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 19,
+                            "openAppointmentSlots": 19,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 26,
+                            "openAppointmentSlots": 26,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 53,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 53,
+                    "name": "Floresville H-E-B",
+                    "longitude": -98.15681,
+                    "latitude": 29.14284,
+                    "fluUrl": "",
+                    "city": "FLORESVILLE"
+                },
+                {
+                    "zip": "78223-1717",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaLQAS",
+                    "type": "store",
+                    "street": "4100 SOUTH NEW BRAUNFELS",
+                    "storeNumber": 26,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 78,
+                            "openAppointmentSlots": 78,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 180,
+                            "openAppointmentSlots": 180,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 90,
+                            "openAppointmentSlots": 90,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 348,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 348,
+                    "name": "McCreless Market H-E-B plus!",
+                    "longitude": -98.46115,
+                    "latitude": 29.37828,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "77573-6750",
+                    "url": null,
+                    "type": "store",
+                    "street": "2955 SOUTH GULF FREEWAY",
+                    "storeNumber": 28,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 57,
+                            "openAppointmentSlots": 57,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 57,
+                    "openFluAppointmentSlots": 57,
+                    "openAppointmentSlots": 0,
+                    "name": "Bay Colony H-E-B",
+                    "longitude": -95.0926,
+                    "latitude": 29.4677,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF42QAE",
+                    "city": "LEAGUE CITY"
+                },
+                {
+                    "zip": "78746-5256",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaNQAS",
+                    "type": "store",
+                    "street": "701 CAPITAL OF TEXAS HWY-BLD C",
+                    "storeNumber": 29,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 18,
+                            "openAppointmentSlots": 18,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 18,
+                            "openAppointmentSlots": 18,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 36,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 36,
+                    "name": "Westlake H-E-B",
+                    "longitude": -97.82813,
+                    "latitude": 30.2928,
+                    "fluUrl": "",
+                    "city": "WEST LAKE HILLS"
+                },
+                {
+                    "zip": "78750-3222",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaOQAS",
+                    "type": "store",
+                    "street": "12860 RESEARCH BLVD",
+                    "storeNumber": 31,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 21,
+                            "openAppointmentSlots": 21,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 21,
+                            "openAppointmentSlots": 21,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 112,
+                            "openAppointmentSlots": 112,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 42,
+                    "openFluTimeslots": 112,
+                    "openFluAppointmentSlots": 112,
+                    "openAppointmentSlots": 42,
+                    "name": "Spicewood Springs H-E-B",
+                    "longitude": -97.7713,
+                    "latitude": 30.43494,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF44QAE",
+                    "city": "AUSTIN"
+                },
+                {
+                    "zip": "78664-4642",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaPQAS",
+                    "type": "store",
+                    "street": "3750 GATTIS SCHOOL RD",
+                    "storeNumber": 34,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 398,
+                            "openAppointmentSlots": 398,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 18,
+                            "openAppointmentSlots": 18,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 416,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 416,
+                    "name": "Red Bud Lane and Gattis School H-E-B",
+                    "longitude": -97.61475,
+                    "latitude": 30.49721,
+                    "fluUrl": "",
+                    "city": "ROUND ROCK"
+                },
+                {
+                    "zip": "77957-2728",
+                    "url": null,
+                    "type": "store",
+                    "street": "301 N. WELLS ST",
+                    "storeNumber": 351,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Edna H-E-B",
+                    "longitude": -96.64731,
+                    "latitude": 28.97947,
+                    "fluUrl": "",
+                    "city": "EDNA"
+                },
+                {
+                    "zip": "78209-2217",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubiQAC",
+                    "type": "store",
+                    "street": "1955 NACOGDOCHES",
+                    "storeNumber": 372,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 247,
+                            "openAppointmentSlots": 247,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 223,
+                            "openAppointmentSlots": 223,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 78,
+                            "openAppointmentSlots": 78,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 520,
+                    "openFluTimeslots": 78,
+                    "openFluAppointmentSlots": 78,
+                    "openAppointmentSlots": 520,
+                    "name": "Oak Park H-E-B",
+                    "longitude": -98.45759,
+                    "latitude": 29.50774,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF29QAE",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "78681-3922",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubjQAC",
+                    "type": "store",
+                    "street": "16900 RANCH ROAD 620",
+                    "storeNumber": 373,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 687,
+                            "openAppointmentSlots": 687,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 369,
+                            "openAppointmentSlots": 369,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 1056,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 1056,
+                    "name": "620 and O'Connor H-E-B",
+                    "longitude": -97.72218,
+                    "latitude": 30.50028,
+                    "fluUrl": "",
+                    "city": "ROUND ROCK"
+                },
+                {
+                    "zip": "78130-5722",
+                    "url": null,
+                    "type": "store",
+                    "street": "651 S. WALNUT",
+                    "storeNumber": 380,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "New Braunfels H-E-B at Walnut",
+                    "longitude": -98.12695,
+                    "latitude": 29.68878,
+                    "fluUrl": "",
+                    "city": "NEW BRAUNFELS"
+                },
+                {
+                    "zip": "76548-1347",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GublQAC",
+                    "type": "store",
+                    "street": "601 INDIAN TRAIL",
+                    "storeNumber": 381,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 47,
+                            "openAppointmentSlots": 47,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 196,
+                            "openAppointmentSlots": 196,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 48,
+                            "openAppointmentSlots": 48,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 219,
+                            "openAppointmentSlots": 219,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 291,
+                    "openFluTimeslots": 219,
+                    "openFluAppointmentSlots": 219,
+                    "openAppointmentSlots": 291,
+                    "name": "Harker Heights H-E-B",
+                    "longitude": -97.65511,
+                    "latitude": 31.07905,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2CQAU",
+                    "city": "HARKER HEIGHTS"
+                },
+                {
+                    "zip": "79707-5714",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubmQAC",
+                    "type": "store",
+                    "street": "3325 WEST WADLEY",
+                    "storeNumber": 382,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 34,
+                            "openAppointmentSlots": 34,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 33,
+                            "openAppointmentSlots": 33,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 19,
+                            "openAppointmentSlots": 19,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 86,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 86,
+                    "name": "West Wadley H-E-B",
+                    "longitude": -102.12562,
+                    "latitude": 32.01955,
+                    "fluUrl": "",
+                    "city": "MIDLAND"
+                },
+                {
+                    "zip": "78239-3233",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubnQAC",
+                    "type": "store",
+                    "street": "6030 MONTGOMERY ROAD",
+                    "storeNumber": 384,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 208,
+                            "openAppointmentSlots": 208,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 755,
+                            "openAppointmentSlots": 755,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 129,
+                            "openAppointmentSlots": 129,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 309,
+                            "openAppointmentSlots": 309,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 1092,
+                    "openFluTimeslots": 309,
+                    "openFluAppointmentSlots": 309,
+                    "openAppointmentSlots": 1092,
+                    "name": "Montgomery at Walzem",
+                    "longitude": -98.37092,
+                    "latitude": 29.5105,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2JQAU",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "78212-1958",
+                    "url": null,
+                    "type": "store",
+                    "street": "300 OLMOS DRIVE",
+                    "storeNumber": 385,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Olmos Park H-E-B",
+                    "longitude": -98.497,
+                    "latitude": 29.4707,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "79762-5947",
+                    "url": null,
+                    "type": "store",
+                    "street": "3801 E 42ND",
+                    "storeNumber": 387,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "42nd St. H-E-B",
+                    "longitude": -102.34383,
+                    "latitude": 31.89134,
+                    "fluUrl": "",
+                    "city": "ODESSA"
+                },
+                {
+                    "zip": "78727-3901",
+                    "url": null,
+                    "type": "store",
+                    "street": "6001 WEST PARMER LANE",
+                    "storeNumber": 388,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Parmer and McNeil H-E-B",
+                    "longitude": -97.74278,
+                    "latitude": 30.44181,
+                    "fluUrl": "",
+                    "city": "AUSTIN"
+                },
+                {
+                    "zip": "77642-7403",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudEQAS",
+                    "type": "store",
+                    "street": "4800 B HWY 365",
+                    "storeNumber": 589,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 91,
+                            "openAppointmentSlots": 91,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 91,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 91,
+                    "name": "Mid County H-E-B",
+                    "longitude": -93.9758,
+                    "latitude": 29.966,
+                    "fluUrl": "",
+                    "city": "PORT ARTHUR"
+                },
+                {
+                    "zip": "78504-7705",
+                    "url": null,
+                    "type": "store",
+                    "street": "901 TRENTON RD",
+                    "storeNumber": 590,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "10th and Trenton H-E-B",
+                    "longitude": -98.2188,
+                    "latitude": 26.2678,
+                    "fluUrl": "",
+                    "city": "MCALLEN"
+                },
+                {
+                    "zip": "78641-7001",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudHQAS",
+                    "type": "store",
+                    "street": "651 N. US HWY 183",
+                    "storeNumber": 592,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 26,
+                            "openAppointmentSlots": 26,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 26,
+                            "openAppointmentSlots": 26,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 8,
+                            "openAppointmentSlots": 8,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 2,
+                            "openAppointmentSlots": 2,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 60,
+                    "openFluTimeslots": 2,
+                    "openFluAppointmentSlots": 2,
+                    "openAppointmentSlots": 60,
+                    "name": "Leander H-E-B plus!",
+                    "longitude": -97.8582,
+                    "latitude": 30.58369,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3nQAE",
+                    "city": "LEANDER"
+                },
+                {
+                    "zip": "77521-9638",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuecQAC",
+                    "type": "store",
+                    "street": "6430 GARTH ROAD",
+                    "storeNumber": 742,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 35,
+                            "openAppointmentSlots": 35,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 35,
+                            "openAppointmentSlots": 35,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 35,
+                            "openAppointmentSlots": 35,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 35,
+                            "openAppointmentSlots": 35,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 105,
+                    "openFluTimeslots": 35,
+                    "openFluAppointmentSlots": 35,
+                    "openAppointmentSlots": 105,
+                    "name": "Baytown H-E-B",
+                    "longitude": -94.9788,
+                    "latitude": 29.79503,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF1rQAE",
+                    "city": "BAYTOWN"
+                },
+                {
+                    "zip": "77007-0",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuedQAC",
+                    "type": "store",
+                    "street": "3663 WASHINGTON AVE. STE. 100",
+                    "storeNumber": 744,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 23,
+                            "openAppointmentSlots": 23,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 35,
+                            "openAppointmentSlots": 35,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 58,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 58,
+                    "name": "Buffalo Heights H-E-B On Washington Ave",
+                    "longitude": -95.39658,
+                    "latitude": 29.76901,
+                    "fluUrl": "",
+                    "city": "HOUSTON"
+                },
+                {
+                    "zip": "77096-4001",
+                    "url": null,
+                    "type": "store",
+                    "street": "4955 BEECHNUT STREET",
+                    "storeNumber": 745,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Meyerland Market H-E-B",
+                    "longitude": -95.46406,
+                    "latitude": 29.68854,
+                    "fluUrl": "",
+                    "city": "HOUSTON"
+                },
+                {
+                    "zip": "77845-4737",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuefQAC",
+                    "type": "store",
+                    "street": "11675 FM 2154",
+                    "storeNumber": 746,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 5,
+                            "openAppointmentSlots": 5,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 17,
+                            "openAppointmentSlots": 17,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 15,
+                            "openAppointmentSlots": 15,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 22,
+                    "openFluTimeslots": 15,
+                    "openFluAppointmentSlots": 15,
+                    "openAppointmentSlots": 22,
+                    "name": "Jones Crossing H-E-B",
+                    "longitude": -96.32324,
+                    "latitude": 30.58444,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF1uQAE",
+                    "city": "COLLEGE STATION"
+                },
+                {
+                    "zip": "78589-3734",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaQQAS",
+                    "type": "store",
+                    "street": "901 WEST EXPRESSWAY 83",
+                    "storeNumber": 38,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 3,
+                            "openAppointmentSlots": 3,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 14,
+                            "openAppointmentSlots": 14,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 23,
+                            "openAppointmentSlots": 23,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 40,
+                    "openFluTimeslots": 50,
+                    "openFluAppointmentSlots": 50,
+                    "openAppointmentSlots": 40,
+                    "name": "San Juan H-E-B plus!",
+                    "longitude": -98.1647,
+                    "latitude": 26.20274,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4JQAU",
+                    "city": "SAN JUAN"
+                },
+                {
+                    "zip": "76513-1519",
+                    "url": null,
+                    "type": "store",
+                    "street": "2509 NORTH MAIN STREET",
+                    "storeNumber": 39,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Belton H-E-B plus!",
+                    "longitude": -97.45759,
+                    "latitude": 31.0805,
+                    "fluUrl": "",
+                    "city": "BELTON"
+                },
+                {
+                    "zip": "78704-0",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaSQAS",
+                    "type": "store",
+                    "street": "2301 S.CONGRESS AVE.",
+                    "storeNumber": 755,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 145,
+                            "openAppointmentSlots": 145,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 105,
+                            "openAppointmentSlots": 105,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 250,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 250,
+                    "name": "South Congress H-E-B",
+                    "longitude": -97.7516,
+                    "latitude": 30.23963,
+                    "fluUrl": "",
+                    "city": "AUSTIN"
+                },
+                {
+                    "zip": "77706-7213",
+                    "url": null,
+                    "type": "store",
+                    "street": "3025 NORTH DOWLEN ROAD",
+                    "storeNumber": 48,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Beaumont H-E-B plus!",
+                    "longitude": -94.1685,
+                    "latitude": 30.10501,
+                    "fluUrl": "",
+                    "city": "BEAUMONT"
+                },
+                {
+                    "zip": "78213-2714",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubrQAC",
+                    "type": "store",
+                    "street": "6000 WEST AVENUE",
+                    "storeNumber": 389,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 111,
+                            "openAppointmentSlots": 111,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 80,
+                            "openAppointmentSlots": 80,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 47,
+                            "openAppointmentSlots": 47,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 238,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 238,
+                    "name": "West Ave and Jackson Keller H-E-B",
+                    "longitude": -98.52574,
+                    "latitude": 29.51639,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "78230-1014",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubsQAC",
+                    "type": "store",
+                    "street": "12777 IH 10 WEST",
+                    "storeNumber": 395,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 15,
+                            "openAppointmentSlots": 15,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 15,
+                            "openAppointmentSlots": 15,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 118,
+                            "openAppointmentSlots": 118,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 30,
+                    "openFluTimeslots": 118,
+                    "openFluAppointmentSlots": 118,
+                    "openAppointmentSlots": 30,
+                    "name": "De Zavala H-E-B",
+                    "longitude": -98.5889,
+                    "latitude": 29.56222,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2OQAU",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "78232-1421",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubtQAC",
+                    "type": "store",
+                    "street": "18140 SAN PEDRO",
+                    "storeNumber": 397,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 80,
+                            "openAppointmentSlots": 80,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 158,
+                            "openAppointmentSlots": 158,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 80,
+                    "openFluTimeslots": 158,
+                    "openFluAppointmentSlots": 158,
+                    "openAppointmentSlots": 80,
+                    "name": "281 and 1604 H-E-B",
+                    "longitude": -98.46828,
+                    "latitude": 29.60772,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2PQAU",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "78247-3312",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubuQAC",
+                    "type": "store",
+                    "street": "2929 THOUSAND OAKS",
+                    "storeNumber": 398,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 124,
+                            "openAppointmentSlots": 124,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 248,
+                            "openAppointmentSlots": 248,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 259,
+                            "openAppointmentSlots": 259,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 631,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 631,
+                    "name": "Thousand Oaks H-E-B",
+                    "longitude": -98.44108,
+                    "latitude": 29.57781,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "78363-3872",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubvQAC",
+                    "type": "store",
+                    "street": "409 E. KLEBERG",
+                    "storeNumber": 401,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 51,
+                            "openAppointmentSlots": 51,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 33,
+                            "openAppointmentSlots": 33,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 101,
+                    "openFluTimeslots": 33,
+                    "openFluAppointmentSlots": 33,
+                    "openAppointmentSlots": 101,
+                    "name": "Kingsville H-E-B",
+                    "longitude": -97.86453,
+                    "latitude": 27.51658,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2RQAU",
+                    "city": "KINGSVILLE"
+                },
+                {
+                    "zip": "77382-2772",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudJQAS",
+                    "type": "store",
+                    "street": "10777 KUYKENDAHL ROAD",
+                    "storeNumber": 594,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 7,
+                            "openAppointmentSlots": 7,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 6,
+                            "openAppointmentSlots": 6,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 21,
+                            "openAppointmentSlots": 21,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 45,
+                            "openAppointmentSlots": 45,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 34,
+                    "openFluTimeslots": 45,
+                    "openFluAppointmentSlots": 45,
+                    "openAppointmentSlots": 34,
+                    "name": "Indian Springs H-E-B",
+                    "longitude": -95.53672,
+                    "latitude": 30.17791,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3pQAE",
+                    "city": "THE WOODLANDS"
+                },
+                {
+                    "zip": "77301-1220",
+                    "url": null,
+                    "type": "store",
+                    "street": "2108 NORTH FRAZIER",
+                    "storeNumber": 595,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "N Frazier At Loop 336 H-E-B",
+                    "longitude": -95.46548,
+                    "latitude": 30.33593,
+                    "fluUrl": "",
+                    "city": "CONROE"
+                },
+                {
+                    "zip": "77494-8100",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudLQAS",
+                    "type": "store",
+                    "street": "6711 SOUTH FRY ROAD",
+                    "storeNumber": 596,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 10,
+                            "openAppointmentSlots": 10,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 80,
+                            "openAppointmentSlots": 80,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 112,
+                            "openAppointmentSlots": 112,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 190,
+                    "openFluTimeslots": 112,
+                    "openFluAppointmentSlots": 112,
+                    "openAppointmentSlots": 190,
+                    "name": "Grand Parkway H-E-B plus!",
+                    "longitude": -95.7739,
+                    "latitude": 29.7144,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3rQAE",
+                    "city": "KATY"
+                },
+                {
+                    "zip": "77005-4210",
+                    "url": null,
+                    "type": "store",
+                    "street": "5225 BUFFALO SPEEDWAY",
+                    "storeNumber": 599,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Buffalo Market H-E-B On Buffalo Speedway",
+                    "longitude": -95.4271,
+                    "latitude": 29.7261,
+                    "fluUrl": "",
+                    "city": "HOUSTON"
+                },
+                {
+                    "zip": "77388-3412",
+                    "url": null,
+                    "type": "store",
+                    "street": "2121 FM 2920",
+                    "storeNumber": 610,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Spring Market H-E-B",
+                    "longitude": -95.44894,
+                    "latitude": 30.07042,
+                    "fluUrl": "",
+                    "city": "SPRING"
+                },
+                {
+                    "zip": "78620-5482",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudOQAS",
+                    "type": "store",
+                    "street": "598 E.HWY US 290",
+                    "storeNumber": 611,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 18,
+                            "openAppointmentSlots": 18,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 42,
+                            "openAppointmentSlots": 42,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 44,
+                            "openAppointmentSlots": 44,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 12,
+                            "openAppointmentSlots": 12,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 116,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 116,
+                    "name": "Dripping Springs H-E-B",
+                    "longitude": -98.08146,
+                    "latitude": 30.18968,
+                    "fluUrl": "",
+                    "city": "DRIPPING SPRINGS"
+                },
+                {
+                    "zip": "78121-5922",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudPQAS",
+                    "type": "store",
+                    "street": "14414 US HWY 87 WEST",
+                    "storeNumber": 612,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 30,
+                            "openAppointmentSlots": 30,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 25,
+                            "openAppointmentSlots": 25,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 5,
+                            "openAppointmentSlots": 5,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 60,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 60,
+                    "name": "La Vernia H-E-B",
+                    "longitude": -98.13514,
+                    "latitude": 29.35803,
+                    "fluUrl": "",
+                    "city": "LA VERNIA"
+                },
+                {
+                    "zip": "77388-0",
+                    "url": null,
+                    "type": "store",
+                    "street": "5251 FM 2920",
+                    "storeNumber": 748,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "H-E-B Market at Gosling",
+                    "longitude": -95.50178,
+                    "latitude": 30.07179,
+                    "fluUrl": "",
+                    "city": "SPRING"
+                },
+                {
+                    "zip": "78218-0",
+                    "url": null,
+                    "type": "store",
+                    "street": "6520 FRATT RD. SUITE B",
+                    "storeNumber": 751,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "RX04-COMPOUND FRATT & RITTIMAN",
+                    "longitude": 0,
+                    "latitude": 0,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "76087-0",
+                    "url": null,
+                    "type": "store",
+                    "street": "100 HUDSON OAKS DR",
+                    "storeNumber": 752,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Hudson Oaks H-E-B",
+                    "longitude": -97.69733,
+                    "latitude": 32.75831,
+                    "fluUrl": "",
+                    "city": "HUDSON OAKS"
+                },
+                {
+                    "zip": "77004-0",
+                    "url": null,
+                    "type": "store",
+                    "street": "6055 SOUTH FREEWAY",
+                    "storeNumber": 756,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "MacGregor Market H-E-B",
+                    "longitude": -95.37644,
+                    "latitude": 29.71432,
+                    "fluUrl": "",
+                    "city": "HOUSTON"
+                },
+                {
+                    "zip": "77385-0",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuekQAC",
+                    "type": "store",
+                    "street": "10200 HIGHWAY 242",
+                    "storeNumber": 757,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 190,
+                            "openAppointmentSlots": 190,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 195,
+                            "openAppointmentSlots": 195,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 194,
+                            "openAppointmentSlots": 194,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 579,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 579,
+                    "name": "Harper's Trace H-E-B",
+                    "longitude": -95.42563,
+                    "latitude": 30.20692,
+                    "fluUrl": "",
+                    "city": "CONROE"
+                },
+                {
+                    "zip": "77339-0",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuelQAC",
+                    "type": "store",
+                    "street": "19529 NORTHPARK DR.",
+                    "storeNumber": 759,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 36,
+                            "openAppointmentSlots": 36,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 35,
+                            "openAppointmentSlots": 35,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 12,
+                            "openAppointmentSlots": 12,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 36,
+                            "openAppointmentSlots": 36,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 83,
+                    "openFluTimeslots": 36,
+                    "openFluAppointmentSlots": 36,
+                    "openAppointmentSlots": 83,
+                    "name": "H-E-B Market at Northpark",
+                    "longitude": -95.25033,
+                    "latitude": 30.06864,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2FQAU",
+                    "city": "KINGWOOD"
+                },
+                {
+                    "zip": "78253-0",
+                    "url": null,
+                    "type": "store",
+                    "street": "14325 POTRANCO RD.",
+                    "storeNumber": 771,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "211 and Potranco H-E-B",
+                    "longitude": -98.77966,
+                    "latitude": 29.42367,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "79424-0",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuenQAC",
+                    "type": "store",
+                    "street": "4405 114TH STREET",
+                    "storeNumber": 772,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 84,
+                            "openAppointmentSlots": 84,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 39,
+                            "openAppointmentSlots": 39,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 123,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 123,
+                    "name": "Lubbock H-E-B",
+                    "longitude": -101.90638,
+                    "latitude": 33.48958,
+                    "fluUrl": "",
+                    "city": "LUBBOCK"
+                },
+                {
+                    "zip": "79720-5437",
+                    "url": null,
+                    "type": "store",
+                    "street": "2000 SOUTH GREGG",
+                    "storeNumber": 51,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Big Spring H-E-B",
+                    "longitude": -101.47211,
+                    "latitude": 32.23493,
+                    "fluUrl": "",
+                    "city": "BIG SPRING"
+                },
+                {
+                    "zip": "76901-3528",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaVQAS",
+                    "type": "store",
+                    "street": "3301 SHERWOOD WAY",
+                    "storeNumber": 52,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 220,
+                            "openAppointmentSlots": 220,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 199,
+                            "openAppointmentSlots": 199,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 240,
+                            "openAppointmentSlots": 240,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 659,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 659,
+                    "name": "Sherwood Avenue N H-E-B",
+                    "longitude": -100.47977,
+                    "latitude": 31.44511,
+                    "fluUrl": "",
+                    "city": "SAN ANGELO"
+                },
+                {
+                    "zip": "77075-2246",
+                    "url": null,
+                    "type": "store",
+                    "street": "9828 BLACKHAWK BLVD.",
+                    "storeNumber": 54,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Blackhawk H-E-B",
+                    "longitude": -95.24868,
+                    "latitude": 29.60234,
+                    "fluUrl": "",
+                    "city": "HOUSTON"
+                },
+                {
+                    "zip": "78418-4426",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaXQAS",
+                    "type": "store",
+                    "street": "1145 WALDRON ROAD",
+                    "storeNumber": 57,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 14,
+                            "openAppointmentSlots": 14,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 14,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 14,
+                    "name": "Flour Bluff H-E-B plus!",
+                    "longitude": -97.28288,
+                    "latitude": 27.66767,
+                    "fluUrl": "",
+                    "city": "CORPUS CHRISTI"
+                },
+                {
+                    "zip": "77584-2191",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaYQAS",
+                    "type": "store",
+                    "street": "2805 BUSINESS CENTER DRIVE",
+                    "storeNumber": 63,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 342,
+                            "openAppointmentSlots": 342,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 342,
+                            "openAppointmentSlots": 342,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 273,
+                            "openAppointmentSlots": 273,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 957,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 957,
+                    "name": "Pearland H-E-B plus!",
+                    "longitude": -95.39002,
+                    "latitude": 29.55932,
+                    "fluUrl": "",
+                    "city": "PEARLAND"
+                },
+                {
+                    "zip": "76708-1675",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaZQAS",
+                    "type": "store",
+                    "street": "3801 N 19TH ST.",
+                    "storeNumber": 64,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 25,
+                            "openAppointmentSlots": 25,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 6,
+                            "openAppointmentSlots": 6,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 31,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 31,
+                    "name": "19th and Meridian H-E-B",
+                    "longitude": -97.17255,
+                    "latitude": 31.5804,
+                    "fluUrl": "",
+                    "city": "WACO"
+                },
+                {
+                    "zip": "78749-6507",
+                    "url": null,
+                    "type": "store",
+                    "street": "5800 W. SLAUGHTER LANE",
+                    "storeNumber": 68,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 113,
+                            "openAppointmentSlots": 113,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 113,
+                    "openFluAppointmentSlots": 113,
+                    "openAppointmentSlots": 0,
+                    "name": "Slaughter and Escarpment H-E-B",
+                    "longitude": -97.87642,
+                    "latitude": 30.20247,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4TQAU",
+                    "city": "AUSTIN"
+                },
+                {
+                    "zip": "78413-2816",
+                    "url": null,
+                    "type": "store",
+                    "street": "5313 SARATOGA",
+                    "storeNumber": 69,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Staples and Saratoga H-E-B plus!",
+                    "longitude": -97.38802,
+                    "latitude": 27.68613,
+                    "fluUrl": "",
+                    "city": "CORPUS CHRISTI"
+                },
+                {
+                    "zip": "76528-1628",
+                    "url": null,
+                    "type": "store",
+                    "street": "1207 E.MAIN",
+                    "storeNumber": 403,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Gatesville H-E-B",
+                    "longitude": -97.7428,
+                    "latitude": 31.43586,
+                    "fluUrl": "",
+                    "city": "GATESVILLE"
+                },
+                {
+                    "zip": "78738-6517",
+                    "url": null,
+                    "type": "store",
+                    "street": "12400 W HIGHWAY 71",
+                    "storeNumber": 404,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Bee Cave H-E-B",
+                    "longitude": -97.93238,
+                    "latitude": 30.30489,
+                    "fluUrl": "",
+                    "city": "BEE CAVE"
+                },
+                {
+                    "zip": "78227-1652",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudQQAS",
+                    "type": "store",
+                    "street": "8219 MARBACH",
+                    "storeNumber": 613,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 68,
+                            "openAppointmentSlots": 68,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 68,
+                            "openAppointmentSlots": 68,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 63,
+                            "openAppointmentSlots": 63,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 199,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 199,
+                    "name": "Marbach and 410 H-E-B plus!",
+                    "longitude": -98.65227,
+                    "latitude": 29.41837,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "77044-6087",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudRQAS",
+                    "type": "store",
+                    "street": "12680 W.LAKE HOUSTON PKWY",
+                    "storeNumber": 614,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 55,
+                            "openAppointmentSlots": 55,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 115,
+                            "openAppointmentSlots": 115,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 84,
+                            "openAppointmentSlots": 84,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 42,
+                            "openAppointmentSlots": 42,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 254,
+                    "openFluTimeslots": 42,
+                    "openFluAppointmentSlots": 42,
+                    "openAppointmentSlots": 254,
+                    "name": "Summerwood Market H-E-B",
+                    "longitude": -95.19697,
+                    "latitude": 29.92325,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF49QAE",
+                    "city": "HOUSTON"
+                },
+                {
+                    "zip": "77494-5904",
+                    "url": null,
+                    "type": "store",
+                    "street": "25675 NELSON WAY",
+                    "storeNumber": 615,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 300,
+                            "openAppointmentSlots": 300,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 300,
+                    "openFluAppointmentSlots": 300,
+                    "openAppointmentSlots": 0,
+                    "name": "Katy Market H-E-B",
+                    "longitude": -95.82005,
+                    "latitude": 29.77644,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4AQAU",
+                    "city": "KATY"
+                },
+                {
+                    "zip": "78240-2136",
+                    "url": null,
+                    "type": "store",
+                    "street": "5910 BABCOCK RD",
+                    "storeNumber": 618,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Babcock H-E-B",
+                    "longitude": -98.60198,
+                    "latitude": 29.5271,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "77845-4638",
+                    "url": null,
+                    "type": "store",
+                    "street": "949 WILLIAM D.FITCH PARKWAY",
+                    "storeNumber": 619,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Tower Point Market H-E-B",
+                    "longitude": -96.26315,
+                    "latitude": 30.55969,
+                    "fluUrl": "",
+                    "city": "COLLEGE STATION"
+                },
+                {
+                    "zip": "78061-6630",
+                    "url": null,
+                    "type": "store",
+                    "street": "225 SOUTH IH 35",
+                    "storeNumber": 620,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Pearsall H-E-B",
+                    "longitude": -99.11446,
+                    "latitude": 28.89503,
+                    "fluUrl": "",
+                    "city": "PEARSALL"
+                },
+                {
+                    "zip": "78712-0",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueoQAC",
+                    "type": "store",
+                    "street": "1601 TRINITY ST",
+                    "storeNumber": 773,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 154,
+                            "openAppointmentSlots": 154,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 159,
+                            "openAppointmentSlots": 159,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 333,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 333,
+                    "name": "H-E-B Pharmacy at the UTHTB",
+                    "longitude": -97.73507,
+                    "latitude": 30.27747,
+                    "fluUrl": "",
+                    "city": "AUSTIN"
+                },
+                {
+                    "zip": "79605-5171",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuacQAC",
+                    "type": "store",
+                    "street": "1345 BARROW",
+                    "storeNumber": 70,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 60,
+                            "openAppointmentSlots": 60,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 105,
+                            "openAppointmentSlots": 105,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 29,
+                            "openAppointmentSlots": 29,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 195,
+                            "openAppointmentSlots": 195,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 194,
+                    "openFluTimeslots": 195,
+                    "openFluAppointmentSlots": 195,
+                    "openAppointmentSlots": 194,
+                    "name": "Abilene H-E-B",
+                    "longitude": -99.75934,
+                    "latitude": 32.43348,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4VQAU",
+                    "city": "ABILENE"
+                },
+                {
+                    "zip": "76504-2448",
+                    "url": null,
+                    "type": "store",
+                    "street": "1314 WEST ADAMS",
+                    "storeNumber": 71,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Adams and 25th St H-E-B",
+                    "longitude": -97.35378,
+                    "latitude": 31.10153,
+                    "fluUrl": "",
+                    "city": "TEMPLE"
+                },
+                {
+                    "zip": "78006-2523",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudWQAS",
+                    "type": "store",
+                    "street": "420 WEST BANDERA ROAD",
+                    "storeNumber": 621,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 73,
+                            "openAppointmentSlots": 73,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 81,
+                            "openAppointmentSlots": 81,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 154,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 154,
+                    "name": "Boerne H-E-B plus!",
+                    "longitude": -98.73481,
+                    "latitude": 29.78173,
+                    "fluUrl": "",
+                    "city": "BOERNE"
+                },
+                {
+                    "zip": "78070-6270",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudXQAS",
+                    "type": "store",
+                    "street": "20725 HWY 46 WEST",
+                    "storeNumber": 622,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 54,
+                            "openAppointmentSlots": 54,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 66,
+                            "openAppointmentSlots": 66,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 140,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 140,
+                    "name": "Bulverde H-E-B plus!",
+                    "longitude": -98.43022,
+                    "latitude": 29.79882,
+                    "fluUrl": "",
+                    "city": "SPRING BRANCH"
+                },
+                {
+                    "zip": "78249-2577",
+                    "url": null,
+                    "type": "store",
+                    "street": "9238 N.LOOP 1604 WEST",
+                    "storeNumber": 623,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Bandera and 1604 H-E-B plus!",
+                    "longitude": -98.66444,
+                    "latitude": 29.55498,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "78586-4395",
+                    "url": null,
+                    "type": "store",
+                    "street": "1095 WEST BUSINESS 77",
+                    "storeNumber": 626,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "San Benito H-E-B",
+                    "longitude": -97.63395,
+                    "latitude": 26.14392,
+                    "fluUrl": "",
+                    "city": "SAN BENITO"
+                },
+                {
+                    "zip": "77478-4947",
+                    "url": null,
+                    "type": "store",
+                    "street": "530 HWY 6",
+                    "storeNumber": 627,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Sugar Land Market H-E-B",
+                    "longitude": -95.64596,
+                    "latitude": 29.60871,
+                    "fluUrl": "",
+                    "city": "SUGAR LAND"
+                },
+                {
+                    "zip": "78218",
+                    "url": null,
+                    "type": "store",
+                    "street": "4949 Rittiman Rd",
+                    "storeNumber": 804471,
+                    "state": "Tx",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Magenta Clinics - Rittiman",
+                    "longitude": -98.39355342726148,
+                    "latitude": 29.48488847441163,
+                    "fluUrl": "",
+                    "city": "San Antonio"
+                },
+                {
+                    "zip": "77406-0",
+                    "url": null,
+                    "type": "store",
+                    "street": "9211 FM 723 RD",
+                    "storeNumber": 749,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Spring Green Market H-E-B",
+                    "longitude": -95.81427,
+                    "latitude": 29.69558,
+                    "fluUrl": "",
+                    "city": "RICHMOND"
+                },
+                {
+                    "zip": "78130-4753",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaeQAC",
+                    "type": "store",
+                    "street": "1655 W STATE HIGHWAY 46",
+                    "storeNumber": 74,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 83,
+                            "openAppointmentSlots": 83,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 55,
+                            "openAppointmentSlots": 55,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 138,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 138,
+                    "name": "New Braunfels H-E-B at Hwy 46",
+                    "longitude": -98.16041,
+                    "latitude": 29.71309,
+                    "fluUrl": "",
+                    "city": "NEW BRAUNFELS"
+                },
+                {
+                    "zip": "78224-1136",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuafQAC",
+                    "type": "store",
+                    "street": "6818 SOUTH ZARZAMORA",
+                    "storeNumber": 84,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 216,
+                            "openAppointmentSlots": 216,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 432,
+                            "openAppointmentSlots": 432,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 534,
+                            "openAppointmentSlots": 534,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 32,
+                            "openAppointmentSlots": 32,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 432,
+                            "openAppointmentSlots": 432,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 1214,
+                    "openFluTimeslots": 432,
+                    "openFluAppointmentSlots": 432,
+                    "openAppointmentSlots": 1214,
+                    "name": "Zarzamora and Military H-E-B plus!",
+                    "longitude": -98.5339,
+                    "latitude": 29.35787,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4nQAE",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "78251-3312",
+                    "url": null,
+                    "type": "store",
+                    "street": "10718 POTRANCO ROAD",
+                    "storeNumber": 85,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 336,
+                            "openAppointmentSlots": 336,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 336,
+                    "openFluAppointmentSlots": 336,
+                    "openAppointmentSlots": 0,
+                    "name": "Potranco and 1604 H-E-B plus!",
+                    "longitude": -98.70445,
+                    "latitude": 29.43536,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4oQAE",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "78028-0",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuahQAC",
+                    "type": "store",
+                    "street": "300 W. MAIN ST.",
+                    "storeNumber": 770,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 120,
+                            "openAppointmentSlots": 120,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 131,
+                            "openAppointmentSlots": 131,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 251,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 251,
+                    "name": "Kerrville H-E-B On Main Street",
+                    "longitude": -99.14287,
+                    "latitude": 30.05056,
+                    "fluUrl": "",
+                    "city": "KERRVILLE"
+                },
+                {
+                    "zip": "78741-3037",
+                    "url": null,
+                    "type": "store",
+                    "street": "2508 EAST RIVERSIDE DRIVE",
+                    "storeNumber": 91,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Riverside H-E-B plus!",
+                    "longitude": -97.72401,
+                    "latitude": 30.23547,
+                    "fluUrl": "",
+                    "city": "AUSTIN"
+                },
+                {
+                    "zip": "77904-1767",
+                    "url": null,
+                    "type": "store",
+                    "street": "6106 N. NAVARRO",
+                    "storeNumber": 92,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Victoria H-E-B plus!",
+                    "longitude": -96.99736,
+                    "latitude": 28.85159,
+                    "fluUrl": "",
+                    "city": "VICTORIA"
+                },
+                {
+                    "zip": "77055-6209",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuasQAC",
+                    "type": "store",
+                    "street": "9710 KATY FREEWAY",
+                    "storeNumber": 109,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 33,
+                            "openAppointmentSlots": 33,
+                            "manufacturer": "Other"
+                        },
+                        {
+                            "openTimeslots": 55,
+                            "openAppointmentSlots": 55,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 125,
+                    "openFluTimeslots": 33,
+                    "openFluAppointmentSlots": 33,
+                    "openAppointmentSlots": 125,
+                    "name": "Bunker Hill H-E-B",
+                    "longitude": -95.53206,
+                    "latitude": 29.78485,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF0aQAE",
+                    "city": "HOUSTON"
+                },
+                {
+                    "zip": "77459-6931",
+                    "url": null,
+                    "type": "store",
+                    "street": "8900 HWY 6",
+                    "storeNumber": 110,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Sienna Market H-E-B",
+                    "longitude": -95.53497,
+                    "latitude": 29.53928,
+                    "fluUrl": "",
+                    "city": "MISSOURI CITY"
+                },
+                {
+                    "zip": "78550-7708",
+                    "url": null,
+                    "type": "store",
+                    "street": "1213 S. COMMERCE",
+                    "storeNumber": 136,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Southland and 12th St H-E-B",
+                    "longitude": -97.68171,
+                    "latitude": 26.18251,
+                    "fluUrl": "",
+                    "city": "HARLINGEN"
+                },
+                {
+                    "zip": "78413-3966",
+                    "url": null,
+                    "type": "store",
+                    "street": "5801 WEBER ROAD",
+                    "storeNumber": 139,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Weber and Holly H-E-B",
+                    "longitude": -97.40529,
+                    "latitude": 27.71118,
+                    "fluUrl": "",
+                    "city": "CORPUS CHRISTI"
+                },
+                {
+                    "zip": "78723-2924",
+                    "url": null,
+                    "type": "store",
+                    "street": "7112 ED BLUESTEIN_#125",
+                    "storeNumber": 161,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Ed Bluestein H-E-B",
+                    "longitude": -97.66465,
+                    "latitude": 30.31211,
+                    "fluUrl": "",
+                    "city": "AUSTIN"
+                },
+                {
+                    "zip": "78232-3714",
+                    "url": null,
+                    "type": "store",
+                    "street": "15000 SAN PEDRO",
+                    "storeNumber": 164,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Brook Hollow H-E-B",
+                    "longitude": -98.47734,
+                    "latitude": 29.5774,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "78572-8354",
+                    "url": null,
+                    "type": "store",
+                    "street": "2409 EAST EXPRESSWAY 83",
+                    "storeNumber": 94,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Mission H-E-B plus!",
+                    "longitude": -98.28628,
+                    "latitude": 26.19755,
+                    "fluUrl": "",
+                    "city": "MISSION"
+                },
+                {
+                    "zip": "78045-6596",
+                    "url": null,
+                    "type": "store",
+                    "street": "1911 NE BOB BULLOCK LOOP",
+                    "storeNumber": 95,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Laredo H-E-B plus!",
+                    "longitude": -99.47435,
+                    "latitude": 27.60863,
+                    "fluUrl": "",
+                    "city": "LAREDO"
+                },
+                {
+                    "zip": "78731-3023",
+                    "url": null,
+                    "type": "store",
+                    "street": "7015 VILLAGE CTR DR.",
+                    "storeNumber": 96,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Far West H-E-B",
+                    "longitude": -97.75598,
+                    "latitude": 30.35289,
+                    "fluUrl": "",
+                    "city": "AUSTIN"
+                },
+                {
+                    "zip": "77070-1667",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuanQAC",
+                    "type": "store",
+                    "street": "10919 LOUETTA RD",
+                    "storeNumber": 99,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 56,
+                            "openAppointmentSlots": 56,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 57,
+                            "openAppointmentSlots": 57,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 68,
+                            "openAppointmentSlots": 68,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 80,
+                            "openAppointmentSlots": 80,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 181,
+                    "openFluTimeslots": 80,
+                    "openFluAppointmentSlots": 80,
+                    "openAppointmentSlots": 181,
+                    "name": "Vintage Park Market H-E-B",
+                    "longitude": -95.57661,
+                    "latitude": 29.9967,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4vQAE",
+                    "city": "HOUSTON"
+                },
+                {
+                    "zip": "78231-1841",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaoQAC",
+                    "type": "store",
+                    "street": "8503 NW MILITARY HWY",
+                    "storeNumber": 102,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 167,
+                            "openAppointmentSlots": 167,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 488,
+                            "openAppointmentSlots": 488,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 90,
+                            "openAppointmentSlots": 90,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 506,
+                            "openAppointmentSlots": 506,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 745,
+                    "openFluTimeslots": 506,
+                    "openFluAppointmentSlots": 506,
+                    "openAppointmentSlots": 745,
+                    "name": "Alon Market H-E-B",
+                    "longitude": -98.53463,
+                    "latitude": 29.55254,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4wQAE",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "78745-5008",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucCQAS",
+                    "type": "store",
+                    "street": "6900 BRODIE LANE",
+                    "storeNumber": 428,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 11,
+                            "openAppointmentSlots": 11,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 15,
+                            "openAppointmentSlots": 15,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 26,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 26,
+                    "name": "Brodie Lane H-E-B",
+                    "longitude": -97.83076,
+                    "latitude": 30.21489,
+                    "fluUrl": "",
+                    "city": "AUSTIN"
+                },
+                {
+                    "zip": "78539-7312",
+                    "url": null,
+                    "type": "store",
+                    "street": "2700 W FREDDY GONZALES",
+                    "storeNumber": 431,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Edinburg H-E-B",
+                    "longitude": -98.1958,
+                    "latitude": 26.29078,
+                    "fluUrl": "",
+                    "city": "EDINBURG"
+                },
+                {
+                    "zip": "77098-2807",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudbQAC",
+                    "type": "store",
+                    "street": "1701 WEST ALABAMA ST",
+                    "storeNumber": 630,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 65,
+                            "openAppointmentSlots": 65,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 67,
+                            "openAppointmentSlots": 67,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 30,
+                            "openAppointmentSlots": 30,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 158,
+                            "openAppointmentSlots": 158,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 162,
+                    "openFluTimeslots": 158,
+                    "openFluAppointmentSlots": 158,
+                    "openAppointmentSlots": 162,
+                    "name": "Montrose Market H-E-B",
+                    "longitude": -95.40284,
+                    "latitude": 29.7379,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4YQAU",
+                    "city": "HOUSTON"
+                },
+                {
+                    "zip": "76049-7428",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudcQAC",
+                    "type": "store",
+                    "street": "3804 US HWY 377",
+                    "storeNumber": 631,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 116,
+                            "openAppointmentSlots": 116,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 118,
+                            "openAppointmentSlots": 118,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 58,
+                            "openAppointmentSlots": 58,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 292,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 292,
+                    "name": "Granbury H-E-B",
+                    "longitude": -97.73026,
+                    "latitude": 32.45528,
+                    "fluUrl": "",
+                    "city": "GRANBURY"
+                },
+                {
+                    "zip": "77384-3943",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuddQAC",
+                    "type": "store",
+                    "street": "3601 FM 1488",
+                    "storeNumber": 638,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 80,
+                            "openAppointmentSlots": 80,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 66,
+                            "openAppointmentSlots": 66,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 9,
+                            "openAppointmentSlots": 9,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 155,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 155,
+                    "name": "North Woodlands Market H-E-B",
+                    "longitude": -95.51296,
+                    "latitude": 30.22918,
+                    "fluUrl": "",
+                    "city": "THE WOODLANDS"
+                },
+                {
+                    "zip": "78723-3014",
+                    "url": null,
+                    "type": "store",
+                    "street": "1801 E.51ST STREET",
+                    "storeNumber": 639,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Mueller H-E-B",
+                    "longitude": -97.69872,
+                    "latitude": 30.3013,
+                    "fluUrl": "",
+                    "city": "AUSTIN"
+                },
+                {
+                    "zip": "78629-2406",
+                    "url": null,
+                    "type": "store",
+                    "street": "1841 CHURCH ST.",
+                    "storeNumber": 641,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Gonzales H-E-B",
+                    "longitude": -97.45202,
+                    "latitude": 29.51832,
+                    "fluUrl": "",
+                    "city": "GONZALES"
+                },
+                {
+                    "zip": "78577-6293",
+                    "url": null,
+                    "type": "store",
+                    "street": "1300 SOUTH CAGE BLVD.",
+                    "storeNumber": 642,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Pharr H-E-B plus!",
+                    "longitude": -98.18706,
+                    "latitude": 26.1803,
+                    "fluUrl": "",
+                    "city": "PHARR"
+                },
+                {
+                    "zip": "78415-5021",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudhQAC",
+                    "type": "store",
+                    "street": "4444 KOSTORYZ",
+                    "storeNumber": 643,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 9,
+                            "openAppointmentSlots": 9,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 24,
+                            "openAppointmentSlots": 24,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 10,
+                            "openAppointmentSlots": 10,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 43,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 43,
+                    "name": "Kostoryz and Gollihar H-E-B",
+                    "longitude": -97.40516,
+                    "latitude": 27.73917,
+                    "fluUrl": "",
+                    "city": "CORPUS CHRISTI"
+                },
+                {
+                    "zip": "77803-1828",
+                    "url": null,
+                    "type": "store",
+                    "street": "1609 NORTH TEXAS AVENUE",
+                    "storeNumber": 644,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Hwy 21 and N Texas Ave H-E-B",
+                    "longitude": -96.3717,
+                    "latitude": 30.6901,
+                    "fluUrl": "",
+                    "city": "BRYAN"
+                },
+                {
+                    "zip": "78229-3931",
+                    "url": null,
+                    "type": "store",
+                    "street": "8300 FLOYD CURL DR.STE 105",
+                    "storeNumber": 647,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "H-E-B Pharmacy at the MARC",
+                    "longitude": -98.58335,
+                    "latitude": 29.51552,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "78028-5916",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudkQAC",
+                    "type": "store",
+                    "street": "313 SIDNEY BAKER SOUTH",
+                    "storeNumber": 655,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 200,
+                            "openAppointmentSlots": 200,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 198,
+                            "openAppointmentSlots": 198,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 197,
+                            "openAppointmentSlots": 197,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 117,
+                            "openAppointmentSlots": 117,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 712,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 712,
+                    "name": "Kerrville H-E-B on Sidney Baker St",
+                    "longitude": -99.14342,
+                    "latitude": 30.04152,
+                    "fluUrl": "",
+                    "city": "KERRVILLE"
+                },
+                {
+                    "zip": "78550-5152",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuayQAC",
+                    "type": "store",
+                    "street": "1103 MORGAN BLVD",
+                    "storeNumber": 168,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 35,
+                            "openAppointmentSlots": 35,
+                            "manufacturer": "Other"
+                        },
+                        {
+                            "openTimeslots": 34,
+                            "openAppointmentSlots": 34,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 34,
+                            "openAppointmentSlots": 34,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 35,
+                            "openAppointmentSlots": 35,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 103,
+                    "openFluTimeslots": 35,
+                    "openFluAppointmentSlots": 35,
+                    "openAppointmentSlots": 103,
+                    "name": "Morgan and Grimes H-E-B",
+                    "longitude": -97.67639,
+                    "latitude": 26.20337,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF0gQAE",
+                    "city": "HARLINGEN"
+                },
+                {
+                    "zip": "78539-5664",
+                    "url": null,
+                    "type": "store",
+                    "street": "1212 S CLOSNER BLVD",
+                    "storeNumber": 172,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Closner and Baker H-E-B",
+                    "longitude": -98.1642,
+                    "latitude": 26.29029,
+                    "fluUrl": "",
+                    "city": "EDINBURG"
+                },
+                {
+                    "zip": "78216-7202",
+                    "url": null,
+                    "type": "store",
+                    "street": "6839 SAN PEDRO",
+                    "storeNumber": 178,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "San Pedro and Oblate H-E-B",
+                    "longitude": -98.4995,
+                    "latitude": 29.50282,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "76502-1802",
+                    "url": null,
+                    "type": "store",
+                    "street": "3002 S 31 ST",
+                    "storeNumber": 182,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Market Place H-E-B",
+                    "longitude": -97.37061,
+                    "latitude": 31.07223,
+                    "fluUrl": "",
+                    "city": "TEMPLE"
+                },
+                {
+                    "zip": "78753-4106",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gub2QAC",
+                    "type": "store",
+                    "street": "9414 N LAMAR BLVD",
+                    "storeNumber": 183,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 47,
+                            "openAppointmentSlots": 47,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 46,
+                            "openAppointmentSlots": 46,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 93,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 93,
+                    "name": "Lamar and Rundberg H-E-B",
+                    "longitude": -97.69689,
+                    "latitude": 30.36357,
+                    "fluUrl": "",
+                    "city": "AUSTIN"
+                },
+                {
+                    "zip": "78410-2612",
+                    "url": null,
+                    "type": "store",
+                    "street": "11100 LEOPARD",
+                    "storeNumber": 184,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Leopard and Violet H-E-B",
+                    "longitude": -97.58473,
+                    "latitude": 27.84494,
+                    "fluUrl": "",
+                    "city": "CORPUS CHRISTI"
+                },
+                {
+                    "zip": "78041-5435",
+                    "url": null,
+                    "type": "store",
+                    "street": "2310 E SAUNDERS ST",
+                    "storeNumber": 186,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Saunders St H-E-B",
+                    "longitude": -99.47131,
+                    "latitude": 27.53071,
+                    "fluUrl": "",
+                    "city": "LAREDO"
+                },
+                {
+                    "zip": "78745-0",
+                    "url": null,
+                    "type": "store",
+                    "street": "8801 SOUTH CONGRESS AVENUE",
+                    "storeNumber": 710,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Slaughter and South Congress H-E-B",
+                    "longitude": -97.78723,
+                    "latitude": 30.16862,
+                    "fluUrl": "",
+                    "city": "AUSTIN"
+                },
+                {
+                    "zip": "78220-2530",
+                    "url": null,
+                    "type": "store",
+                    "street": "1015 S.W.W. WHITE ROAD",
+                    "storeNumber": 106,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "W. W. White H-E-B",
+                    "longitude": -98.40568,
+                    "latitude": 29.41476,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "75119-4519",
+                    "url": null,
+                    "type": "store",
+                    "street": "101 S. CLAY ST",
+                    "storeNumber": 107,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Ennis H-E-B",
+                    "longitude": -96.63251,
+                    "latitude": 32.32542,
+                    "fluUrl": "",
+                    "city": "ENNIS"
+                },
+                {
+                    "zip": "78258-7587",
+                    "url": null,
+                    "type": "store",
+                    "street": "20935 US HIGHWAY 281 NORTH",
+                    "storeNumber": 108,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "281 and Evans Road H-E-B plus!",
+                    "longitude": -98.45756,
+                    "latitude": 29.63886,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "77433-4288",
+                    "url": null,
+                    "type": "store",
+                    "street": "28550 US- 290",
+                    "storeNumber": 656,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Fairfield Market H-E-B",
+                    "longitude": -95.74599,
+                    "latitude": 29.9925,
+                    "fluUrl": "",
+                    "city": "CYPRESS"
+                },
+                {
+                    "zip": "77065-4814",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudmQAC",
+                    "type": "store",
+                    "street": "9503 JONES ROAD",
+                    "storeNumber": 657,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 2,
+                            "openAppointmentSlots": 2,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 13,
+                            "openAppointmentSlots": 13,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 2,
+                    "openFluTimeslots": 13,
+                    "openFluAppointmentSlots": 13,
+                    "openAppointmentSlots": 2,
+                    "name": "Jones and West H-E-B",
+                    "longitude": -95.5859,
+                    "latitude": 29.91104,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4jQAE",
+                    "city": "HOUSTON"
+                },
+                {
+                    "zip": "78258-0",
+                    "url": null,
+                    "type": "store",
+                    "street": "23635 WILDERNESS OAK",
+                    "storeNumber": 658,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 6,
+                            "openAppointmentSlots": 6,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 6,
+                    "openFluAppointmentSlots": 6,
+                    "openAppointmentSlots": 0,
+                    "name": "The Market at Stone Oak",
+                    "longitude": -98.50062,
+                    "latitude": 29.662,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4kQAE",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "78717-5992",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudoQAC",
+                    "type": "store",
+                    "street": "14028 NORTH US 183",
+                    "storeNumber": 659,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 34,
+                            "openAppointmentSlots": 34,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 34,
+                            "openAppointmentSlots": 34,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 12,
+                            "openAppointmentSlots": 12,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 80,
+                    "openFluTimeslots": 20,
+                    "openFluAppointmentSlots": 20,
+                    "openAppointmentSlots": 80,
+                    "name": "Lakeline H-E-B plus!",
+                    "longitude": -97.8034,
+                    "latitude": 30.47786,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4lQAE",
+                    "city": "AUSTIN"
+                },
+                {
+                    "zip": "77304-1837",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudpQAC",
+                    "type": "store",
+                    "street": "3875 W.DAVIS ST.",
+                    "storeNumber": 660,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 338,
+                            "openAppointmentSlots": 338,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 338,
+                            "openAppointmentSlots": 338,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 676,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 676,
+                    "name": "Conroe Market H-E-B",
+                    "longitude": -95.49817,
+                    "latitude": 30.32647,
+                    "fluUrl": "",
+                    "city": "CONROE"
+                },
+                {
+                    "zip": "77590-6548",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudqQAC",
+                    "type": "store",
+                    "street": "3502 PALMER HIGHWAY",
+                    "storeNumber": 662,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 49,
+                            "openAppointmentSlots": 49,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 138,
+                            "openAppointmentSlots": 138,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 120,
+                            "openAppointmentSlots": 120,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 207,
+                    "openFluTimeslots": 120,
+                    "openFluAppointmentSlots": 120,
+                    "openAppointmentSlots": 207,
+                    "name": "Texas City H-E-B",
+                    "longitude": -94.94893,
+                    "latitude": 29.39535,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF51QAE",
+                    "city": "TEXAS CITY"
+                },
+                {
+                    "zip": "78228-6308",
+                    "url": null,
+                    "type": "store",
+                    "street": "2130 CULEBRA",
+                    "storeNumber": 189,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "El Mercado H-E-B",
+                    "longitude": -98.5407,
+                    "latitude": 29.44655,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "78209-5703",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gub6QAC",
+                    "type": "store",
+                    "street": "4821 BROADWAY",
+                    "storeNumber": 191,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 70,
+                            "openAppointmentSlots": 70,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 52,
+                            "openAppointmentSlots": 52,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 36,
+                            "openAppointmentSlots": 36,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 178,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 178,
+                    "name": "Broadway Central Market",
+                    "longitude": -98.46408,
+                    "latitude": 29.47069,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO"
+                },
+                {
+                    "zip": "76522-2515",
+                    "url": null,
+                    "type": "store",
+                    "street": "2990 EAST HWY 190",
+                    "storeNumber": 668,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Copperas Cove H-E-B plus!",
+                    "longitude": -97.86448,
+                    "latitude": 31.11872,
+                    "fluUrl": "",
+                    "city": "COPPERAS COVE"
+                },
+                {
+                    "zip": "78834-2028",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudsQAC",
+                    "type": "store",
+                    "street": "2030 N. 1ST STREET",
+                    "storeNumber": 671,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 35,
+                            "openAppointmentSlots": 35,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 55,
+                            "openAppointmentSlots": 55,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 90,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 90,
+                    "name": "Carrizo Springs H-E-B",
+                    "longitude": -99.85102,
+                    "latitude": 28.53642,
+                    "fluUrl": "",
+                    "city": "CARRIZO SPRINGS"
+                },
+                {
+                    "zip": "76711-2119",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudtQAC",
+                    "type": "store",
+                    "street": "1821 SOUTH VALLEY MILLS DR.",
+                    "storeNumber": 672,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 16,
+                            "openAppointmentSlots": 16,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 16,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 16,
+                    "name": "Valley Mills H-E-B plus!",
+                    "longitude": -97.13916,
+                    "latitude": 31.52508,
+                    "fluUrl": "",
+                    "city": "WACO"
+                },
+                {
+                    "zip": "78665-1044",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuduQAC",
+                    "type": "store",
+                    "street": "250 UNIVERSITY BLVD.",
+                    "storeNumber": 673,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 29,
+                            "openAppointmentSlots": 29,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 6,
+                            "openAppointmentSlots": 6,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 35,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 35,
+                    "name": "University Blvd H-E-B",
+                    "longitude": -97.68859,
+                    "latitude": 30.56107,
+                    "fluUrl": "",
+                    "city": "ROUND ROCK"
+                },
+                {
+                    "zip": "78573-5070",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudvQAC",
+                    "type": "store",
+                    "street": "120 E. MILE 3 RD",
+                    "storeNumber": 674,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 23,
+                            "openAppointmentSlots": 23,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 44,
+                            "openAppointmentSlots": 44,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 25,
+                            "openAppointmentSlots": 25,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 87,
+                    "openFluTimeslots": 25,
+                    "openFluAppointmentSlots": 25,
+                    "openAppointmentSlots": 87,
+                    "name": "Palmhurst H-E-B",
+                    "longitude": -98.31816,
+                    "latitude": 26.25684,
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF56QAE",
+                    "city": "PALMHURST"
+                },
+                {
+                    "zip": "77581-5346",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudwQAC",
+                    "type": "store",
+                    "street": "2710 PEARLAND PARKWAY",
+                    "storeNumber": 675,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 66,
+                            "openAppointmentSlots": 66,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 59,
+                            "openAppointmentSlots": 59,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 125,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 125,
+                    "name": "Pearland Market H-E-B",
+                    "longitude": -95.26499,
+                    "latitude": 29.55812,
+                    "fluUrl": "",
+                    "city": "PEARLAND"
+                },
+                {
+                    "zip": "75206-2921",
+                    "url": null,
+                    "type": "store",
+                    "street": "5750 EAST LOVERS LANE",
+                    "storeNumber": 552,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Central Market Lovers Lane",
+                    "longitude": -96.76835,
+                    "latitude": 32.85091,
+                    "fluUrl": "",
+                    "city": "DALLAS"
+                },
+                {
+                    "zip": "76092-6420",
+                    "url": null,
+                    "type": "store",
+                    "street": "1425 E. SOUTHLAKE",
+                    "storeNumber": 55,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Central Market Southlake",
+                    "longitude": -97.12966,
+                    "latitude": 32.94096,
+                    "fluUrl": "",
+                    "city": "SOUTHLAKE"
+                }
+            ]
+        },
+        "rawHeaders": [
+            "Content-Type",
+            "binary/octet-stream",
+            "Content-Length",
+            "153993",
+            "Connection",
+            "close",
+            "Date",
+            "Mon, 18 Apr 2022 00:17:49 GMT",
+            "Last-Modified",
+            "Mon, 18 Apr 2022 00:17:27 GMT",
+            "ETag",
+            "\"452eba1e00f3703a9d42ac0e92fb526d\"",
+            "Cache-Control",
+            "max-age:0",
+            "Accept-Ranges",
+            "bytes",
+            "Server",
+            "AmazonS3",
+            "X-Cache",
+            "Miss from cloudfront",
+            "Via",
+            "1.1 61729b32280fd6715c2a3b0dbb7e571a.cloudfront.net (CloudFront)",
+            "X-Amz-Cf-Pop",
+            "SFO5-C1",
+            "X-Amz-Cf-Id",
+            "fPM7nj2l4KhwEl8rL1AqA1TIZvu-2Eg6m7AUf_mrgtuienSTGkRPqQ=="
+        ],
+        "responseIsBinary": false
+    }
+]

--- a/loader/test/heb.test.js
+++ b/loader/test/heb.test.js
@@ -4,7 +4,7 @@ const { expectDatetimeString } = require("./support");
 const { locationSchema } = require("./support/schemas");
 
 describe("H-E-B", () => {
-  it("should output valid data", async () => {
+  it.nock("should output valid data", { ignoreQuery: ["v"] }, async () => {
     const result = await checkAvailability(() => {}, { states: "TX" });
     expect(result).toContainItemsMatchingSchema(locationSchema);
   });

--- a/loader/test/server.test.js
+++ b/loader/test/server.test.js
@@ -1,10 +1,18 @@
 const got = require("got");
+const nock = require("nock");
 const { runServer } = require("../src/server");
 
 describe("Server", () => {
   let server;
 
+  beforeEach(async () => {
+    nock.enableNetConnect("localhost");
+  });
+
   afterEach((done) => {
+    nock.cleanAll();
+    nock.enableNetConnect();
+
     if (server) server.close(done);
     else done();
   });

--- a/loader/test/support/nock-back-plugin.js
+++ b/loader/test/support/nock-back-plugin.js
@@ -2,6 +2,7 @@ const nock = require("nock");
 const path = require("path");
 
 const DEFAULT_NOCKBACK_PATH = path.join(__dirname, "..", "fixtures", "nock");
+const USER_NOCKBACK_MODE = process.env.NOCK_BACK_MODE;
 const JEST_TEST_FUNCTIONS = ["test", "it", "fit", "xit"];
 
 /**
@@ -70,9 +71,13 @@ function withNockBack(options, testFunction) {
     options = {};
   }
 
+  // Set the mode to "record" unless explicitly specified otherwise and reset
+  // it when the test is done. Having the user explicitly set the mode to
+  // "record" can cause other non-nock.back tests that use normal, non-recorded
+  // Nock mocks to behave incorrectly, so this is the next best thing.
   const originalMode = nock.back.currentMode;
   setupNockBack();
-  nock.back.setMode("record");
+  nock.back.setMode(USER_NOCKBACK_MODE || "record");
 
   return async () => {
     const name = expect.getState().currentTestName;


### PR DESCRIPTION
This makes sure Nock cannot connect to live servers and make new recordings during tests in CI, effectively ensuring that all HTTP requests in tests either:

1. Have saved recordings to use,
2. Have explicit mocks in code, or
3. Are explicitly allowed by test code.

Fixes https://github.com/usdigitalresponse/univaf/issues/454.