### PR TITLE
Support a new generic vaccine name in Prepmod

### DIFF
--- a/loader/src/sources/prepmod/index.js
+++ b/loader/src/sources/prepmod/index.js
@@ -186,7 +186,17 @@ function formatLocationBookingUrl(host, location) {
 // - Adenovirus vaccines (This one has a narrower definition to make sure we
 //   are only matching vaccines against adenovirus, not ones that might be using
 //   modified adenovirus as a vaccine against COVID or other things.)
-const nonCovidProductName = /^influenza|flu|zoster|^\s*adenovirus\s*$/i;
+const raw = String.raw;
+const nonCovidProductName = new RegExp(
+  [
+    raw`^influenza`,
+    raw`flu`,
+    raw`zoster`,
+    raw`^\s*adenovirus\s*$`,
+    raw`^child and adolescent immunization`,
+  ].join("|"),
+  "i"
+);
 
 /**
  * Parse useful data about a schedule.

--- a/loader/test/prepmod.test.js
+++ b/loader/test/prepmod.test.js
@@ -709,6 +709,32 @@ describe("PrepMod API", () => {
     expect(result).toBeNull();
   });
 
+  it("does not include generic immunizations", async () => {
+    const testLocation = createSmartLocation({
+      schedules: [
+        {
+          extension: [
+            {
+              url: EXTENSIONS.PRODUCT,
+              valueCoding: {
+                system: "http://hl7.org/fhir/sid/cvx",
+                code: null,
+                display: "Child and Adolescent Immunization(s)",
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = formatLocation(
+      "https://myhealth.alaska.gov",
+      new Date(),
+      testLocation
+    );
+    expect(result).toBeNull();
+  });
+
   it("hides locations not in the API response when --hide-missing-locations is set", async () => {
     const testLocation = createSmartLocation({ id: "abc123" });
     // A UNIVAF-formatted location that matches the above SMART SL data.


### PR DESCRIPTION
We are now seeing vaccines named "Child and Adolescent Immunization(s)" in Prepmod, and this adds support for that. Fixes https://sentry.io/organizations/usdr/issues/3206105433