### PR TITLE
Handle Bartell stores showing up in Rite Aid APIs

### DIFF
--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -347,7 +347,7 @@ function getStoreExternalIds(location) {
           ? idValue
           : [[definition.system, idValue]];
       }
-      return [];
+      break;
     }
   }
 

--- a/loader/src/sources/riteaid/api.js
+++ b/loader/src/sources/riteaid/api.js
@@ -13,7 +13,7 @@ const {
   assertSchema,
   requireAllProperties,
 } = require("../../schema-validation");
-const { RiteAidApiError } = require("./common");
+const { RiteAidApiError, getExternalIds } = require("./common");
 
 const warn = createWarningLogger("Rite Aid API");
 
@@ -205,7 +205,7 @@ function formatStore(provider) {
   return {
     // All API locations are named "Rite Aid", so add the store number.
     name: `Rite Aid #${provider.id}`,
-    external_ids: [["rite_aid", provider.id.toString()]],
+    external_ids: getExternalIds(provider.id),
     provider: "rite_aid",
     location_type: LocationType.pharmacy,
 

--- a/loader/src/sources/riteaid/api.js
+++ b/loader/src/sources/riteaid/api.js
@@ -13,7 +13,11 @@ const {
   assertSchema,
   requireAllProperties,
 } = require("../../schema-validation");
-const { RiteAidApiError, getExternalIds } = require("./common");
+const {
+  RiteAidApiError,
+  getExternalIds,
+  getLocationName,
+} = require("./common");
 
 const warn = createWarningLogger("Rite Aid API");
 
@@ -202,10 +206,11 @@ function formatStore(provider) {
     valid_at = checked_at;
   }
 
+  const external_ids = getExternalIds(provider.id);
+
   return {
-    // All API locations are named "Rite Aid", so add the store number.
-    name: `Rite Aid #${provider.id}`,
-    external_ids: getExternalIds(provider.id),
+    name: getLocationName(external_ids),
+    external_ids,
     provider: "rite_aid",
     location_type: LocationType.pharmacy,
 

--- a/loader/src/sources/riteaid/common.js
+++ b/loader/src/sources/riteaid/common.js
@@ -39,16 +39,20 @@ function getExternalIds(storeNumber) {
  * @returns {string}
  */
 function getLocationName(externalIds) {
-  let riteAidId;
+  let nonBrandName = "Rite Aid";
+
   for (const [system, value] of externalIds) {
-    if (system === "rite_aid") {
-      riteAidId = value;
-    } else if (system === "bartell") {
+    if (system === "bartell") {
       return `Bartell Drugs #${value}`;
+    } else if (system === "rite_aid") {
+      // External IDs can come in any order, and we want to prefer a sub-brand
+      // name over a "Rite Aid" name, so store this as a fallback rather than
+      // returning immediately.
+      nonBrandName = `Rite Aid #${value}`;
     }
   }
 
-  return `Rite Aid #${riteAidId}`;
+  return nonBrandName;
 }
 
 module.exports = { RiteAidApiError, getExternalIds, getLocationName };

--- a/loader/src/sources/riteaid/common.js
+++ b/loader/src/sources/riteaid/common.js
@@ -9,4 +9,26 @@ class RiteAidApiError extends HttpApiError {
   }
 }
 
-module.exports = { RiteAidApiError };
+/**
+ * Get the external IDs for a given Rite Aid store number. Rite Aid has a
+ * number of sub-brands, and sometimes we need external IDs for both the whole
+ * Rite Aid system and for the store's sub-brand. Luckily, the Rite-Aid wide ID
+ * is always "<sub-brand-specific prefix(es)><sub-brand ID>", so we can
+ * determine the sub-brand and sub-brand ID from the Rite Aid ID.
+ * (Per discussion in 2021 with Rite Aid tech team.)
+ *
+ * For example, the Rite Aid ID "06958" is also the Bartell ID "58".
+ *
+ * @param {number|string} storeNumber The Rite Aid store number.
+ * @returns {[string, string][]}
+ */
+function getExternalIds(storeNumber) {
+  const numberString = storeNumber.toString();
+  const result = [["rite_aid", numberString]];
+  if (/69\d\d$/.test(numberString)) {
+    result.push(["bartell", numberString.slice(-2)]);
+  }
+  return result;
+}
+
+module.exports = { RiteAidApiError, getExternalIds };

--- a/loader/src/sources/riteaid/common.js
+++ b/loader/src/sources/riteaid/common.js
@@ -31,4 +31,24 @@ function getExternalIds(storeNumber) {
   return result;
 }
 
-module.exports = { RiteAidApiError, getExternalIds };
+/**
+ * Get a human-friendly name for a Rite Aid location. If the store is part of a
+ * known sub-brand, this uses the sub-brand's name instead of "Rite Aid".
+ *
+ * @param {[string, string][]} externalIds The store's external IDs
+ * @returns {string}
+ */
+function getLocationName(externalIds) {
+  let riteAidId;
+  for (const [system, value] of externalIds) {
+    if (system === "rite_aid") {
+      riteAidId = value;
+    } else if (system === "bartell") {
+      return `Bartell Drugs #${value}`;
+    }
+  }
+
+  return `Rite Aid #${riteAidId}`;
+}
+
+module.exports = { RiteAidApiError, getExternalIds, getLocationName };

--- a/loader/src/sources/riteaid/scraper.js
+++ b/loader/src/sources/riteaid/scraper.js
@@ -20,7 +20,7 @@ const {
   createWarningLogger,
   parseUsPhoneNumber,
 } = require("../../utils");
-const { RiteAidApiError } = require("./common");
+const { RiteAidApiError, getExternalIds } = require("./common");
 const { zipCodesCovering100Miles } = require("./zip-codes");
 
 // Load slot-level data in chunks of this many stores at a time.
@@ -132,8 +132,8 @@ const riteAidLocationSchema = {
   type: "object",
   properties: {
     storeNumber: { type: "integer", minimum: 1 },
-    brand: { enum: ["RITEAID", "UNKNOWN", null] },
-    customDisplayName: { enum: ["UNKNOWN", null] },
+    brand: { enum: ["RITEAID", "BARTELL", "UNKNOWN", null] },
+    customDisplayName: { type: "string", nullable: true },
     address: { type: "string" },
     city: { type: "string" },
     state: { type: "string", pattern: "[A-Z]{2}" },
@@ -212,8 +212,11 @@ function formatLocation(apiData) {
   const isAvailable = slots?.length > 0 || apiData.firstAvailableSlot;
 
   return {
+    // `customDisplayName` looks like something that might apply here, but in
+    // practice it doesn't quite seem useful. Values we've seen are:
+    // null, "UNKNOWN", and "Edmonds" (name of the city the store is in)
     name: `Rite Aid #${apiData.storeNumber}`,
-    external_ids: [["rite_aid", apiData.storeNumber.toString()]],
+    external_ids: getExternalIds(apiData.storeNumber),
     provider: "rite_aid",
     location_type: LocationType.pharmacy,
 

--- a/loader/src/sources/riteaid/scraper.js
+++ b/loader/src/sources/riteaid/scraper.js
@@ -20,7 +20,11 @@ const {
   createWarningLogger,
   parseUsPhoneNumber,
 } = require("../../utils");
-const { RiteAidApiError, getExternalIds } = require("./common");
+const {
+  RiteAidApiError,
+  getExternalIds,
+  getLocationName,
+} = require("./common");
 const { zipCodesCovering100Miles } = require("./zip-codes");
 
 // Load slot-level data in chunks of this many stores at a time.
@@ -211,12 +215,14 @@ function formatLocation(apiData) {
   }
   const isAvailable = slots?.length > 0 || apiData.firstAvailableSlot;
 
+  const external_ids = getExternalIds(apiData.storeNumber);
+
   return {
     // `customDisplayName` looks like something that might apply here, but in
-    // practice it doesn't quite seem useful. Values we've seen are:
+    // practice it doesn't seem useful. Values we've seen are:
     // null, "UNKNOWN", and "Edmonds" (name of the city the store is in)
-    name: `Rite Aid #${apiData.storeNumber}`,
-    external_ids: getExternalIds(apiData.storeNumber),
+    name: getLocationName(external_ids),
+    external_ids,
     provider: "rite_aid",
     location_type: LocationType.pharmacy,
 

--- a/loader/test/cdc.api.test.js
+++ b/loader/test/cdc.api.test.js
@@ -128,6 +128,38 @@ describe("CDC Open Data API", () => {
     ]);
   });
 
+  it("supports Bartell data with multiple external_id systems", () => {
+    const formatted = formatStore(
+      [
+        {
+          provider_location_guid: "fe474d63-41c6-4587-a80b-d8463b8973fa",
+          loc_store_no: "06958",
+          loc_phone: "713-461-2915",
+          loc_name: "The Bartell Drug Co #06958",
+          loc_admin_street1: "3855 Lamar Ave",
+          loc_admin_city: "Paris",
+          loc_admin_state: "TX",
+          loc_admin_zip: "75462",
+          ndc: "59267-1000-01",
+          med_name: "Pfizer-BioNTech, COVID-19 Vaccine, 30 mcg/0.3mL",
+          in_stock: false,
+          supply_level: "0",
+          quantity_last_updated: "2022-01-09",
+          latitude: "33.664697",
+          longitude: "-95.505641",
+          category: "covid",
+        },
+      ],
+      new Date()
+    );
+
+    expect(formatted).toHaveProperty("external_ids", [
+      ["vaccines_gov", "fe474d63-41c6-4587-a80b-d8463b8973fa"],
+      ["bartell", "58"],
+      ["rite_aid", "6958"],
+    ]);
+  });
+
   it("cleans up not-quite-valid URLs", async () => {
     const baseEntry = JSON.parse(await fs.readFile(fixturePath, "utf8"))[0];
     const formatted = formatStore(
@@ -141,5 +173,33 @@ describe("CDC Open Data API", () => {
     );
 
     expect(formatted).toHaveProperty("info_url", "http://www.cvs.com/covid/");
+  });
+
+  it("skips rows for unsupported providers", () => {
+    const formatted = formatStore(
+      [
+        {
+          provider_location_guid: "fe474d63-41c6-4587-a80b-d8463b8973fa",
+          loc_store_no: "06958",
+          loc_phone: "713-461-2915",
+          loc_name: "Some random provider",
+          loc_admin_street1: "3855 Lamar Ave",
+          loc_admin_city: "Paris",
+          loc_admin_state: "TX",
+          loc_admin_zip: "75462",
+          ndc: "59267-1000-01",
+          med_name: "Pfizer-BioNTech, COVID-19 Vaccine, 30 mcg/0.3mL",
+          in_stock: false,
+          supply_level: "0",
+          quantity_last_updated: "2022-01-09",
+          latitude: "33.664697",
+          longitude: "-95.505641",
+          category: "covid",
+        },
+      ],
+      new Date()
+    );
+
+    expect(formatted).toBeFalsy();
   });
 });

--- a/loader/test/riteaid.api.test.js
+++ b/loader/test/riteaid.api.test.js
@@ -255,9 +255,11 @@ describe("Rite Aid Source", () => {
       id: 6958,
     };
 
-    expect(formatStore(rawData)).toHaveProperty("external_ids", [
+    const formatted = formatStore(rawData);
+    expect(formatted).toHaveProperty("external_ids", [
       ["rite_aid", "6958"],
       ["bartell", "58"],
     ]);
+    expect(formatted).toHaveProperty("name", "Bartell Drugs #58");
   });
 });

--- a/loader/test/riteaid.api.test.js
+++ b/loader/test/riteaid.api.test.js
@@ -248,4 +248,16 @@ describe("Rite Aid Source", () => {
       expect.stringContaining("slot count")
     );
   });
+
+  it("includes sub-brand IDs when appropriate", () => {
+    const rawData = {
+      ...createMockApiLocation(),
+      id: 6958,
+    };
+
+    expect(formatStore(rawData)).toHaveProperty("external_ids", [
+      ["rite_aid", "6958"],
+      ["bartell", "58"],
+    ]);
+  });
 });

--- a/loader/test/riteaid.scraper.test.js
+++ b/loader/test/riteaid.scraper.test.js
@@ -357,4 +357,45 @@ describe("Rite Aid Scraper", () => {
       "Something went wrong"
     );
   });
+
+  it("includes sub-brand IDs when appropriate", async () => {
+    nock(API_URL_BASE)
+      .get(API_URL_PATH)
+      .query(true)
+      .reply(200, {
+        Status: "SUCCESS",
+        data: {
+          stores: [
+            {
+              ...basicLocation,
+              storeNumber: 6958,
+              totalSlotCount: 50,
+              firstAvailableSlot: null,
+            },
+          ],
+        },
+      });
+    nock(API_URL_BASE)
+      .get(API_URL_PATH)
+      .query((query) => query.storeNumbers === "6958")
+      .reply(200, {
+        Status: "SUCCESS",
+        data: {
+          stores: [
+            {
+              ...basicLocation,
+              storeNumber: 6958,
+              totalSlotCount: 50,
+              firstAvailableSlot: null,
+            },
+          ],
+        },
+      });
+
+    const result = await checkAvailability(() => {}, { states: "NJ" });
+    expect(result).toHaveProperty("0.external_ids", [
+      ["rite_aid", "6958"],
+      ["bartell", "58"],
+    ]);
+  });
 });

--- a/loader/test/riteaid.scraper.test.js
+++ b/loader/test/riteaid.scraper.test.js
@@ -397,5 +397,6 @@ describe("Rite Aid Scraper", () => {
       ["rite_aid", "6958"],
       ["bartell", "58"],
     ]);
+    expect(result).toHaveProperty("0.name", "Bartell Drugs #58");
   });
 });


### PR DESCRIPTION
In hindsight, I probably should have seen this coming. Rite Aid bought Bartell back in 2020, and it looks like they may be starting to integrate systems — Bartell data is showing up in Rite Aid’s booking website backend, causing our scraper to break. See Sentry issue: https://sentry.io/organizations/usdr/issues/3141140661.

Unfortunately, we already have most Bartells via the CDC’s data portal, and we have them stored with a Bartell-specific ID rather than a Rite Aid-wide ID.

However! We happen to know that Rite Aid’s IDs are in the form `"<brand-based-prefix><brand-based-ID>"`, so we can use this appropriately determine both an ID for both the `rite_aid` and `bartell` external ID systems, and make sure all the right records get merged together. 🎉

The code on the CDC side is a little messy, since it originally supported only one external ID per location, and now we need to support two. I could have done a large refactoring, but opted not to for now.

This will probably need to be followed up with a run of the merge script to fix some locations we’ve previously been identifying as separate based on the Rite Aid API and the CDC open data. For example, these are the same:
- http://getmyvax.org/api/edge/locations/bartell:10
- http://getmyvax.org/api/edge/locations/rite_aid:6910

Fixes https://sentry.io/organizations/usdr/issues/3141140661