### PR TITLE
Make addresses optional in merge script

### DIFF
--- a/server/scripts/merge-locations.js
+++ b/server/scripts/merge-locations.js
@@ -142,7 +142,7 @@ function matchableAddress(text, line = null) {
 }
 
 function getAddressString(location) {
-  return `${location.address_lines.join(", ")}, ${location.city}, ${
+  return `${location.address_lines?.join(", ")}, ${location.city}, ${
     location.state
   } ${location.postal_code}`;
 }


### PR DESCRIPTION
I ran into an issue with an entry that had no address while merging Rite Aid and CDC data as a follow-up to #654. This changes the merge scripts to account for and handle it appropriately.