### PR TITLE
Handle Albertsons locations without adult vaccines

### DIFF
--- a/loader/src/sources/albertsons/index.js
+++ b/loader/src/sources/albertsons/index.js
@@ -296,7 +296,9 @@ async function getData(states) {
 
       const result = Object.assign({}, ...group);
       result.meta = {
-        ...adult.meta,
+        ...unknown?.meta,
+        ...pediatric?.meta,
+        ...adult?.meta,
         booking_url_adult: adult?.booking_url,
         booking_url_pediatric: pediatric?.booking_url,
       };


### PR DESCRIPTION
Fixes the fatal error in https://sentry.io/organizations/usdr/issues/3298819475. The error was intermittent, so I can’t investigate deeper as to whether some other mistake was triggering it, but seeing as we made `adult` an optional value in the next line, I think this was just an oversight.