### PR TITLE
Support "ABS" as an abbreviation for Albertsons

### DIFF
--- a/loader/src/sources/albertsons/index.js
+++ b/loader/src/sources/albertsons/index.js
@@ -87,7 +87,7 @@ const BRANDS = [
     ...BASE_BRAND,
     key: "albertsons",
     name: "Albertsons",
-    pattern: /Albertsons/i,
+    pattern: /Albertsons|\bABS\s/i,
   },
   {
     ...BASE_BRAND,


### PR DESCRIPTION
It looks like whoever is listing vaccine appointments for Albertsons is now using "ABS" to abbreviate "Albertons Pharmacy" for a lot of locations. Fixes https://sentry.io/organizations/usdr/issues/2809052505.