### PR TITLE
Use more detailed pattern for United Supermarkets

### DIFF
--- a/loader/src/sources/albertsons/index.js
+++ b/loader/src/sources/albertsons/index.js
@@ -184,7 +184,9 @@ const BRANDS = [
     ...BASE_BRAND,
     key: "united",
     name: "United Supermarkets",
-    pattern: /United/i,
+    // "United" is really common in other names, so we need to a more complex
+    // pattern than most other stores.
+    pattern: /United (#?\d|\w+market)/i,
   },
   {
     ...BASE_BRAND,


### PR DESCRIPTION
Discovered while testing #677. It turns out we have a few community clinics getting classified as United Supermarkets. 😓

Example: `First Tongan United Methodist Church  - 560 El Camino Real, San Bruno, CA, 94066`.