### PR TITLE
Handle new Walmart store name formatting from CDC

### DIFF
--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -202,10 +202,10 @@ function getWalmartId(location) {
     return unpadNumber(location.loc_store_no.slice(3));
   }
 
-  // When the number is not in loc_store_no, it is usually formatted as a normal
-  // store number in the name (i.e. "NNN" instead of "10-NNN").
+  // When the number is not in loc_store_no, it may be formatted like above
+  // (10-NNN) or without the "10-" prefix.
   const numberInName = location.loc_name.match(
-    /^(?:Walmart|Sam['\u2019]?s Club) .* #?(\d+)$/i
+    /^(?:Walmart|Sam['\u2019]?s Club) [^#\d]*#?(?:10-)?(\d+)$/i
   );
   if (numberInName) {
     return unpadNumber(numberInName[1]);
@@ -214,6 +214,7 @@ function getWalmartId(location) {
   warn("Unexpected Walmart/Sams ID format", {
     id: location.provider_location_guid,
     storeNumber: location.loc_store_no,
+    storeName: location.loc_name,
   });
   return null;
 }

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -166,7 +166,7 @@ function formatStore(storeItems, checkedAt) {
         longitude: Number(base.longitude),
         latitude: Number(base.latitude),
       };
-      if (isNaN(position.longitude) || isNaN(position.longitude)) {
+      if (isNaN(position.longitude) || isNaN(position.latitude)) {
         error("longitude and latitude are not numbers");
       } else {
         result.position = position;

--- a/loader/test/cdc.api.test.js
+++ b/loader/test/cdc.api.test.js
@@ -128,6 +128,37 @@ describe("CDC Open Data API", () => {
     ]);
   });
 
+  it("supports Walmart data with no `loc_store_no` and `10-` prefix", () => {
+    const formatted = formatStore(
+      [
+        {
+          provider_location_guid: "fe474d63-41c6-4587-a80b-d8463b8973fa",
+          loc_store_no: "Not applicable",
+          loc_phone: "713-461-2915",
+          loc_name: "Walmart Pharmacy 10-0148",
+          loc_admin_street1: "3855 Lamar Ave",
+          loc_admin_city: "Paris",
+          loc_admin_state: "TX",
+          loc_admin_zip: "75462",
+          ndc: "59267-1000-01",
+          med_name: "Pfizer-BioNTech, COVID-19 Vaccine, 30 mcg/0.3mL",
+          in_stock: false,
+          supply_level: "0",
+          quantity_last_updated: "2022-01-09",
+          latitude: "33.664697",
+          longitude: "-95.505641",
+          category: "covid",
+        },
+      ],
+      new Date()
+    );
+
+    expect(formatted).toHaveProperty("external_ids", [
+      ["vaccines_gov", "fe474d63-41c6-4587-a80b-d8463b8973fa"],
+      ["walmart", "148"],
+    ]);
+  });
+
   it("supports Bartell data with multiple external_id systems", () => {
     const formatted = formatStore(
       [


### PR DESCRIPTION
When Walmart stores had a store number in the name (instead of in the store number field), they used to be formatted as "Walmart NNN" (where N is a digit). Some are now appearing with a "10-" prefix, e.g. "Walmart 10-0178" (the same format as in the store number field). This alters our parser to handle both.

Fixes https://sentry.io/organizations/usdr/issues/3338103303.

I also fixed a geographic position validation bug I noticed while I was addressing the above issue.