### PR TITLE
Support new `00069-2025-*` NDC codes

### DIFF
--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -427,6 +427,13 @@ const ndcLookup = {
   [normalizeNdc("00069-1000-01")]: VaccineProduct.pfizer, // use
   [normalizeNdc("00069-1000-02")]: VaccineProduct.pfizer, // sale
   [normalizeNdc("00069-1000-03")]: VaccineProduct.pfizer, // sale
+  // 00069-2025 *appears* to have replaced the 00069-1000 codes for "Comirnaty"
+  // branding. (We never saw the old ones used in practice. They are still
+  // listed on the CDC's COVID-19 codes page, but not on CDC's complete
+  // crosswalk of all vaccine codes, where these new ones are listed.)
+  [normalizeNdc("00069-2025-01")]: VaccineProduct.pfizer, // use
+  [normalizeNdc("00069-2025-10")]: VaccineProduct.pfizer, // sale
+  [normalizeNdc("00069-2025-25")]: VaccineProduct.pfizer, // sale
 
   [normalizeNdc("59267-1055-01")]: VaccineProduct.pfizerAge5_11, // use
   [normalizeNdc("59267-1055-02")]: VaccineProduct.pfizerAge5_11, // sale


### PR DESCRIPTION
New `00069-2025-*` NDC codes started showing up in CDC's data today. They aren't (yet?) listed on CDC's COVID-19 codes page, but are listed on the complete crosswalk of all vaccines. These are for Comirnaty (the sales name for Pfizer's vaccine), so appear to effectively replace the `00069-1000-*` codes.

(More technically: `0069-1000-*` was for a version of the vaccine that was licensed but never manufactured, and we don’t appear to have ever seen it used in practice. `00069-2025-*` is a the newer tris-sucrose formulation of the same vaccine, which appears to finally be getting manufactured and sold now.)

Fixes https://sentry.io/organizations/usdr/issues/3342633674