### PR TITLE
Split metadata from address on last ` - `

### DIFF
--- a/loader/src/sources/albertsons/index.js
+++ b/loader/src/sources/albertsons/index.js
@@ -409,11 +409,12 @@ function parseNameAndAddress(text) {
     }
   }
 
-  const partMatch = body.match(addressFieldParts);
-  if (!partMatch) {
+  const splitPosition = body.lastIndexOf(" - ");
+  if (splitPosition === -1) {
     throw new ParseError(`Could not separate name and address in "${body}"`);
   }
-  let { name, address } = partMatch.groups;
+  let name = body.slice(0, splitPosition).trim();
+  const address = body.slice(splitPosition + 3).trim();
 
   // Most store names are in the form "<Brand Name> NNNN", e.g. "Safeway 3189".
   // Sometimes names repeat after the store number, e.g. "Safeway 3189 Safeway".


### PR DESCRIPTION
This is a first, quick attempt at improving address parsing in Albertsons. This is a draft PR because it probably needs some testing and reworking.

When we started, the `address` field in Albertsons appointment data looked pretty reliably like:

```
Safeway 0187 - 1539 Whatever Rd, Somewhere, NJ 08022
```

So we split the location name and address on the first dash with a regular expression. These days, more and more data, often dash-separated, has been stuffed into the `address` field, and we often wind up with other metadata in the address when we parse this way. Here are some real example addresses now:

```
Albertsons 4406 - Pediatric Vaccine Clinic  - Albertsons - 11330 N W 51st Ave, Gig Harbor, WA, 98332
Pfizer 5 - 11 year old Pediatric/Child Vaccine at Kingstowne Safeway - 5980 Kingstowne Center, Alexandria, VA, 22315
```

These obviously do not parse well with the previous approach, and can lead to less accurate matching against known store data and to messy location names.