### PR TITLE
Route 53 CNAME records must have a TTL

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -63,6 +63,7 @@ resource "aws_route53_record" "api_www_domain_record" {
   name    = "www"
   type    = "CNAME"
   records = [var.domain_name]
+  ttl     = 300
 }
 
 module "api_task" {


### PR DESCRIPTION
This is a follow-on to #665, which failed to deploy because of this.