### PR TITLE
HOTFIX: Don't redirect healthcheck to primary host

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -58,7 +58,7 @@ app.use(cors());
 app.use(authorizeRequest);
 app.use(urlDecodeSpecialPathChars);
 
-// Check/Test Routes ---------------------------------------------
+// Diagnostic Routes ---------------------------------------------
 
 app.get("/health", (req: Request, res: Response) => {
   // TODO: include the db status before declaring ourselves "up"

--- a/server/test/app.test.ts
+++ b/server/test/app.test.ts
@@ -12,15 +12,15 @@ describe("server application", () => {
 
   it("redirects requests to PRIMARY_HOST", async () => {
     process.env.PRIMARY_HOST = "test.primary.host";
-    const response = await context.client.get<any>("health", {
+    const response = await context.client.get<any>("docs/", {
       followRedirect: false,
       responseType: "text",
     } as any);
-    expect(response.headers.location).toBe("http://test.primary.host/health");
+    expect(response.headers.location).toBe("http://test.primary.host/docs/");
   });
 
   it("does not redirect requests if PRIMARY_HOST is not set", async () => {
-    const response = await context.client.get<any>("health", {
+    const response = await context.client.get<any>("docs/", {
       followRedirect: false,
       responseType: "text",
     } as any);


### PR DESCRIPTION
It turns out a redirect on the healthcheck endpoint is a failure, since it's not a 200 status code. Without this fix, ECS won't deploy our code, since it thinks the server is failing to run. :(

While I was at it, I also moved DataDog earlier in the stack, so we track errors that happen in middleware.