### PR TITLE
Don't run CI jobs for terraform/docs only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 on:
-  pull_request: {}
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "terraform/**"
   push:
     branches:
       - main


### PR DESCRIPTION
We already did this for regular pushes, and it makes sense for PRs, too.