### PR TITLE
Forward the Host header from Cloudfront

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -214,6 +214,7 @@ resource "aws_cloudfront_distribution" "univaf_api" {
     max_ttl                = 3600
 
     forwarded_values {
+      headers = ["Host", "Origin"]
       query_string = true
 
       cookies {


### PR DESCRIPTION
Part of the problem in #706 is that the `Host` header is not getting forwarded by Cloudfront. This should solve that, although I suspect there might be some ELB rejiggering needed afterwards.