### PR TITLE
Implement `www.` → no subdomain redirect in ELB

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -37,6 +37,25 @@ resource "aws_alb_listener" "front_end" {
   }
 }
 
+resource "aws_alb_listener_rule" "redirect_www" {
+  listener_arn = aws_alb_listener.front_end.arn
+
+  condition {
+    host_header {
+      values = ["www.${var.domain_name}"]
+    }
+  }
+
+  action {
+    type = "redirect"
+
+    redirect {
+      host        = var.domain_name
+      status_code = "HTTP_301"
+    }
+  }
+}
+
 # Add DNS (optional)
 data "aws_route53_zone" "domain_zone" {
   count = var.domain_name != "" ? 1 : 0


### PR DESCRIPTION
I thought I'd looked for a way to do this before and didn't see it, but while dealing with issues in the earlier approach, I found this. Hopefully this (plus #708, which this depends on) solves #302 in pretty much the ideal way.

If this works out, there’ll be some cleanup to do from the earlier approach.