### PR TITLE
Support H-E-B's new `Ultra_Pediatric_Pfizer` code

### DIFF
--- a/loader/src/sources/heb/index.js
+++ b/loader/src/sources/heb/index.js
@@ -24,6 +24,7 @@ const PRODUCT_NAMES = {
   moderna: VaccineProduct.moderna,
   janssen: VaccineProduct.janssen,
   pediatric_pfizer: VaccineProduct.pfizerAge5_11,
+  ultra_pediatric_pfizer: VaccineProduct.pfizerAge0_4,
 };
 
 async function fetchRawData() {

--- a/loader/test/fixtures/nock/h-e-b_should_output_valid_data.json
+++ b/loader/test/fixtures/nock/h-e-b_should_output_valid_data.json
@@ -2,23 +2,39 @@
     {
         "scope": "https://heb-ecom-covid-vaccine.hebdigital-prd.com:443",
         "method": "GET",
-        "path": "/vaccine_locations.json?v=853979742455.3682",
+        "path": "/vaccine_locations.json?v=417656911761.3762",
         "body": "",
         "status": 200,
         "response": {
             "locations": [
                 {
                     "zip": "78664-4677",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudGQAS",
                     "type": "store",
                     "street": "1700 EAST PALM VALLEY BLVD",
                     "storeNumber": 591,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 68,
+                            "openAppointmentSlots": 68,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 103,
+                            "openAppointmentSlots": 103,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 88,
+                            "openAppointmentSlots": 88,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 259,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 259,
                     "name": "Round Rock H-E-B plus!",
                     "longitude": -97.65978,
                     "latitude": 30.5177,
@@ -27,16 +43,32 @@
                 },
                 {
                     "zip": "76574-7059",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudIQAS",
                     "type": "store",
                     "street": "100 N.W.CARLOS G.PARKER BL#101",
                     "storeNumber": 593,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 100,
+                            "openAppointmentSlots": 100,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 58,
+                            "openAppointmentSlots": 58,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 208,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 208,
                     "name": "Taylor H-E-B",
                     "longitude": -97.4167,
                     "latitude": 30.6007,
@@ -45,27 +77,16 @@
                 },
                 {
                     "zip": "78654-4902",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueXQAS",
+                    "url": null,
                     "type": "store",
                     "street": "1503 FM 1431",
                     "storeNumber": 735,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 14,
-                            "openAppointmentSlots": 14,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 22,
-                            "openAppointmentSlots": 22,
-                            "manufacturer": "Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 36,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 36,
+                    "openAppointmentSlots": 0,
                     "name": "Marble Falls H-E-B",
                     "longitude": -98.27972,
                     "latitude": 30.58301,
@@ -81,20 +102,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 79,
-                            "openAppointmentSlots": 79,
+                            "openTimeslots": 124,
+                            "openAppointmentSlots": 124,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 62,
-                            "openAppointmentSlots": 62,
+                            "openTimeslots": 56,
+                            "openAppointmentSlots": 56,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 141,
+                    "openTimeslots": 180,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 141,
+                    "openAppointmentSlots": 180,
                     "name": "Wells Branch H-E-B",
                     "longitude": -97.66419,
                     "latitude": 30.44263,
@@ -110,20 +131,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
+                            "openTimeslots": 23,
+                            "openAppointmentSlots": 23,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 11,
-                            "openAppointmentSlots": 11,
+                            "openTimeslots": 19,
+                            "openAppointmentSlots": 19,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 21,
+                    "openTimeslots": 42,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 21,
+                    "openAppointmentSlots": 42,
                     "name": "Louis Henna Blvd H-E-B",
                     "longitude": -97.65938,
                     "latitude": 30.48179,
@@ -131,7 +152,7 @@
                     "city": "ROUND ROCK"
                 },
                 {
-                    "zip": "78641-0",
+                    "zip": "78628-0",
                     "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h6P0000004CWMQA2",
                     "type": "store",
                     "street": "19348 RONALD W.REAGAN BLVD",
@@ -139,30 +160,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 49,
-                            "openAppointmentSlots": 49,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 42,
-                            "openAppointmentSlots": 42,
+                            "openTimeslots": 115,
+                            "openAppointmentSlots": 115,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 20,
-                            "openAppointmentSlots": 20,
+                            "openTimeslots": 87,
+                            "openAppointmentSlots": 87,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 111,
+                    "openTimeslots": 202,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 111,
+                    "openAppointmentSlots": 202,
                     "name": "H-E-B at Ronald Reagan Blvd",
                     "longitude": -97.82446,
                     "latitude": 30.63307,
                     "fluUrl": "",
-                    "city": "LEANDER"
+                    "city": "GEORGETOWN"
                 },
                 {
                     "zip": "77598-0",
@@ -173,64 +189,43 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 185,
-                            "openAppointmentSlots": 185,
+                            "openTimeslots": 105,
+                            "openAppointmentSlots": 105,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 208,
-                            "openAppointmentSlots": 208,
+                            "openTimeslots": 105,
+                            "openAppointmentSlots": 105,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 210,
-                            "openAppointmentSlots": 210,
+                            "openTimeslots": 105,
+                            "openAppointmentSlots": 105,
                             "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 210,
-                            "openAppointmentSlots": 210,
-                            "manufacturer": "Other"
                         }
                     ],
-                    "openTimeslots": 603,
-                    "openFluTimeslots": 210,
-                    "openFluAppointmentSlots": 210,
-                    "openAppointmentSlots": 603,
+                    "openTimeslots": 315,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 315,
                     "name": "El Dorado H-E-B",
                     "longitude": -95.14874,
                     "latitude": 29.55117,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h6P0000004ChkQAE",
+                    "fluUrl": "",
                     "city": "WEBSTER"
                 },
                 {
                     "zip": "78045-2802",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucLQAS",
+                    "url": null,
                     "type": "store",
                     "street": "7811 MCPHERSON RD.",
                     "storeNumber": 449,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 14,
-                            "openAppointmentSlots": 14,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 15,
-                            "openAppointmentSlots": 15,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
-                            "manufacturer": "Pediatric_Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 39,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 39,
+                    "openAppointmentSlots": 0,
                     "name": "McPherson Rd H-E-B",
                     "longitude": -99.4733,
                     "latitude": 27.5754,
@@ -239,16 +234,27 @@
                 },
                 {
                     "zip": "78355-4365",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gub8QAC",
                     "type": "store",
                     "street": "700 S SAINT MARYS ST",
                     "storeNumber": 200,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 70,
+                            "openAppointmentSlots": 70,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 30,
+                            "openAppointmentSlots": 30,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 100,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 100,
                     "name": "Falfurrias H-E-B",
                     "longitude": -98.14572,
                     "latitude": 27.22043,
@@ -264,25 +270,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 65,
-                            "openAppointmentSlots": 65,
+                            "openTimeslots": 39,
+                            "openAppointmentSlots": 39,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 37,
-                            "openAppointmentSlots": 37,
+                            "openTimeslots": 15,
+                            "openAppointmentSlots": 15,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 20,
-                            "openAppointmentSlots": 20,
+                            "openTimeslots": 19,
+                            "openAppointmentSlots": 19,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 122,
+                    "openTimeslots": 73,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 122,
+                    "openAppointmentSlots": 73,
                     "name": "Burnet Rd H-E-B",
                     "longitude": -97.74016,
                     "latitude": 30.33374,
@@ -291,32 +297,16 @@
                 },
                 {
                     "zip": "78237-3134",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubAQAS",
+                    "url": null,
                     "type": "store",
                     "street": "721 CASTROVILLE RD",
                     "storeNumber": 205,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 159,
-                            "openAppointmentSlots": 159,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 167,
-                            "openAppointmentSlots": 167,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 139,
-                            "openAppointmentSlots": 139,
-                            "manufacturer": "Pediatric_Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 465,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 465,
+                    "openAppointmentSlots": 0,
                     "name": "Las Palmas H-E-B",
                     "longitude": -98.55132,
                     "latitude": 29.41734,
@@ -332,13 +322,8 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 16,
-                            "openAppointmentSlots": 16,
-                            "manufacturer": "Other"
-                        },
-                        {
-                            "openTimeslots": 7,
-                            "openAppointmentSlots": 7,
+                            "openTimeslots": 12,
+                            "openAppointmentSlots": 12,
                             "manufacturer": "Moderna"
                         },
                         {
@@ -352,14 +337,14 @@
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 29,
-                    "openFluTimeslots": 16,
-                    "openFluAppointmentSlots": 16,
-                    "openAppointmentSlots": 29,
+                    "openTimeslots": 34,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 34,
                     "name": "Guadalupe and Stone H-E-B",
                     "longitude": -99.48344,
                     "latitude": 27.50656,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF18QAE",
+                    "fluUrl": "",
                     "city": "LAREDO"
                 },
                 {
@@ -425,20 +410,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 149,
-                            "openAppointmentSlots": 149,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 171,
+                            "openAppointmentSlots": 171,
+                            "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 30,
-                            "openAppointmentSlots": 30,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 172,
+                            "openAppointmentSlots": 172,
+                            "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 179,
+                    "openTimeslots": 343,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 179,
+                    "openAppointmentSlots": 343,
                     "name": "Parmer and Mopac H-E-B",
                     "longitude": -97.70326,
                     "latitude": 30.41883,
@@ -454,30 +439,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 62,
-                            "openAppointmentSlots": 62,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 126,
-                            "openAppointmentSlots": 126,
+                            "openTimeslots": 95,
+                            "openAppointmentSlots": 95,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 130,
-                            "openAppointmentSlots": 130,
+                            "openTimeslots": 89,
+                            "openAppointmentSlots": 89,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 130,
-                            "openAppointmentSlots": 130,
+                            "openTimeslots": 90,
+                            "openAppointmentSlots": 90,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 448,
+                    "openTimeslots": 274,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 448,
+                    "openAppointmentSlots": 274,
                     "name": "Pleasanton H-E-B",
                     "longitude": -98.48567,
                     "latitude": 28.95696,
@@ -486,16 +466,22 @@
                 },
                 {
                     "zip": "78102-5613",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubzQAC",
                     "type": "store",
                     "street": "100 EAST HOUSTON ST.",
                     "storeNumber": 412,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 159,
+                            "openAppointmentSlots": 159,
+                            "manufacturer": "Moderna"
+                        }
+                    ],
+                    "openTimeslots": 159,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 159,
                     "name": "Beeville H-E-B",
                     "longitude": -97.74667,
                     "latitude": 28.40071,
@@ -504,16 +490,32 @@
                 },
                 {
                     "zip": "78404-2505",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Guc0QAC",
                     "type": "store",
                     "street": "3133 S. ALAMEDA",
                     "storeNumber": 413,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 8,
+                            "openAppointmentSlots": 8,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 2,
+                            "openAppointmentSlots": 2,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 8,
+                            "openAppointmentSlots": 8,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 18,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 18,
                     "name": "Alameda / Texan Trail (Medical District)",
                     "longitude": -97.3912,
                     "latitude": 27.75745,
@@ -529,34 +531,29 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 60,
-                            "openAppointmentSlots": 60,
-                            "manufacturer": "Other"
-                        },
-                        {
-                            "openTimeslots": 93,
-                            "openAppointmentSlots": 93,
+                            "openTimeslots": 195,
+                            "openAppointmentSlots": 195,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 69,
-                            "openAppointmentSlots": 69,
+                            "openTimeslots": 129,
+                            "openAppointmentSlots": 129,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 70,
-                            "openAppointmentSlots": 70,
+                            "openTimeslots": 129,
+                            "openAppointmentSlots": 129,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 232,
-                    "openFluTimeslots": 60,
-                    "openFluAppointmentSlots": 60,
-                    "openAppointmentSlots": 232,
+                    "openTimeslots": 453,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 453,
                     "name": "Brenham H-E-B",
                     "longitude": -96.39591,
                     "latitude": 30.14381,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2XQAU",
+                    "fluUrl": "",
                     "city": "BRENHAM"
                 },
                 {
@@ -586,25 +583,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
+                            "openTimeslots": 90,
+                            "openAppointmentSlots": 90,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
+                            "openTimeslots": 135,
+                            "openAppointmentSlots": 135,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
+                            "openTimeslots": 90,
+                            "openAppointmentSlots": 90,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 150,
+                    "openTimeslots": 315,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 150,
+                    "openAppointmentSlots": 315,
                     "name": "La Grange H-E-B",
                     "longitude": -96.87264,
                     "latitude": 29.9073,
@@ -620,25 +617,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 11,
-                            "openAppointmentSlots": 11,
+                            "openTimeslots": 17,
+                            "openAppointmentSlots": 17,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 2,
-                            "openAppointmentSlots": 2,
+                            "openTimeslots": 10,
+                            "openAppointmentSlots": 10,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 11,
-                            "openAppointmentSlots": 11,
+                            "openTimeslots": 15,
+                            "openAppointmentSlots": 15,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 24,
+                    "openTimeslots": 42,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 24,
+                    "openAppointmentSlots": 42,
                     "name": "Avenue F and Gibbs H-E-B",
                     "longitude": -100.8998,
                     "latitude": 29.36632,
@@ -647,32 +644,16 @@
                 },
                 {
                     "zip": "78852-4718",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Guc5QAC",
+                    "url": null,
                     "type": "store",
                     "street": "2135 E. MAIN",
                     "storeNumber": 419,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 18,
-                            "openAppointmentSlots": 18,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 1,
-                            "openAppointmentSlots": 1,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 23,
-                            "openAppointmentSlots": 23,
-                            "manufacturer": "Pediatric_Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 42,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 42,
+                    "openAppointmentSlots": 0,
                     "name": "Eagle Pass H-E-B",
                     "longitude": -100.48583,
                     "latitude": 28.70894,
@@ -742,30 +723,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 24,
-                            "openAppointmentSlots": 24,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 115,
-                            "openAppointmentSlots": 115,
+                            "openTimeslots": 167,
+                            "openAppointmentSlots": 167,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 98,
-                            "openAppointmentSlots": 98,
+                            "openTimeslots": 166,
+                            "openAppointmentSlots": 166,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 30,
-                            "openAppointmentSlots": 30,
+                            "openTimeslots": 58,
+                            "openAppointmentSlots": 58,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 267,
+                    "openTimeslots": 391,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 267,
+                    "openAppointmentSlots": 391,
                     "name": "Hancock Center H-E-B",
                     "longitude": -97.71973,
                     "latitude": 30.30057,
@@ -781,23 +757,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 47,
-                            "openAppointmentSlots": 47,
+                            "openTimeslots": 48,
+                            "openAppointmentSlots": 48,
                             "manufacturer": "Janssen"
                         },
                         {
-                            "openTimeslots": 80,
-                            "openAppointmentSlots": 80,
+                            "openTimeslots": 74,
+                            "openAppointmentSlots": 74,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 93,
-                            "openAppointmentSlots": 93,
+                            "openTimeslots": 89,
+                            "openAppointmentSlots": 89,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 49,
-                            "openAppointmentSlots": 49,
+                            "openTimeslots": 58,
+                            "openAppointmentSlots": 58,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
@@ -820,48 +796,54 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 93,
-                            "openAppointmentSlots": 93,
-                            "manufacturer": "Other"
-                        },
-                        {
-                            "openTimeslots": 80,
-                            "openAppointmentSlots": 80,
+                            "openTimeslots": 16,
+                            "openAppointmentSlots": 16,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 62,
-                            "openAppointmentSlots": 62,
+                            "openTimeslots": 4,
+                            "openAppointmentSlots": 4,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 36,
-                            "openAppointmentSlots": 36,
+                            "openTimeslots": 8,
+                            "openAppointmentSlots": 8,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 178,
-                    "openFluTimeslots": 93,
-                    "openFluAppointmentSlots": 93,
-                    "openAppointmentSlots": 178,
+                    "openTimeslots": 28,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 28,
                     "name": "Military and Pleasanton H-E-B",
                     "longitude": -98.50277,
                     "latitude": 29.35666,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2hQAE",
+                    "fluUrl": "",
                     "city": "SAN ANTONIO"
                 },
                 {
                     "zip": "78213-1343",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gub7QAC",
                     "type": "store",
                     "street": "11551 WEST AVE.",
                     "storeNumber": 195,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 145,
+                            "openAppointmentSlots": 145,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 148,
+                            "openAppointmentSlots": 148,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 293,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 293,
                     "name": "Blanco and West Ave H-E-B",
                     "longitude": -98.51025,
                     "latitude": 29.54526,
@@ -877,39 +859,29 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 3,
-                            "openAppointmentSlots": 3,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 134,
-                            "openAppointmentSlots": 134,
+                            "openTimeslots": 181,
+                            "openAppointmentSlots": 181,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 139,
-                            "openAppointmentSlots": 139,
+                            "openTimeslots": 182,
+                            "openAppointmentSlots": 182,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 141,
-                            "openAppointmentSlots": 141,
+                            "openTimeslots": 182,
+                            "openAppointmentSlots": 182,
                             "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 140,
-                            "openAppointmentSlots": 140,
-                            "manufacturer": "Other"
                         }
                     ],
-                    "openTimeslots": 417,
-                    "openFluTimeslots": 140,
-                    "openFluAppointmentSlots": 140,
-                    "openAppointmentSlots": 417,
+                    "openTimeslots": 545,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 545,
                     "name": "Pflugerville H-E-B",
                     "longitude": -97.6133,
                     "latitude": 30.4373,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF34QAE",
+                    "fluUrl": "",
                     "city": "PFLUGERVILLE"
                 },
                 {
@@ -921,25 +893,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 150,
-                            "openAppointmentSlots": 150,
+                            "openTimeslots": 90,
+                            "openAppointmentSlots": 90,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 146,
-                            "openAppointmentSlots": 146,
+                            "openTimeslots": 87,
+                            "openAppointmentSlots": 87,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
+                            "openTimeslots": 45,
+                            "openAppointmentSlots": 45,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 346,
+                    "openTimeslots": 222,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 346,
+                    "openAppointmentSlots": 222,
                     "name": "I10 and Wurzbach H-E-B",
                     "longitude": -98.5595,
                     "latitude": 29.5336,
@@ -1009,34 +981,29 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 69,
-                            "openAppointmentSlots": 69,
+                            "openTimeslots": 18,
+                            "openAppointmentSlots": 18,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 132,
-                            "openAppointmentSlots": 132,
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 64,
-                            "openAppointmentSlots": 64,
+                            "openTimeslots": 24,
+                            "openAppointmentSlots": 24,
                             "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 1242,
-                            "openAppointmentSlots": 1242,
-                            "manufacturer": "Other"
                         }
                     ],
-                    "openTimeslots": 265,
-                    "openFluTimeslots": 1242,
-                    "openFluAppointmentSlots": 1242,
-                    "openAppointmentSlots": 265,
+                    "openTimeslots": 62,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 62,
                     "name": "Valley Hi H-E-B",
                     "longitude": -98.64021,
                     "latitude": 29.38099,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF59QAE",
+                    "fluUrl": "",
                     "city": "SAN ANTONIO"
                 },
                 {
@@ -1066,48 +1033,54 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 36,
-                            "openAppointmentSlots": 36,
+                            "openTimeslots": 79,
+                            "openAppointmentSlots": 79,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 85,
-                            "openAppointmentSlots": 85,
+                            "openTimeslots": 99,
+                            "openAppointmentSlots": 99,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 18,
-                            "openAppointmentSlots": 18,
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
                             "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 228,
-                            "openAppointmentSlots": 228,
-                            "manufacturer": "Other"
                         }
                     ],
-                    "openTimeslots": 139,
-                    "openFluTimeslots": 228,
-                    "openFluAppointmentSlots": 228,
-                    "openAppointmentSlots": 139,
+                    "openTimeslots": 228,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 228,
                     "name": "Creekside Park H-E-B",
                     "longitude": -95.55072,
                     "latitude": 30.14362,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF5BQAU",
+                    "fluUrl": "",
                     "city": "TOMBALL"
                 },
                 {
                     "zip": "77057-3061",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gue1QAC",
                     "type": "store",
                     "street": "5895 SAN FELIPE STREET",
                     "storeNumber": 687,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 100,
+                            "openAppointmentSlots": 100,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 82,
+                            "openAppointmentSlots": 82,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 182,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 182,
                     "name": "San Felipe H-E-B",
                     "longitude": -95.48512,
                     "latitude": 29.74797,
@@ -1116,16 +1089,27 @@
                 },
                 {
                     "zip": "78332-5046",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubGQAS",
                     "type": "store",
                     "street": "1115 E. MAIN",
                     "storeNumber": 223,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 53,
+                            "openAppointmentSlots": 53,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 87,
+                            "openAppointmentSlots": 87,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 140,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 140,
                     "name": "Alice H-E-B",
                     "longitude": -98.06425,
                     "latitude": 27.75141,
@@ -1141,25 +1125,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 147,
-                            "openAppointmentSlots": 147,
+                            "openTimeslots": 198,
+                            "openAppointmentSlots": 198,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 153,
-                            "openAppointmentSlots": 153,
+                            "openTimeslots": 208,
+                            "openAppointmentSlots": 208,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 52,
-                            "openAppointmentSlots": 52,
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 352,
+                    "openTimeslots": 456,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 352,
+                    "openAppointmentSlots": 456,
                     "name": "Bandera and Guilbeau H-E-B",
                     "longitude": -98.64364,
                     "latitude": 29.51985,
@@ -1175,13 +1159,13 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 15,
-                            "openAppointmentSlots": 15,
+                            "openTimeslots": 30,
+                            "openAppointmentSlots": 30,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 15,
-                            "openAppointmentSlots": 15,
+                            "openTimeslots": 34,
+                            "openAppointmentSlots": 34,
                             "manufacturer": "Pfizer"
                         },
                         {
@@ -1190,10 +1174,10 @@
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 34,
+                    "openTimeslots": 68,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 34,
+                    "openAppointmentSlots": 68,
                     "name": "Oak Hill H-E-B",
                     "longitude": -97.88755,
                     "latitude": 30.22696,
@@ -1202,16 +1186,22 @@
                 },
                 {
                     "zip": "78611-3201",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucEQAS",
                     "type": "store",
                     "street": "105 S BOUNDARY",
                     "storeNumber": 433,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 622,
+                            "openAppointmentSlots": 622,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 622,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 622,
                     "name": "Burnet H-E-B",
                     "longitude": -98.22452,
                     "latitude": 30.7588,
@@ -1265,11 +1255,6 @@
                         {
                             "openTimeslots": 120,
                             "openAppointmentSlots": 120,
-                            "manufacturer": "Other"
-                        },
-                        {
-                            "openTimeslots": 120,
-                            "openAppointmentSlots": 120,
                             "manufacturer": "Moderna"
                         },
                         {
@@ -1284,13 +1269,13 @@
                         }
                     ],
                     "openTimeslots": 360,
-                    "openFluTimeslots": 120,
-                    "openFluAppointmentSlots": 120,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
                     "openAppointmentSlots": 360,
                     "name": "Military and Goliad H-E-B",
                     "longitude": -98.4362,
                     "latitude": 29.35194,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2nQAE",
+                    "fluUrl": "",
                     "city": "SAN ANTONIO"
                 },
                 {
@@ -1302,20 +1287,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 77,
-                            "openAppointmentSlots": 77,
+                            "openTimeslots": 130,
+                            "openAppointmentSlots": 130,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 79,
-                            "openAppointmentSlots": 79,
+                            "openTimeslots": 130,
+                            "openAppointmentSlots": 130,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 156,
+                    "openTimeslots": 260,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 156,
+                    "openAppointmentSlots": 260,
                     "name": "Lockhart H-E-B",
                     "longitude": -97.66994,
                     "latitude": 29.88213,
@@ -1396,16 +1381,32 @@
                 },
                 {
                     "zip": "77084-5813",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuceQAC",
                     "type": "store",
                     "street": "1550 FRY RD",
                     "storeNumber": 492,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 16,
+                            "openAppointmentSlots": 16,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 18,
+                            "openAppointmentSlots": 18,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 19,
+                            "openAppointmentSlots": 19,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 53,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 53,
                     "name": "Fry Rd and I10 H-E-B",
                     "longitude": -95.7189,
                     "latitude": 29.7898,
@@ -1421,39 +1422,34 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 45,
-                            "openAppointmentSlots": 45,
+                            "openTimeslots": 61,
+                            "openAppointmentSlots": 61,
                             "manufacturer": "Janssen"
                         },
                         {
-                            "openTimeslots": 17,
-                            "openAppointmentSlots": 17,
+                            "openTimeslots": 249,
+                            "openAppointmentSlots": 249,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 259,
-                            "openAppointmentSlots": 259,
+                            "openTimeslots": 649,
+                            "openAppointmentSlots": 649,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 43,
-                            "openAppointmentSlots": 43,
+                            "openTimeslots": 188,
+                            "openAppointmentSlots": 188,
                             "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 259,
-                            "openAppointmentSlots": 259,
-                            "manufacturer": "Other"
                         }
                     ],
-                    "openTimeslots": 364,
-                    "openFluTimeslots": 259,
-                    "openFluAppointmentSlots": 259,
-                    "openAppointmentSlots": 364,
+                    "openTimeslots": 1147,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 1147,
                     "name": "Culebra and 1604 H-E-B",
                     "longitude": -98.70445,
                     "latitude": 29.49292,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3BQAU",
+                    "fluUrl": "",
                     "city": "SAN ANTONIO"
                 },
                 {
@@ -1465,24 +1461,34 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 119,
-                            "openAppointmentSlots": 119,
+                            "openTimeslots": 37,
+                            "openAppointmentSlots": 37,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 35,
+                            "openAppointmentSlots": 35,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 103,
-                            "openAppointmentSlots": 103,
+                            "openTimeslots": 35,
+                            "openAppointmentSlots": 35,
                             "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 36,
+                            "openAppointmentSlots": 36,
+                            "manufacturer": "Other"
                         }
                     ],
-                    "openTimeslots": 222,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 222,
+                    "openTimeslots": 107,
+                    "openFluTimeslots": 36,
+                    "openFluAppointmentSlots": 36,
+                    "openAppointmentSlots": 107,
                     "name": "Beaumont 6 H-E-B",
                     "longitude": -94.12834,
                     "latitude": 30.06853,
-                    "fluUrl": "",
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF0qQAE",
                     "city": "BEAUMONT"
                 },
                 {
@@ -1512,20 +1518,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 78,
-                            "openAppointmentSlots": 78,
+                            "openTimeslots": 42,
+                            "openAppointmentSlots": 42,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 621,
-                            "openAppointmentSlots": 621,
+                            "openTimeslots": 180,
+                            "openAppointmentSlots": 180,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 699,
+                    "openTimeslots": 222,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 699,
+                    "openAppointmentSlots": 222,
                     "name": "New Braunfels H-E-B plus!",
                     "longitude": -98.0782,
                     "latitude": 29.731,
@@ -1534,16 +1540,32 @@
                 },
                 {
                     "zip": "78634-2025",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gue5QAC",
                     "type": "store",
                     "street": "5000 GATTIS SCHOOL RD",
                     "storeNumber": 696,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 274,
+                            "openAppointmentSlots": 274,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 269,
+                            "openAppointmentSlots": 269,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 152,
+                            "openAppointmentSlots": 152,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 695,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 695,
                     "name": "Hutto 130 and Gattis School H-E-B plus!",
                     "longitude": -97.58284,
                     "latitude": 30.50112,
@@ -1559,49 +1581,65 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 103,
-                            "openAppointmentSlots": 103,
+                            "openTimeslots": 206,
+                            "openAppointmentSlots": 206,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 102,
-                            "openAppointmentSlots": 102,
+                            "openTimeslots": 203,
+                            "openAppointmentSlots": 203,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 20,
-                            "openAppointmentSlots": 20,
+                            "openTimeslots": 40,
+                            "openAppointmentSlots": 40,
                             "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 28,
-                            "openAppointmentSlots": 28,
-                            "manufacturer": "Other"
                         }
                     ],
-                    "openTimeslots": 225,
-                    "openFluTimeslots": 28,
-                    "openFluAppointmentSlots": 28,
-                    "openAppointmentSlots": 225,
+                    "openTimeslots": 449,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 449,
                     "name": "League City H-E-B",
                     "longitude": -95.04131,
                     "latitude": 29.50588,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF0uQAE",
+                    "fluUrl": "",
                     "city": "LEAGUE CITY"
                 },
                 {
                     "zip": "79764-7155",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueGQAS",
                     "type": "store",
                     "street": "2501 W UNIVERSITY BLVD",
                     "storeNumber": 711,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 36,
+                            "openAppointmentSlots": 36,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 34,
+                            "openAppointmentSlots": 34,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 69,
+                            "openAppointmentSlots": 69,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 26,
+                            "openAppointmentSlots": 26,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 165,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
-                    "name": "University Blvd H-E-B",
+                    "openAppointmentSlots": 165,
+                    "name": "Odessa H-E-B University Blvd",
                     "longitude": -102.41008,
                     "latitude": 31.86213,
                     "fluUrl": "",
@@ -1627,16 +1665,32 @@
                 },
                 {
                     "zip": "77059-2511",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueIQAS",
                     "type": "store",
                     "street": "3501 CLEAR LAKE CITY BLVD",
                     "storeNumber": 713,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 37,
+                            "openAppointmentSlots": 37,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 19,
+                            "openAppointmentSlots": 19,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 76,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 76,
                     "name": "Clear Lake Marketplace H-E-B",
                     "longitude": -95.12473,
                     "latitude": 29.60563,
@@ -1652,20 +1706,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 14,
-                            "openAppointmentSlots": 14,
+                            "openTimeslots": 10,
+                            "openAppointmentSlots": 10,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 14,
-                            "openAppointmentSlots": 14,
+                            "openTimeslots": 9,
+                            "openAppointmentSlots": 9,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 28,
+                    "openTimeslots": 19,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 28,
+                    "openAppointmentSlots": 19,
                     "name": "Lakeway H-E-B",
                     "longitude": -97.96662,
                     "latitude": 30.34368,
@@ -1735,48 +1789,44 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 97,
-                            "openAppointmentSlots": 97,
-                            "manufacturer": "Other"
-                        },
-                        {
-                            "openTimeslots": 42,
-                            "openAppointmentSlots": 42,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
+                            "openTimeslots": 30,
+                            "openAppointmentSlots": 30,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 35,
-                            "openAppointmentSlots": 35,
+                            "openTimeslots": 23,
+                            "openAppointmentSlots": 23,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 127,
-                    "openFluTimeslots": 97,
-                    "openFluAppointmentSlots": 97,
-                    "openAppointmentSlots": 127,
+                    "openTimeslots": 53,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 53,
                     "name": "Tomball Pkwy and Graham H-E-B",
                     "longitude": -95.63218,
                     "latitude": 30.08868,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3ZQAU",
+                    "fluUrl": "",
                     "city": "TOMBALL"
                 },
                 {
                     "zip": "77379-7234",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gud4QAC",
                     "type": "store",
                     "street": "7310 LOUETTA",
                     "storeNumber": 576,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 27,
+                            "openAppointmentSlots": 27,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 27,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 27,
                     "name": "Louetta and Stuebner H-E-B",
                     "longitude": -95.5243,
                     "latitude": 30.0209,
@@ -1785,16 +1835,32 @@
                 },
                 {
                     "zip": "77043-1803",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gud5QAC",
                     "type": "store",
                     "street": "10251 KEMPWOOD",
                     "storeNumber": 577,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 98,
+                            "openAppointmentSlots": 98,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 112,
+                            "openAppointmentSlots": 112,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 98,
+                            "openAppointmentSlots": 98,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 308,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 308,
                     "name": "Kempwood and Gessner H-E-B",
                     "longitude": -95.5468,
                     "latitude": 29.8226,
@@ -1821,16 +1887,37 @@
                 },
                 {
                     "zip": "78613-7273",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gud7QAC",
                     "type": "store",
                     "street": "2800 EAST WHITESTONE",
                     "storeNumber": 580,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 109,
+                            "openAppointmentSlots": 109,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 100,
+                            "openAppointmentSlots": 100,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 296,
+                            "openAppointmentSlots": 296,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 12,
+                            "openAppointmentSlots": 12,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 517,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 517,
                     "name": "Parmer and Whitestone H-E-B",
                     "longitude": -97.78545,
                     "latitude": 30.5328,
@@ -1846,34 +1933,29 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 17,
-                            "openAppointmentSlots": 17,
+                            "openTimeslots": 24,
+                            "openAppointmentSlots": 24,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 18,
-                            "openAppointmentSlots": 18,
+                            "openTimeslots": 25,
+                            "openAppointmentSlots": 25,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 6,
-                            "openAppointmentSlots": 6,
+                            "openTimeslots": 24,
+                            "openAppointmentSlots": 24,
                             "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 18,
-                            "openAppointmentSlots": 18,
-                            "manufacturer": "Other"
                         }
                     ],
-                    "openTimeslots": 41,
-                    "openFluTimeslots": 18,
-                    "openFluAppointmentSlots": 18,
-                    "openAppointmentSlots": 41,
+                    "openTimeslots": 73,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 73,
                     "name": "Stephenville H-E-B",
                     "longitude": -98.22569,
                     "latitude": 32.20975,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3tQAE",
+                    "fluUrl": "",
                     "city": "STEPHENVILLE"
                 },
                 {
@@ -1885,48 +1967,59 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 96,
-                            "openAppointmentSlots": 96,
+                            "openTimeslots": 101,
+                            "openAppointmentSlots": 101,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 57,
-                            "openAppointmentSlots": 57,
+                            "openTimeslots": 54,
+                            "openAppointmentSlots": 54,
                             "manufacturer": "Pfizer"
                         },
                         {
                             "openTimeslots": 34,
                             "openAppointmentSlots": 34,
                             "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 40,
-                            "openAppointmentSlots": 40,
-                            "manufacturer": "Other"
                         }
                     ],
-                    "openTimeslots": 187,
-                    "openFluTimeslots": 40,
-                    "openFluAppointmentSlots": 40,
-                    "openAppointmentSlots": 187,
+                    "openTimeslots": 189,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 189,
                     "name": "Slaughter and Manchaca H-E-B",
                     "longitude": -97.82509,
                     "latitude": 30.17524,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF1WQAU",
+                    "fluUrl": "",
                     "city": "AUSTIN"
                 },
                 {
                     "zip": "78744-3410",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubLQAS",
                     "type": "store",
                     "street": "6607 SOUTH IH 35",
                     "storeNumber": 229,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 15,
+                            "openAppointmentSlots": 15,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 30,
+                            "openAppointmentSlots": 30,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 1,
+                            "openAppointmentSlots": 1,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 46,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 46,
                     "name": "I 35 and William Cannon H-E-B",
                     "longitude": -97.76922,
                     "latitude": 30.19107,
@@ -1942,30 +2035,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 100,
-                            "openAppointmentSlots": 100,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 366,
-                            "openAppointmentSlots": 366,
+                            "openTimeslots": 24,
+                            "openAppointmentSlots": 24,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 461,
-                            "openAppointmentSlots": 461,
+                            "openTimeslots": 608,
+                            "openAppointmentSlots": 608,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 46,
-                            "openAppointmentSlots": 46,
+                            "openTimeslots": 49,
+                            "openAppointmentSlots": 49,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 973,
+                    "openTimeslots": 681,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 973,
+                    "openAppointmentSlots": 681,
                     "name": "Nacogdoches and O'Connor H-E-B",
                     "longitude": -98.3856,
                     "latitude": 29.56937,
@@ -2010,36 +2098,20 @@
                 },
                 {
                     "zip": "77450-4564",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuchQAC",
+                    "url": null,
                     "type": "store",
                     "street": "1621 MASON ROAD",
                     "storeNumber": 497,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 71,
-                            "openAppointmentSlots": 71,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 66,
-                            "openAppointmentSlots": 66,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 70,
-                            "openAppointmentSlots": 70,
-                            "manufacturer": "Other"
-                        }
-                    ],
-                    "openTimeslots": 137,
-                    "openFluTimeslots": 70,
-                    "openFluAppointmentSlots": 70,
-                    "openAppointmentSlots": 137,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
                     "name": "Mason Rd H-E-B",
                     "longitude": -95.75102,
                     "latitude": 29.75787,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3DQAU",
+                    "fluUrl": "",
                     "city": "KATY"
                 },
                 {
@@ -2051,20 +2123,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 45,
-                            "openAppointmentSlots": 45,
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 25,
-                            "openAppointmentSlots": 25,
+                            "openTimeslots": 51,
+                            "openAppointmentSlots": 51,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 70,
+                    "openTimeslots": 101,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 70,
+                    "openAppointmentSlots": 101,
                     "name": "Atascocita H-E-B",
                     "longitude": -95.1642,
                     "latitude": 29.9983,
@@ -2080,30 +2152,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 151,
-                            "openAppointmentSlots": 151,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 65,
-                            "openAppointmentSlots": 65,
+                            "openTimeslots": 36,
+                            "openAppointmentSlots": 36,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 156,
-                            "openAppointmentSlots": 156,
+                            "openTimeslots": 84,
+                            "openAppointmentSlots": 84,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 108,
-                            "openAppointmentSlots": 108,
+                            "openTimeslots": 55,
+                            "openAppointmentSlots": 55,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 480,
+                    "openTimeslots": 175,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 480,
+                    "openAppointmentSlots": 175,
                     "name": "Gulfgate H-E-B",
                     "longitude": -95.2968,
                     "latitude": 29.6994,
@@ -2112,16 +2179,27 @@
                 },
                 {
                     "zip": "77072-5000",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuckQAC",
                     "type": "store",
                     "street": "10100 BEECHNUT",
                     "storeNumber": 541,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 21,
+                            "openAppointmentSlots": 21,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 10,
+                            "openAppointmentSlots": 10,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 31,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 31,
                     "name": "Beechnut H-E-B",
                     "longitude": -95.5604,
                     "latitude": 29.6896,
@@ -2130,16 +2208,27 @@
                 },
                 {
                     "zip": "77840-3914",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuclQAC",
                     "type": "store",
                     "street": "1900 TEXAS AVENUE SOUTH",
                     "storeNumber": 543,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 74,
+                            "openAppointmentSlots": 74,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 76,
+                            "openAppointmentSlots": 76,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 150,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 150,
                     "name": "Texas Avenue H-E-B",
                     "longitude": -96.3165,
                     "latitude": 30.6131,
@@ -2148,16 +2237,27 @@
                 },
                 {
                     "zip": "77429-6286",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gue7QAC",
                     "type": "store",
                     "street": "14100 SPRING CYPRESS RD",
                     "storeNumber": 698,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 16,
+                            "openAppointmentSlots": 16,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 11,
+                            "openAppointmentSlots": 11,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 27,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 27,
                     "name": "Grant and Spring Cypress H-E-B",
                     "longitude": -95.63698,
                     "latitude": 30.00365,
@@ -2173,20 +2273,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 150,
-                            "openAppointmentSlots": 150,
+                            "openTimeslots": 429,
+                            "openAppointmentSlots": 429,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 150,
-                            "openAppointmentSlots": 150,
+                            "openTimeslots": 430,
+                            "openAppointmentSlots": 430,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 430,
+                            "openAppointmentSlots": 430,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 300,
+                    "openTimeslots": 1289,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 300,
+                    "openAppointmentSlots": 1289,
                     "name": "Nogalitos H-E-B",
                     "longitude": -98.51485,
                     "latitude": 29.39799,
@@ -2249,32 +2354,16 @@
                 },
                 {
                     "zip": "77386-4343",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueCQAS",
+                    "url": null,
                     "type": "store",
                     "street": "3540 RAYFORD RD",
                     "storeNumber": 705,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 79,
-                            "openAppointmentSlots": 79,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 199,
-                            "openAppointmentSlots": 199,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 200,
-                            "openAppointmentSlots": 200,
-                            "manufacturer": "Pediatric_Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 478,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 478,
+                    "openAppointmentSlots": 0,
                     "name": "Spring Creek Market H-E-B",
                     "longitude": -95.38801,
                     "latitude": 30.11036,
@@ -2337,32 +2426,16 @@
                 },
                 {
                     "zip": "76542-0",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueOQAS",
+                    "url": null,
                     "type": "store",
                     "street": "1101 W. STAN SCHLUETER LOOP",
                     "storeNumber": 721,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 30,
-                            "openAppointmentSlots": 30,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 30,
-                            "openAppointmentSlots": 30,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 27,
-                            "openAppointmentSlots": 27,
-                            "manufacturer": "Pediatric_Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 87,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 87,
+                    "openAppointmentSlots": 0,
                     "name": "Fort Hood Stan Schlueter H-E-B",
                     "longitude": -97.75988,
                     "latitude": 31.07989,
@@ -2371,16 +2444,32 @@
                 },
                 {
                     "zip": "77354-1611",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuePQAS",
                     "type": "store",
                     "street": "7988 FM 1488",
                     "storeNumber": 722,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 11,
+                            "openAppointmentSlots": 11,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 13,
+                            "openAppointmentSlots": 13,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 12,
+                            "openAppointmentSlots": 12,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 36,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 36,
                     "name": "Magnolia Market H-E-B",
                     "longitude": -95.5837,
                     "latitude": 30.2217,
@@ -2396,15 +2485,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 140,
-                            "openAppointmentSlots": 140,
+                            "openTimeslots": 29,
+                            "openAppointmentSlots": 29,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 131,
+                            "openAppointmentSlots": 131,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 140,
+                    "openTimeslots": 180,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 140,
+                    "openAppointmentSlots": 180,
                     "name": "Aliana Market H-E-B",
                     "longitude": -95.7137,
                     "latitude": 29.6597,
@@ -2413,22 +2512,16 @@
                 },
                 {
                     "zip": "78572-9139",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucKQAS",
+                    "url": null,
                     "type": "store",
                     "street": "6010 W EXPRESSWAY 83",
                     "storeNumber": 448,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 112,
-                            "openAppointmentSlots": 112,
-                            "manufacturer": "Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 112,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 112,
+                    "openAppointmentSlots": 0,
                     "name": "Palmview H-E-B",
                     "longitude": -98.38385,
                     "latitude": 26.23538,
@@ -2444,20 +2537,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 51,
-                            "openAppointmentSlots": 51,
+                            "openTimeslots": 52,
+                            "openAppointmentSlots": 52,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
+                            "openTimeslots": 58,
+                            "openAppointmentSlots": 58,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 10,
+                            "openAppointmentSlots": 10,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 101,
+                    "openTimeslots": 120,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 101,
+                    "openAppointmentSlots": 120,
                     "name": "Four Points H-E-B",
                     "longitude": -97.85202,
                     "latitude": 30.40458,
@@ -2466,32 +2564,16 @@
                 },
                 {
                     "zip": "78666-5615",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucNQAS",
+                    "url": null,
                     "type": "store",
                     "street": "200 WEST HOPKINS ST.",
                     "storeNumber": 455,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 6,
-                            "openAppointmentSlots": 6,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 18,
-                            "openAppointmentSlots": 18,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 6,
-                            "openAppointmentSlots": 6,
-                            "manufacturer": "Pediatric_Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 30,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 30,
+                    "openAppointmentSlots": 0,
                     "name": "West Hopkins H-E-B",
                     "longitude": -97.94292,
                     "latitude": 29.88305,
@@ -2500,16 +2582,27 @@
                 },
                 {
                     "zip": "78405-2040",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucOQAS",
                     "type": "store",
                     "street": "3033 SOUTH PORT ST.",
                     "storeNumber": 462,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 24,
+                            "openAppointmentSlots": 24,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 11,
+                            "openAppointmentSlots": 11,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 35,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 35,
                     "name": "S Port and Tarlton H-E-B",
                     "longitude": -97.42137,
                     "latitude": 27.76687,
@@ -2525,25 +2618,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 238,
-                            "openAppointmentSlots": 238,
+                            "openTimeslots": 493,
+                            "openAppointmentSlots": 493,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 273,
-                            "openAppointmentSlots": 273,
+                            "openTimeslots": 631,
+                            "openAppointmentSlots": 631,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 244,
-                            "openAppointmentSlots": 244,
+                            "openTimeslots": 485,
+                            "openAppointmentSlots": 485,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 755,
+                    "openTimeslots": 1609,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 755,
+                    "openAppointmentSlots": 1609,
                     "name": "Loop 1604 and Blanco Rd H-E-B plus!",
                     "longitude": -98.50968,
                     "latitude": 29.60792,
@@ -2552,16 +2645,22 @@
                 },
                 {
                     "zip": "78702-3907",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucQQAS",
                     "type": "store",
                     "street": "2701 EAST 7TH",
                     "storeNumber": 465,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 201,
+                            "openAppointmentSlots": 201,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 201,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 201,
                     "name": "7th Street H-E-B",
                     "longitude": -97.71143,
                     "latitude": 30.26046,
@@ -2588,16 +2687,27 @@
                 },
                 {
                     "zip": "76667-2445",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucSQAS",
                     "type": "store",
                     "street": "701 E. MILAM STREET",
                     "storeNumber": 467,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 10,
+                            "openAppointmentSlots": 10,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 7,
+                            "openAppointmentSlots": 7,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 17,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 17,
                     "name": "Mexia H-E-B",
                     "longitude": -96.47858,
                     "latitude": 31.68434,
@@ -2613,20 +2723,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 182,
-                            "openAppointmentSlots": 182,
+                            "openTimeslots": 154,
+                            "openAppointmentSlots": 154,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 182,
-                            "openAppointmentSlots": 182,
+                            "openTimeslots": 196,
+                            "openAppointmentSlots": 196,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 132,
+                            "openAppointmentSlots": 132,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 364,
+                    "openTimeslots": 482,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 364,
+                    "openAppointmentSlots": 482,
                     "name": "Fairmont Pkwy H-E-B",
                     "longitude": -95.14512,
                     "latitude": 29.6497,
@@ -2642,20 +2757,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 51,
-                            "openAppointmentSlots": 51,
+                            "openTimeslots": 52,
+                            "openAppointmentSlots": 52,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 48,
-                            "openAppointmentSlots": 48,
+                            "openTimeslots": 52,
+                            "openAppointmentSlots": 52,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 99,
+                    "openTimeslots": 104,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 99,
+                    "openAppointmentSlots": 104,
                     "name": "Lake Colony H-E-B",
                     "longitude": -95.58244,
                     "latitude": 29.58032,
@@ -2671,20 +2786,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 57,
-                            "openAppointmentSlots": 57,
+                            "openTimeslots": 40,
+                            "openAppointmentSlots": 40,
                             "manufacturer": "Moderna"
                         },
                         {
                             "openTimeslots": 100,
                             "openAppointmentSlots": 100,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 15,
+                            "openAppointmentSlots": 15,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 157,
+                    "openTimeslots": 155,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 157,
+                    "openAppointmentSlots": 155,
                     "name": "Elgin H-E-B",
                     "longitude": -97.38258,
                     "latitude": 30.34701,
@@ -2693,22 +2813,16 @@
                 },
                 {
                     "zip": "78753-1632",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucWQAS",
+                    "url": null,
                     "type": "store",
                     "street": "500 CANYON RIDGE DR.",
                     "storeNumber": 476,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 33,
-                            "openAppointmentSlots": 33,
-                            "manufacturer": "Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 33,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 33,
+                    "openAppointmentSlots": 0,
                     "name": "Tech Ridge H-E-B",
                     "longitude": -97.67201,
                     "latitude": 30.40443,
@@ -2717,16 +2831,22 @@
                 },
                 {
                     "zip": "78610-9703",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucXQAS",
                     "type": "store",
                     "street": "15300 S IH-35",
                     "storeNumber": 477,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 55,
+                            "openAppointmentSlots": 55,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 55,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 55,
                     "name": "Buda H-E-B",
                     "longitude": -97.82074,
                     "latitude": 30.08769,
@@ -2742,25 +2862,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 129,
-                            "openAppointmentSlots": 129,
+                            "openTimeslots": 114,
+                            "openAppointmentSlots": 114,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 114,
-                            "openAppointmentSlots": 114,
+                            "openTimeslots": 118,
+                            "openAppointmentSlots": 118,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 124,
-                            "openAppointmentSlots": 124,
+                            "openTimeslots": 117,
+                            "openAppointmentSlots": 117,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 367,
+                    "openTimeslots": 349,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 367,
+                    "openAppointmentSlots": 349,
                     "name": "Grissom and Tezel H-E-B",
                     "longitude": -98.66574,
                     "latitude": 29.48432,
@@ -2812,18 +2932,13 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 24,
-                            "openAppointmentSlots": 24,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
+                            "openTimeslots": 10,
+                            "openAppointmentSlots": 10,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 58,
-                            "openAppointmentSlots": 58,
+                            "openTimeslots": 60,
+                            "openAppointmentSlots": 60,
                             "manufacturer": "Pfizer"
                         },
                         {
@@ -2832,10 +2947,10 @@
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 152,
+                    "openTimeslots": 90,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 152,
+                    "openAppointmentSlots": 90,
                     "name": "East Hopkins H-E-B",
                     "longitude": -97.93132,
                     "latitude": 29.88489,
@@ -2844,16 +2959,27 @@
                 },
                 {
                     "zip": "78408-3204",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubUQAS",
                     "type": "store",
                     "street": "3500 LEOPARD",
                     "storeNumber": 253,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 672,
+                            "openAppointmentSlots": 672,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 75,
+                            "openAppointmentSlots": 75,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 747,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 747,
                     "name": "Leopard and Nueces Bay H-E-B",
                     "longitude": -97.42774,
                     "latitude": 27.79695,
@@ -2869,25 +2995,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 83,
-                            "openAppointmentSlots": 83,
+                            "openTimeslots": 191,
+                            "openAppointmentSlots": 191,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 128,
-                            "openAppointmentSlots": 128,
+                            "openTimeslots": 220,
+                            "openAppointmentSlots": 220,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
+                            "openTimeslots": 54,
+                            "openAppointmentSlots": 54,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 261,
+                    "openTimeslots": 465,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 261,
+                    "openAppointmentSlots": 465,
                     "name": "Tejas Center H-E-B",
                     "longitude": -96.3513,
                     "latitude": 30.64506,
@@ -2896,16 +3022,27 @@
                 },
                 {
                     "zip": "77077-6860",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucnQAC",
                     "type": "store",
                     "street": "11815 WESTHEIMER",
                     "storeNumber": 551,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 56,
+                            "openAppointmentSlots": 56,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 8,
+                            "openAppointmentSlots": 8,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 64,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 64,
                     "name": "Westheimer and Kirkwood H-E-B",
                     "longitude": -95.587,
                     "latitude": 29.7363,
@@ -2921,25 +3058,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 44,
-                            "openAppointmentSlots": 44,
+                            "openTimeslots": 45,
+                            "openAppointmentSlots": 45,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 53,
-                            "openAppointmentSlots": 53,
+                            "openTimeslots": 71,
+                            "openAppointmentSlots": 71,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 30,
-                            "openAppointmentSlots": 30,
+                            "openTimeslots": 35,
+                            "openAppointmentSlots": 35,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 127,
+                    "openTimeslots": 151,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 127,
+                    "openAppointmentSlots": 151,
                     "name": "Bear Creek H-E-B",
                     "longitude": -95.6457,
                     "latitude": 29.8487,
@@ -2984,16 +3121,22 @@
                 },
                 {
                     "zip": "78201-4407",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucrQAC",
                     "type": "store",
                     "street": "2118 FREDERICKSBURG RD",
                     "storeNumber": 556,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 111,
+                            "openAppointmentSlots": 111,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 111,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 111,
                     "name": "Deco District H-E-B",
                     "longitude": -98.5261,
                     "latitude": 29.4646,
@@ -3027,43 +3170,54 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 470,
-                            "openAppointmentSlots": 470,
+                            "openTimeslots": 483,
+                            "openAppointmentSlots": 483,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 472,
-                            "openAppointmentSlots": 472,
+                            "openTimeslots": 489,
+                            "openAppointmentSlots": 489,
                             "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 452,
-                            "openAppointmentSlots": 452,
-                            "manufacturer": "Other"
                         }
                     ],
-                    "openTimeslots": 942,
-                    "openFluTimeslots": 452,
-                    "openFluAppointmentSlots": 452,
-                    "openAppointmentSlots": 942,
+                    "openTimeslots": 972,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 972,
                     "name": "Friendswood H-E-B",
                     "longitude": -95.1912,
                     "latitude": 29.5066,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3PQAU",
+                    "fluUrl": "",
                     "city": "FRIENDSWOOD"
                 },
                 {
                     "zip": "77566-4622",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueDQAS",
                     "type": "store",
                     "street": "97 OYSTER CREEK DRIV",
                     "storeNumber": 707,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 136,
+                            "openAppointmentSlots": 136,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 134,
+                            "openAppointmentSlots": 134,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 67,
+                            "openAppointmentSlots": 67,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 337,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 337,
                     "name": "Lake Jackson H-E-B",
                     "longitude": -95.44554,
                     "latitude": 29.04151,
@@ -3072,16 +3226,27 @@
                 },
                 {
                     "zip": "78676-6215",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueEQAS",
                     "type": "store",
                     "street": "14501 RR12",
                     "storeNumber": 708,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 18,
+                            "openAppointmentSlots": 18,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 35,
+                            "openAppointmentSlots": 35,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 53,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 53,
                     "name": "Wimberley H-E-B",
                     "longitude": -98.10174,
                     "latitude": 30.00144,
@@ -3090,40 +3255,56 @@
                 },
                 {
                     "zip": "77433-4847",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueFQAS",
                     "type": "store",
                     "street": "9722 FRY ROAD",
                     "storeNumber": 709,
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
-                            "manufacturer": "Other"
+                            "openTimeslots": 159,
+                            "openAppointmentSlots": 159,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 115,
+                            "openAppointmentSlots": 115,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 0,
-                    "openFluTimeslots": 10,
-                    "openFluAppointmentSlots": 10,
-                    "openAppointmentSlots": 0,
+                    "openTimeslots": 274,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 274,
                     "name": "H-E-B Market at Tuckerton",
                     "longitude": -95.72501,
                     "latitude": 29.92737,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF13QAE",
+                    "fluUrl": "",
                     "city": "CYPRESS"
                 },
                 {
                     "zip": "77379-8693",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueRQAS",
                     "type": "store",
                     "street": "20311 CHAMPION FOREST DRIVE",
                     "storeNumber": 725,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 89,
+                            "openAppointmentSlots": 89,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 86,
+                            "openAppointmentSlots": 86,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 175,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 175,
                     "name": "Champion Forest Market H-E-B",
                     "longitude": -95.57475,
                     "latitude": 30.0551,
@@ -3132,16 +3313,32 @@
                 },
                 {
                     "zip": "77469-2509",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueSQAS",
                     "type": "store",
                     "street": "23500 CIRCLE OAK PARKWAY",
                     "storeNumber": 727,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 24,
+                            "openAppointmentSlots": 24,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 68,
+                            "openAppointmentSlots": 68,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 83,
+                            "openAppointmentSlots": 83,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 175,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 175,
                     "name": "Richmond Market H-E-B",
                     "longitude": -95.74781,
                     "latitude": 29.55142,
@@ -3157,39 +3354,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 150,
-                            "openAppointmentSlots": 150,
-                            "manufacturer": "Other"
-                        },
-                        {
-                            "openTimeslots": 24,
-                            "openAppointmentSlots": 24,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 25,
-                            "openAppointmentSlots": 25,
+                            "openTimeslots": 11,
+                            "openAppointmentSlots": 11,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 25,
-                            "openAppointmentSlots": 25,
+                            "openTimeslots": 15,
+                            "openAppointmentSlots": 15,
                             "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 25,
-                            "openAppointmentSlots": 25,
-                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 99,
-                    "openFluTimeslots": 150,
-                    "openFluAppointmentSlots": 150,
-                    "openAppointmentSlots": 99,
+                    "openTimeslots": 26,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 26,
                     "name": "Huntsville H-E-B",
                     "longitude": -95.56075,
                     "latitude": 30.72274,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF1TQAU",
+                    "fluUrl": "",
                     "city": "HUNTSVILLE"
                 },
                 {
@@ -3201,25 +3383,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 274,
-                            "openAppointmentSlots": 274,
+                            "openTimeslots": 243,
+                            "openAppointmentSlots": 243,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 369,
-                            "openAppointmentSlots": 369,
+                            "openTimeslots": 322,
+                            "openAppointmentSlots": 322,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 260,
-                            "openAppointmentSlots": 260,
+                            "openTimeslots": 249,
+                            "openAppointmentSlots": 249,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 903,
+                    "openTimeslots": 814,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 903,
+                    "openAppointmentSlots": 814,
                     "name": "Bulverde and 1604 H-E-B",
                     "longitude": -98.41746,
                     "latitude": 29.59497,
@@ -3228,16 +3410,22 @@
                 },
                 {
                     "zip": "78041-5754",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubVQAS",
                     "type": "store",
                     "street": "4801 SAN DARIO",
                     "storeNumber": 255,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 1,
+                            "openAppointmentSlots": 1,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 1,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 1,
                     "name": "35 and Calton H-E-B",
                     "longitude": -99.50182,
                     "latitude": 27.54172,
@@ -3246,27 +3434,16 @@
                 },
                 {
                     "zip": "78238-1986",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubWQAS",
+                    "url": null,
                     "type": "store",
                     "street": "5601 BANDERA ROAD",
                     "storeNumber": 262,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 128,
-                            "openAppointmentSlots": 128,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 124,
-                            "openAppointmentSlots": 124,
-                            "manufacturer": "Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 252,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 252,
+                    "openAppointmentSlots": 0,
                     "name": "Marketplace H-E-B",
                     "longitude": -98.59477,
                     "latitude": 29.48119,
@@ -3275,16 +3452,32 @@
                 },
                 {
                     "zip": "78520-8327",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubXQAS",
                     "type": "store",
                     "street": "1628 CENTRAL BLVD",
                     "storeNumber": 263,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 62,
+                            "openAppointmentSlots": 62,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 47,
+                            "openAppointmentSlots": 47,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 159,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 159,
                     "name": "Central Blvd H-E-B",
                     "longitude": -97.51093,
                     "latitude": 25.92849,
@@ -3300,20 +3493,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 18,
-                            "openAppointmentSlots": 18,
+                            "openTimeslots": 59,
+                            "openAppointmentSlots": 59,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 12,
-                            "openAppointmentSlots": 12,
+                            "openTimeslots": 79,
+                            "openAppointmentSlots": 79,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 49,
+                            "openAppointmentSlots": 49,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 30,
+                    "openTimeslots": 187,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 30,
+                    "openAppointmentSlots": 187,
                     "name": "Hwy 183 and Whitestone Blvd H-E-B",
                     "longitude": -97.82911,
                     "latitude": 30.5225,
@@ -3329,20 +3527,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 21,
-                            "openAppointmentSlots": 21,
+                            "openTimeslots": 8,
+                            "openAppointmentSlots": 8,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 23,
-                            "openAppointmentSlots": 23,
+                            "openTimeslots": 5,
+                            "openAppointmentSlots": 5,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 44,
+                    "openTimeslots": 13,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 44,
+                    "openAppointmentSlots": 13,
                     "name": "North Hills H-E-B",
                     "longitude": -97.74832,
                     "latitude": 30.39868,
@@ -3358,29 +3556,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 16,
-                            "openAppointmentSlots": 16,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
+                            "openTimeslots": 6,
+                            "openAppointmentSlots": 6,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 54,
-                            "openAppointmentSlots": 54,
-                            "manufacturer": "Other"
+                            "openTimeslots": 47,
+                            "openAppointmentSlots": 47,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 26,
-                    "openFluTimeslots": 54,
-                    "openFluAppointmentSlots": 54,
-                    "openAppointmentSlots": 26,
+                    "openTimeslots": 53,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 53,
                     "name": "Moore Plaza H-E-B",
                     "longitude": -97.37238,
                     "latitude": 27.70605,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF21QAE",
+                    "fluUrl": "",
                     "city": "CORPUS CHRISTI"
                 },
                 {
@@ -3392,20 +3585,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 93,
-                            "openAppointmentSlots": 93,
+                            "openTimeslots": 79,
+                            "openAppointmentSlots": 79,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 98,
-                            "openAppointmentSlots": 98,
+                            "openTimeslots": 80,
+                            "openAppointmentSlots": 80,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 191,
+                    "openTimeslots": 159,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 191,
+                    "openAppointmentSlots": 159,
                     "name": "Fredericksburg H-E-B",
                     "longitude": -98.87538,
                     "latitude": 30.27006,
@@ -3439,59 +3632,43 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 44,
-                            "openAppointmentSlots": 44,
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
                             "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 40,
-                            "openAppointmentSlots": 40,
-                            "manufacturer": "Pediatric_Pfizer"
                         },
                         {
                             "openTimeslots": 12,
                             "openAppointmentSlots": 12,
-                            "manufacturer": "Other"
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 4,
+                            "openAppointmentSlots": 4,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 134,
-                    "openFluTimeslots": 12,
-                    "openFluAppointmentSlots": 12,
-                    "openAppointmentSlots": 134,
+                    "openTimeslots": 36,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 36,
                     "name": "Riverpark H-E-B",
                     "longitude": -95.6815,
                     "latitude": 29.5636,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3SQAU",
+                    "fluUrl": "",
                     "city": "SUGAR LAND"
                 },
                 {
                     "zip": "77380-2272",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucxQAC",
+                    "url": null,
                     "type": "store",
                     "street": "130 SAWDUST ROAD",
                     "storeNumber": 564,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 69,
-                            "openAppointmentSlots": 69,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 129,
-                            "openAppointmentSlots": 129,
-                            "manufacturer": "Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 198,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 198,
+                    "openAppointmentSlots": 0,
                     "name": "Sawdust Rd and 45 H-E-B",
                     "longitude": -95.44512,
                     "latitude": 30.12684,
@@ -3507,30 +3684,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 76,
-                            "openAppointmentSlots": 76,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 146,
-                            "openAppointmentSlots": 146,
+                            "openTimeslots": 162,
+                            "openAppointmentSlots": 162,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 140,
-                            "openAppointmentSlots": 140,
+                            "openTimeslots": 149,
+                            "openAppointmentSlots": 149,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 76,
-                            "openAppointmentSlots": 76,
+                            "openTimeslots": 10,
+                            "openAppointmentSlots": 10,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 438,
+                    "openTimeslots": 321,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 438,
+                    "openAppointmentSlots": 321,
                     "name": "Leon Springs H-E-B",
                     "longitude": -98.63218,
                     "latitude": 29.6659,
@@ -3557,16 +3729,22 @@
                 },
                 {
                     "zip": "78217-2116",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gud0QAC",
                     "type": "store",
                     "street": "12018 PERRIN BEITEL ROAD",
                     "storeNumber": 568,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 344,
+                            "openAppointmentSlots": 344,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 344,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 344,
                     "name": "Perrin Beitel and Thousand Oaks H-E-B",
                     "longitude": -98.4082,
                     "latitude": 29.5491,
@@ -3618,29 +3796,29 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 24,
-                            "openAppointmentSlots": 24,
+                            "openTimeslots": 4,
+                            "openAppointmentSlots": 4,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 26,
-                            "openAppointmentSlots": 26,
+                            "openTimeslots": 44,
+                            "openAppointmentSlots": 44,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 26,
-                            "openAppointmentSlots": 26,
-                            "manufacturer": "Other"
+                            "openTimeslots": 44,
+                            "openAppointmentSlots": 44,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 50,
-                    "openFluTimeslots": 26,
-                    "openFluAppointmentSlots": 26,
-                    "openAppointmentSlots": 50,
+                    "openTimeslots": 92,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 92,
                     "name": "Bay City H-E-B",
                     "longitude": -95.95804,
                     "latitude": 28.98306,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF23QAE",
+                    "fluUrl": "",
                     "city": "BAY CITY"
                 },
                 {
@@ -3652,29 +3830,29 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 23,
-                            "openAppointmentSlots": 23,
+                            "openTimeslots": 31,
+                            "openAppointmentSlots": 31,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 31,
+                            "openAppointmentSlots": 31,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 25,
-                            "openAppointmentSlots": 25,
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
                             "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 23,
-                            "openAppointmentSlots": 23,
-                            "manufacturer": "Other"
                         }
                     ],
-                    "openTimeslots": 48,
-                    "openFluTimeslots": 23,
-                    "openFluAppointmentSlots": 23,
-                    "openAppointmentSlots": 48,
+                    "openTimeslots": 82,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 82,
                     "name": "Foster Rd H-E-B",
                     "longitude": -98.3591,
                     "latitude": 29.48109,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF24QAE",
+                    "fluUrl": "",
                     "city": "SAN ANTONIO"
                 },
                 {
@@ -3715,16 +3893,32 @@
                 },
                 {
                     "zip": "78501-3512",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubgQAC",
                     "type": "store",
                     "street": "3601 PECAN",
                     "storeNumber": 334,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 34,
+                            "openAppointmentSlots": 34,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 12,
+                            "openAppointmentSlots": 12,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 11,
+                            "openAppointmentSlots": 11,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 57,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 57,
                     "name": "Pecan and Ware H-E-B",
                     "longitude": -98.25799,
                     "latitude": 26.21925,
@@ -3733,26 +3927,36 @@
                 },
                 {
                     "zip": "78640-6038",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaFQAS",
                     "type": "store",
                     "street": "5401 SOUTH FM 1626",
                     "storeNumber": 14,
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 5,
-                            "openAppointmentSlots": 5,
-                            "manufacturer": "Other"
+                            "openTimeslots": 24,
+                            "openAppointmentSlots": 24,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 58,
+                            "openAppointmentSlots": 58,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 25,
+                            "openAppointmentSlots": 25,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 0,
-                    "openFluTimeslots": 5,
-                    "openFluAppointmentSlots": 5,
-                    "openAppointmentSlots": 0,
+                    "openTimeslots": 107,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 107,
                     "name": "Kyle H-E-B plus!",
                     "longitude": -97.86258,
                     "latitude": 30.01533,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3vQAE",
+                    "fluUrl": "",
                     "city": "KYLE"
                 },
                 {
@@ -3764,15 +3968,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 66,
-                            "openAppointmentSlots": 66,
-                            "manufacturer": "Moderna"
+                            "openTimeslots": 31,
+                            "openAppointmentSlots": 31,
+                            "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 66,
+                    "openTimeslots": 31,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 66,
+                    "openAppointmentSlots": 31,
                     "name": "Burleson H-E-B plus!",
                     "longitude": -97.34901,
                     "latitude": 32.52083,
@@ -3788,48 +3992,59 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 161,
-                            "openAppointmentSlots": 161,
+                            "openTimeslots": 135,
+                            "openAppointmentSlots": 135,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 152,
-                            "openAppointmentSlots": 152,
+                            "openTimeslots": 109,
+                            "openAppointmentSlots": 109,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 111,
-                            "openAppointmentSlots": 111,
+                            "openTimeslots": 133,
+                            "openAppointmentSlots": 133,
                             "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 103,
-                            "openAppointmentSlots": 103,
-                            "manufacturer": "Other"
                         }
                     ],
-                    "openTimeslots": 424,
-                    "openFluTimeslots": 103,
-                    "openFluAppointmentSlots": 103,
-                    "openAppointmentSlots": 424,
+                    "openTimeslots": 377,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 377,
                     "name": "Lytle H-E-B plus!",
                     "longitude": -98.78924,
                     "latitude": 29.23224,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3xQAE",
+                    "fluUrl": "",
                     "city": "LYTLE"
                 },
                 {
                     "zip": "77429-5683",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaIQAS",
                     "type": "store",
                     "street": "24224 NORTHWEST FREEWAY",
                     "storeNumber": 20,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 40,
+                            "openAppointmentSlots": 40,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 32,
+                            "openAppointmentSlots": 32,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 6,
+                            "openAppointmentSlots": 6,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 78,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 78,
                     "name": "Cypress Market H-E-B",
                     "longitude": -95.6765,
                     "latitude": 29.95569,
@@ -3845,43 +4060,59 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 7,
-                            "openAppointmentSlots": 7,
+                            "openTimeslots": 16,
+                            "openAppointmentSlots": 16,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 12,
-                            "openAppointmentSlots": 12,
+                            "openTimeslots": 34,
+                            "openAppointmentSlots": 34,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 17,
-                            "openAppointmentSlots": 17,
-                            "manufacturer": "Other"
+                            "openTimeslots": 80,
+                            "openAppointmentSlots": 80,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 19,
-                    "openFluTimeslots": 17,
-                    "openFluAppointmentSlots": 17,
-                    "openAppointmentSlots": 19,
+                    "openTimeslots": 130,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 130,
                     "name": "Anderson Mill H-E-B plus!",
                     "longitude": -97.82626,
                     "latitude": 30.45495,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3zQAE",
+                    "fluUrl": "",
                     "city": "AUSTIN"
                 },
                 {
                     "zip": "76542-1910",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gud8QAC",
                     "type": "store",
                     "street": "2511 TRIMMIER RD, SUITE 100",
                     "storeNumber": 581,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 178,
+                            "openAppointmentSlots": 178,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 168,
+                            "openAppointmentSlots": 168,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 396,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 396,
                     "name": "Trimmier H-E-B plus!",
                     "longitude": -97.7338,
                     "latitude": 31.0909,
@@ -3951,30 +4182,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 44,
-                            "openAppointmentSlots": 44,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 57,
-                            "openAppointmentSlots": 57,
+                            "openTimeslots": 119,
+                            "openAppointmentSlots": 119,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 70,
-                            "openAppointmentSlots": 70,
+                            "openTimeslots": 120,
+                            "openAppointmentSlots": 120,
                             "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 78,
-                            "openAppointmentSlots": 78,
-                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 249,
+                    "openTimeslots": 239,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 249,
+                    "openAppointmentSlots": 239,
                     "name": "Austin Highway H-E-B",
                     "longitude": -98.43132,
                     "latitude": 29.4937,
@@ -3990,20 +4211,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
+                            "openTimeslots": 15,
+                            "openAppointmentSlots": 15,
+                            "manufacturer": "Moderna"
+                        },
+                        {
                             "openTimeslots": 10,
                             "openAppointmentSlots": 10,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
+                            "openTimeslots": 16,
+                            "openAppointmentSlots": 16,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 20,
+                    "openTimeslots": 41,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 20,
+                    "openAppointmentSlots": 41,
                     "name": "Zapata Highway H-E-B",
                     "longitude": -99.47479,
                     "latitude": 27.47673,
@@ -4012,16 +4238,27 @@
                 },
                 {
                     "zip": "78253-0",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueVQAS",
                     "type": "store",
                     "street": "12125 ALAMO RANCH PKWY",
                     "storeNumber": 733,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 22,
+                            "openAppointmentSlots": 22,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 121,
+                            "openAppointmentSlots": 121,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 143,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 143,
                     "name": "Alamo Ranch H-E-B",
                     "longitude": -98.73294,
                     "latitude": 29.48572,
@@ -4030,41 +4267,20 @@
                 },
                 {
                     "zip": "76901-0",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueWQAS",
+                    "url": null,
                     "type": "store",
                     "street": "5502 SHERWOOD WAY",
                     "storeNumber": 734,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 16,
-                            "openAppointmentSlots": 16,
-                            "manufacturer": "Other"
-                        },
-                        {
-                            "openTimeslots": 15,
-                            "openAppointmentSlots": 15,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 16,
-                            "openAppointmentSlots": 16,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 16,
-                            "openAppointmentSlots": 16,
-                            "manufacturer": "Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 47,
-                    "openFluTimeslots": 16,
-                    "openFluAppointmentSlots": 16,
-                    "openAppointmentSlots": 47,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
                     "name": "Sherwood & FM 2288 H-E-B",
                     "longitude": -100.51103,
                     "latitude": 31.43158,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF1lQAE",
+                    "fluUrl": "",
                     "city": "SAN ANGELO"
                 },
                 {
@@ -4076,25 +4292,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 14,
-                            "openAppointmentSlots": 14,
+                            "openTimeslots": 44,
+                            "openAppointmentSlots": 44,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 48,
-                            "openAppointmentSlots": 48,
+                            "openTimeslots": 32,
+                            "openAppointmentSlots": 32,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 13,
-                            "openAppointmentSlots": 13,
+                            "openTimeslots": 19,
+                            "openAppointmentSlots": 19,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 75,
+                    "openTimeslots": 95,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 75,
+                    "openAppointmentSlots": 95,
                     "name": "Cross Creek Ranch H-E-B",
                     "longitude": -95.84788,
                     "latitude": 29.71936,
@@ -4110,20 +4326,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 66,
-                            "openAppointmentSlots": 66,
+                            "openTimeslots": 129,
+                            "openAppointmentSlots": 129,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 67,
-                            "openAppointmentSlots": 67,
+                            "openTimeslots": 180,
+                            "openAppointmentSlots": 180,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 133,
+                    "openTimeslots": 309,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 133,
+                    "openAppointmentSlots": 309,
                     "name": "The Heights H-E-B",
                     "longitude": -95.40865,
                     "latitude": 29.80735,
@@ -4132,16 +4348,27 @@
                 },
                 {
                     "zip": "77401-4019",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueaQAC",
                     "type": "store",
                     "street": "5106 BISSONNET",
                     "storeNumber": 738,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 7,
+                            "openAppointmentSlots": 7,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 4,
+                            "openAppointmentSlots": 4,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 11,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 11,
                     "name": "Bellaire Market H-E-B",
                     "longitude": -95.46938,
                     "latitude": 29.70764,
@@ -4157,20 +4384,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 69,
-                            "openAppointmentSlots": 69,
+                            "openTimeslots": 30,
+                            "openAppointmentSlots": 30,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 30,
+                            "openAppointmentSlots": 30,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 8,
-                            "openAppointmentSlots": 8,
+                            "openTimeslots": 28,
+                            "openAppointmentSlots": 28,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 77,
+                    "openTimeslots": 88,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 77,
+                    "openAppointmentSlots": 88,
                     "name": "Mont Belvieu H-E-B",
                     "longitude": -94.84973,
                     "latitude": 29.82755,
@@ -4179,32 +4411,16 @@
                 },
                 {
                     "zip": "78114-1851",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaKQAS",
+                    "url": null,
                     "type": "store",
                     "street": "925 10TH STREET",
                     "storeNumber": 25,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 8,
-                            "openAppointmentSlots": 8,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 19,
-                            "openAppointmentSlots": 19,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 26,
-                            "openAppointmentSlots": 26,
-                            "manufacturer": "Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 53,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 53,
+                    "openAppointmentSlots": 0,
                     "name": "Floresville H-E-B",
                     "longitude": -98.15681,
                     "latitude": 29.14284,
@@ -4220,25 +4436,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 78,
-                            "openAppointmentSlots": 78,
+                            "openTimeslots": 30,
+                            "openAppointmentSlots": 30,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 180,
-                            "openAppointmentSlots": 180,
+                            "openTimeslots": 319,
+                            "openAppointmentSlots": 319,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 90,
-                            "openAppointmentSlots": 90,
+                            "openTimeslots": 308,
+                            "openAppointmentSlots": 308,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 348,
+                    "openTimeslots": 657,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 348,
+                    "openAppointmentSlots": 657,
                     "name": "McCreless Market H-E-B plus!",
                     "longitude": -98.46115,
                     "latitude": 29.37828,
@@ -4247,26 +4463,31 @@
                 },
                 {
                     "zip": "77573-6750",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaMQAS",
                     "type": "store",
                     "street": "2955 SOUTH GULF FREEWAY",
                     "storeNumber": 28,
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 57,
-                            "openAppointmentSlots": 57,
-                            "manufacturer": "Other"
+                            "openTimeslots": 69,
+                            "openAppointmentSlots": 69,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 69,
+                            "openAppointmentSlots": 69,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 0,
-                    "openFluTimeslots": 57,
-                    "openFluAppointmentSlots": 57,
-                    "openAppointmentSlots": 0,
+                    "openTimeslots": 138,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 138,
                     "name": "Bay Colony H-E-B",
                     "longitude": -95.0926,
                     "latitude": 29.4677,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF42QAE",
+                    "fluUrl": "",
                     "city": "LEAGUE CITY"
                 },
                 {
@@ -4283,15 +4504,15 @@
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 18,
-                            "openAppointmentSlots": 18,
+                            "openTimeslots": 12,
+                            "openAppointmentSlots": 12,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 36,
+                    "openTimeslots": 30,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 36,
+                    "openAppointmentSlots": 30,
                     "name": "Westlake H-E-B",
                     "longitude": -97.82813,
                     "latitude": 30.2928,
@@ -4307,29 +4528,29 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 21,
-                            "openAppointmentSlots": 21,
+                            "openTimeslots": 25,
+                            "openAppointmentSlots": 25,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 23,
+                            "openAppointmentSlots": 23,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 21,
-                            "openAppointmentSlots": 21,
+                            "openTimeslots": 29,
+                            "openAppointmentSlots": 29,
                             "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 112,
-                            "openAppointmentSlots": 112,
-                            "manufacturer": "Other"
                         }
                     ],
-                    "openTimeslots": 42,
-                    "openFluTimeslots": 112,
-                    "openFluAppointmentSlots": 112,
-                    "openAppointmentSlots": 42,
+                    "openTimeslots": 77,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 77,
                     "name": "Spicewood Springs H-E-B",
                     "longitude": -97.7713,
                     "latitude": 30.43494,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF44QAE",
+                    "fluUrl": "",
                     "city": "AUSTIN"
                 },
                 {
@@ -4341,20 +4562,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 398,
-                            "openAppointmentSlots": 398,
+                            "openTimeslots": 275,
+                            "openAppointmentSlots": 275,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 237,
+                            "openAppointmentSlots": 237,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 18,
-                            "openAppointmentSlots": 18,
+                            "openTimeslots": 47,
+                            "openAppointmentSlots": 47,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 416,
+                    "openTimeslots": 559,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 416,
+                    "openAppointmentSlots": 559,
                     "name": "Red Bud Lane and Gattis School H-E-B",
                     "longitude": -97.61475,
                     "latitude": 30.49721,
@@ -4363,16 +4589,32 @@
                 },
                 {
                     "zip": "77957-2728",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubhQAC",
                     "type": "store",
                     "street": "301 N. WELLS ST",
                     "storeNumber": 351,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 34,
+                            "openAppointmentSlots": 34,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 30,
+                            "openAppointmentSlots": 30,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 34,
+                            "openAppointmentSlots": 34,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 98,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 98,
                     "name": "Edna H-E-B",
                     "longitude": -96.64731,
                     "latitude": 28.97947,
@@ -4388,34 +4630,29 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 247,
-                            "openAppointmentSlots": 247,
+                            "openTimeslots": 169,
+                            "openAppointmentSlots": 169,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 223,
-                            "openAppointmentSlots": 223,
+                            "openTimeslots": 152,
+                            "openAppointmentSlots": 152,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
+                            "openTimeslots": 89,
+                            "openAppointmentSlots": 89,
                             "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 78,
-                            "openAppointmentSlots": 78,
-                            "manufacturer": "Other"
                         }
                     ],
-                    "openTimeslots": 520,
-                    "openFluTimeslots": 78,
-                    "openFluAppointmentSlots": 78,
-                    "openAppointmentSlots": 520,
+                    "openTimeslots": 410,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 410,
                     "name": "Oak Park H-E-B",
                     "longitude": -98.45759,
                     "latitude": 29.50774,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF29QAE",
+                    "fluUrl": "",
                     "city": "SAN ANTONIO"
                 },
                 {
@@ -4427,20 +4664,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 687,
-                            "openAppointmentSlots": 687,
+                            "openTimeslots": 1272,
+                            "openAppointmentSlots": 1272,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 1236,
+                            "openAppointmentSlots": 1236,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 369,
-                            "openAppointmentSlots": 369,
+                            "openTimeslots": 316,
+                            "openAppointmentSlots": 316,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 1056,
+                    "openTimeslots": 2824,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 1056,
+                    "openAppointmentSlots": 2824,
                     "name": "620 and O'Connor H-E-B",
                     "longitude": -97.72218,
                     "latitude": 30.50028,
@@ -4449,19 +4691,40 @@
                 },
                 {
                     "zip": "78130-5722",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubkQAC",
                     "type": "store",
-                    "street": "651 S. WALNUT",
-                    "storeNumber": 380,
+                    "street": "651 S.WALNUT",
+                    "storeNumber": 775,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 25,
+                            "openAppointmentSlots": 25,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 30,
+                            "openAppointmentSlots": 30,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 31,
+                            "openAppointmentSlots": 31,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 136,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 136,
                     "name": "New Braunfels H-E-B at Walnut",
-                    "longitude": -98.12695,
-                    "latitude": 29.68878,
+                    "longitude": -98.12631,
+                    "latitude": 29.68903,
                     "fluUrl": "",
                     "city": "NEW BRAUNFELS"
                 },
@@ -4474,34 +4737,19 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 47,
-                            "openAppointmentSlots": 47,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 196,
-                            "openAppointmentSlots": 196,
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
                             "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 48,
-                            "openAppointmentSlots": 48,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 219,
-                            "openAppointmentSlots": 219,
-                            "manufacturer": "Other"
                         }
                     ],
-                    "openTimeslots": 291,
-                    "openFluTimeslots": 219,
-                    "openFluAppointmentSlots": 219,
-                    "openAppointmentSlots": 291,
+                    "openTimeslots": 20,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 20,
                     "name": "Harker Heights H-E-B",
                     "longitude": -97.65511,
                     "latitude": 31.07905,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2CQAU",
+                    "fluUrl": "",
                     "city": "HARKER HEIGHTS"
                 },
                 {
@@ -4513,25 +4761,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 34,
-                            "openAppointmentSlots": 34,
+                            "openTimeslots": 87,
+                            "openAppointmentSlots": 87,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 33,
-                            "openAppointmentSlots": 33,
+                            "openTimeslots": 70,
+                            "openAppointmentSlots": 70,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 19,
-                            "openAppointmentSlots": 19,
+                            "openTimeslots": 70,
+                            "openAppointmentSlots": 70,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 86,
+                    "openTimeslots": 227,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 86,
+                    "openAppointmentSlots": 227,
                     "name": "West Wadley H-E-B",
                     "longitude": -102.12562,
                     "latitude": 32.01955,
@@ -4547,48 +4795,59 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 208,
-                            "openAppointmentSlots": 208,
+                            "openTimeslots": 222,
+                            "openAppointmentSlots": 222,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 755,
-                            "openAppointmentSlots": 755,
+                            "openTimeslots": 279,
+                            "openAppointmentSlots": 279,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 129,
-                            "openAppointmentSlots": 129,
+                            "openTimeslots": 140,
+                            "openAppointmentSlots": 140,
                             "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 309,
-                            "openAppointmentSlots": 309,
-                            "manufacturer": "Other"
                         }
                     ],
-                    "openTimeslots": 1092,
-                    "openFluTimeslots": 309,
-                    "openFluAppointmentSlots": 309,
-                    "openAppointmentSlots": 1092,
+                    "openTimeslots": 641,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 641,
                     "name": "Montgomery at Walzem",
                     "longitude": -98.37092,
                     "latitude": 29.5105,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2JQAU",
+                    "fluUrl": "",
                     "city": "SAN ANTONIO"
                 },
                 {
                     "zip": "78212-1958",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuboQAC",
                     "type": "store",
                     "street": "300 OLMOS DRIVE",
                     "storeNumber": 385,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 53,
+                            "openAppointmentSlots": 53,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 163,
+                            "openAppointmentSlots": 163,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 9,
+                            "openAppointmentSlots": 9,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 225,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 225,
                     "name": "Olmos Park H-E-B",
                     "longitude": -98.497,
                     "latitude": 29.4707,
@@ -4615,16 +4874,22 @@
                 },
                 {
                     "zip": "78727-3901",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubqQAC",
                     "type": "store",
                     "street": "6001 WEST PARMER LANE",
                     "storeNumber": 388,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 9,
+                            "openAppointmentSlots": 9,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 9,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 9,
                     "name": "Parmer and McNeil H-E-B",
                     "longitude": -97.74278,
                     "latitude": 30.44181,
@@ -4640,15 +4905,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 91,
-                            "openAppointmentSlots": 91,
+                            "openTimeslots": 78,
+                            "openAppointmentSlots": 78,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 91,
+                    "openTimeslots": 78,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 91,
+                    "openAppointmentSlots": 78,
                     "name": "Mid County H-E-B",
                     "longitude": -93.9758,
                     "latitude": 29.966,
@@ -4682,34 +4947,29 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 26,
-                            "openAppointmentSlots": 26,
+                            "openTimeslots": 46,
+                            "openAppointmentSlots": 46,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 26,
-                            "openAppointmentSlots": 26,
+                            "openTimeslots": 45,
+                            "openAppointmentSlots": 45,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 8,
-                            "openAppointmentSlots": 8,
+                            "openTimeslots": 9,
+                            "openAppointmentSlots": 9,
                             "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 2,
-                            "openAppointmentSlots": 2,
-                            "manufacturer": "Other"
                         }
                     ],
-                    "openTimeslots": 60,
-                    "openFluTimeslots": 2,
-                    "openFluAppointmentSlots": 2,
-                    "openAppointmentSlots": 60,
+                    "openTimeslots": 100,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 100,
                     "name": "Leander H-E-B plus!",
                     "longitude": -97.8582,
                     "latitude": 30.58369,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3nQAE",
+                    "fluUrl": "",
                     "city": "LEANDER"
                 },
                 {
@@ -4721,34 +4981,29 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 35,
-                            "openAppointmentSlots": 35,
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 35,
-                            "openAppointmentSlots": 35,
+                            "openTimeslots": 49,
+                            "openAppointmentSlots": 49,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 35,
-                            "openAppointmentSlots": 35,
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
                             "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 35,
-                            "openAppointmentSlots": 35,
-                            "manufacturer": "Other"
                         }
                     ],
-                    "openTimeslots": 105,
-                    "openFluTimeslots": 35,
-                    "openFluAppointmentSlots": 35,
-                    "openAppointmentSlots": 105,
+                    "openTimeslots": 149,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 149,
                     "name": "Baytown H-E-B",
                     "longitude": -94.9788,
                     "latitude": 29.79503,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF1rQAE",
+                    "fluUrl": "",
                     "city": "BAYTOWN"
                 },
                 {
@@ -4760,20 +5015,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 23,
-                            "openAppointmentSlots": 23,
+                            "openTimeslots": 40,
+                            "openAppointmentSlots": 40,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 35,
-                            "openAppointmentSlots": 35,
+                            "openTimeslots": 89,
+                            "openAppointmentSlots": 89,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 39,
+                            "openAppointmentSlots": 39,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 58,
+                    "openTimeslots": 168,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 58,
+                    "openAppointmentSlots": 168,
                     "name": "Buffalo Heights H-E-B On Washington Ave",
                     "longitude": -95.39658,
                     "latitude": 29.76901,
@@ -4782,16 +5042,32 @@
                 },
                 {
                     "zip": "77096-4001",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueeQAC",
                     "type": "store",
                     "street": "4955 BEECHNUT STREET",
                     "storeNumber": 745,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 16,
+                            "openAppointmentSlots": 16,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 5,
+                            "openAppointmentSlots": 5,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 41,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 41,
                     "name": "Meyerland Market H-E-B",
                     "longitude": -95.46406,
                     "latitude": 29.68854,
@@ -4807,68 +5083,37 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 5,
-                            "openAppointmentSlots": 5,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 17,
-                            "openAppointmentSlots": 17,
+                            "openTimeslots": 14,
+                            "openAppointmentSlots": 14,
                             "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 15,
-                            "openAppointmentSlots": 15,
-                            "manufacturer": "Other"
                         }
                     ],
-                    "openTimeslots": 22,
-                    "openFluTimeslots": 15,
-                    "openFluAppointmentSlots": 15,
-                    "openAppointmentSlots": 22,
+                    "openTimeslots": 14,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 14,
                     "name": "Jones Crossing H-E-B",
                     "longitude": -96.32324,
                     "latitude": 30.58444,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF1uQAE",
+                    "fluUrl": "",
                     "city": "COLLEGE STATION"
                 },
                 {
                     "zip": "78589-3734",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaQQAS",
+                    "url": null,
                     "type": "store",
                     "street": "901 WEST EXPRESSWAY 83",
                     "storeNumber": 38,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 3,
-                            "openAppointmentSlots": 3,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 14,
-                            "openAppointmentSlots": 14,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 23,
-                            "openAppointmentSlots": 23,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
-                            "manufacturer": "Other"
-                        }
-                    ],
-                    "openTimeslots": 40,
-                    "openFluTimeslots": 50,
-                    "openFluAppointmentSlots": 50,
-                    "openAppointmentSlots": 40,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
                     "name": "San Juan H-E-B plus!",
                     "longitude": -98.1647,
                     "latitude": 26.20274,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4JQAU",
+                    "fluUrl": "",
                     "city": "SAN JUAN"
                 },
                 {
@@ -4898,20 +5143,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 145,
-                            "openAppointmentSlots": 145,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 105,
-                            "openAppointmentSlots": 105,
+                            "openTimeslots": 214,
+                            "openAppointmentSlots": 214,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 250,
+                    "openTimeslots": 214,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 250,
+                    "openAppointmentSlots": 214,
                     "name": "South Congress H-E-B",
                     "longitude": -97.7516,
                     "latitude": 30.23963,
@@ -4920,16 +5160,27 @@
                 },
                 {
                     "zip": "77706-7213",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaTQAS",
                     "type": "store",
                     "street": "3025 NORTH DOWLEN ROAD",
                     "storeNumber": 48,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 233,
+                            "openAppointmentSlots": 233,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 96,
+                            "openAppointmentSlots": 96,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 329,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 329,
                     "name": "Beaumont H-E-B plus!",
                     "longitude": -94.1685,
                     "latitude": 30.10501,
@@ -4938,32 +5189,16 @@
                 },
                 {
                     "zip": "78213-2714",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubrQAC",
+                    "url": null,
                     "type": "store",
                     "street": "6000 WEST AVENUE",
                     "storeNumber": 389,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 111,
-                            "openAppointmentSlots": 111,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 80,
-                            "openAppointmentSlots": 80,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 47,
-                            "openAppointmentSlots": 47,
-                            "manufacturer": "Pediatric_Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 238,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 238,
+                    "openAppointmentSlots": 0,
                     "name": "West Ave and Jackson Keller H-E-B",
                     "longitude": -98.52574,
                     "latitude": 29.51639,
@@ -4989,19 +5224,19 @@
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 118,
-                            "openAppointmentSlots": 118,
-                            "manufacturer": "Other"
+                            "openTimeslots": 60,
+                            "openAppointmentSlots": 60,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 30,
-                    "openFluTimeslots": 118,
-                    "openFluAppointmentSlots": 118,
-                    "openAppointmentSlots": 30,
+                    "openTimeslots": 90,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 90,
                     "name": "De Zavala H-E-B",
                     "longitude": -98.5889,
                     "latitude": 29.56222,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2OQAU",
+                    "fluUrl": "",
                     "city": "SAN ANTONIO"
                 },
                 {
@@ -5013,24 +5248,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 80,
-                            "openAppointmentSlots": 80,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 6,
+                            "openAppointmentSlots": 6,
+                            "manufacturer": "Moderna"
                         },
                         {
                             "openTimeslots": 158,
                             "openAppointmentSlots": 158,
-                            "manufacturer": "Other"
+                            "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 80,
-                    "openFluTimeslots": 158,
-                    "openFluAppointmentSlots": 158,
-                    "openAppointmentSlots": 80,
+                    "openTimeslots": 164,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 164,
                     "name": "281 and 1604 H-E-B",
                     "longitude": -98.46828,
                     "latitude": 29.60772,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2PQAU",
+                    "fluUrl": "",
                     "city": "SAN ANTONIO"
                 },
                 {
@@ -5042,25 +5277,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 124,
-                            "openAppointmentSlots": 124,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 248,
-                            "openAppointmentSlots": 248,
+                            "openTimeslots": 254,
+                            "openAppointmentSlots": 254,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 259,
-                            "openAppointmentSlots": 259,
+                            "openTimeslots": 255,
+                            "openAppointmentSlots": 255,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 249,
+                            "openAppointmentSlots": 249,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 631,
+                    "openTimeslots": 758,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 631,
+                    "openAppointmentSlots": 758,
                     "name": "Thousand Oaks H-E-B",
                     "longitude": -98.44108,
                     "latitude": 29.57781,
@@ -5076,82 +5311,72 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
+                            "openTimeslots": 134,
+                            "openAppointmentSlots": 134,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 51,
-                            "openAppointmentSlots": 51,
+                            "openTimeslots": 100,
+                            "openAppointmentSlots": 100,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 33,
-                            "openAppointmentSlots": 33,
-                            "manufacturer": "Other"
+                            "openTimeslots": 77,
+                            "openAppointmentSlots": 77,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 101,
-                    "openFluTimeslots": 33,
-                    "openFluAppointmentSlots": 33,
-                    "openAppointmentSlots": 101,
+                    "openTimeslots": 311,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 311,
                     "name": "Kingsville H-E-B",
                     "longitude": -97.86453,
                     "latitude": 27.51658,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2RQAU",
+                    "fluUrl": "",
                     "city": "KINGSVILLE"
                 },
                 {
                     "zip": "77382-2772",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudJQAS",
+                    "url": null,
                     "type": "store",
                     "street": "10777 KUYKENDAHL ROAD",
                     "storeNumber": 594,
-                    "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 7,
-                            "openAppointmentSlots": 7,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 6,
-                            "openAppointmentSlots": 6,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 21,
-                            "openAppointmentSlots": 21,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 45,
-                            "openAppointmentSlots": 45,
-                            "manufacturer": "Other"
-                        }
-                    ],
-                    "openTimeslots": 34,
-                    "openFluTimeslots": 45,
-                    "openFluAppointmentSlots": 45,
-                    "openAppointmentSlots": 34,
-                    "name": "Indian Springs H-E-B",
-                    "longitude": -95.53672,
-                    "latitude": 30.17791,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3pQAE",
-                    "city": "THE WOODLANDS"
-                },
-                {
-                    "zip": "77301-1220",
-                    "url": null,
-                    "type": "store",
-                    "street": "2108 NORTH FRAZIER",
-                    "storeNumber": 595,
                     "state": "TX",
                     "slotDetails": [],
                     "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
                     "openAppointmentSlots": 0,
+                    "name": "Indian Springs H-E-B",
+                    "longitude": -95.53672,
+                    "latitude": 30.17791,
+                    "fluUrl": "",
+                    "city": "THE WOODLANDS"
+                },
+                {
+                    "zip": "77301-1220",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudKQAS",
+                    "type": "store",
+                    "street": "2108 NORTH FRAZIER",
+                    "storeNumber": 595,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 504,
+                            "openAppointmentSlots": 504,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 501,
+                            "openAppointmentSlots": 501,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 1005,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 1005,
                     "name": "N Frazier At Loop 336 H-E-B",
                     "longitude": -95.46548,
                     "latitude": 30.33593,
@@ -5167,39 +5392,29 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
+                            "openTimeslots": 48,
+                            "openAppointmentSlots": 48,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
+                            "openTimeslots": 46,
+                            "openAppointmentSlots": 46,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 80,
-                            "openAppointmentSlots": 80,
+                            "openTimeslots": 96,
+                            "openAppointmentSlots": 96,
                             "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 112,
-                            "openAppointmentSlots": 112,
-                            "manufacturer": "Other"
                         }
                     ],
                     "openTimeslots": 190,
-                    "openFluTimeslots": 112,
-                    "openFluAppointmentSlots": 112,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
                     "openAppointmentSlots": 190,
                     "name": "Grand Parkway H-E-B plus!",
                     "longitude": -95.7739,
                     "latitude": 29.7144,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3rQAE",
+                    "fluUrl": "",
                     "city": "KATY"
                 },
                 {
@@ -5222,16 +5437,27 @@
                 },
                 {
                     "zip": "77388-3412",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudNQAS",
                     "type": "store",
                     "street": "2121 FM 2920",
                     "storeNumber": 610,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 14,
+                            "openAppointmentSlots": 14,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 25,
+                            "openAppointmentSlots": 25,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 39,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 39,
                     "name": "Spring Market H-E-B",
                     "longitude": -95.44894,
                     "latitude": 30.07042,
@@ -5247,30 +5473,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 18,
-                            "openAppointmentSlots": 18,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 42,
-                            "openAppointmentSlots": 42,
+                            "openTimeslots": 55,
+                            "openAppointmentSlots": 55,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 44,
-                            "openAppointmentSlots": 44,
+                            "openTimeslots": 56,
+                            "openAppointmentSlots": 56,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 12,
-                            "openAppointmentSlots": 12,
+                            "openTimeslots": 21,
+                            "openAppointmentSlots": 21,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 116,
+                    "openTimeslots": 132,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 116,
+                    "openAppointmentSlots": 132,
                     "name": "Dripping Springs H-E-B",
                     "longitude": -98.08146,
                     "latitude": 30.18968,
@@ -5279,32 +5500,16 @@
                 },
                 {
                     "zip": "78121-5922",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudPQAS",
+                    "url": null,
                     "type": "store",
                     "street": "14414 US HWY 87 WEST",
                     "storeNumber": 612,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 30,
-                            "openAppointmentSlots": 30,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 25,
-                            "openAppointmentSlots": 25,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 5,
-                            "openAppointmentSlots": 5,
-                            "manufacturer": "Pediatric_Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 60,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 60,
+                    "openAppointmentSlots": 0,
                     "name": "La Vernia H-E-B",
                     "longitude": -98.13514,
                     "latitude": 29.35803,
@@ -5349,16 +5554,27 @@
                 },
                 {
                     "zip": "76087-0",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueiQAC",
                     "type": "store",
                     "street": "100 HUDSON OAKS DR",
                     "storeNumber": 752,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 933,
+                            "openAppointmentSlots": 933,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 934,
+                            "openAppointmentSlots": 934,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 1867,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 1867,
                     "name": "Hudson Oaks H-E-B",
                     "longitude": -97.69733,
                     "latitude": 32.75831,
@@ -5367,16 +5583,27 @@
                 },
                 {
                     "zip": "77004-0",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuejQAC",
                     "type": "store",
                     "street": "6055 SOUTH FREEWAY",
                     "storeNumber": 756,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 23,
+                            "openAppointmentSlots": 23,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 18,
+                            "openAppointmentSlots": 18,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 41,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 41,
                     "name": "MacGregor Market H-E-B",
                     "longitude": -95.37644,
                     "latitude": 29.71432,
@@ -5392,25 +5619,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 190,
-                            "openAppointmentSlots": 190,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 195,
-                            "openAppointmentSlots": 195,
+                            "openTimeslots": 120,
+                            "openAppointmentSlots": 120,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 194,
-                            "openAppointmentSlots": 194,
+                            "openTimeslots": 160,
+                            "openAppointmentSlots": 160,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 579,
+                    "openTimeslots": 280,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 579,
+                    "openAppointmentSlots": 280,
                     "name": "Harper's Trace H-E-B",
                     "longitude": -95.42563,
                     "latitude": 30.20692,
@@ -5426,48 +5648,54 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 36,
-                            "openAppointmentSlots": 36,
+                            "openTimeslots": 45,
+                            "openAppointmentSlots": 45,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 35,
-                            "openAppointmentSlots": 35,
+                            "openTimeslots": 40,
+                            "openAppointmentSlots": 40,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 12,
-                            "openAppointmentSlots": 12,
+                            "openTimeslots": 23,
+                            "openAppointmentSlots": 23,
                             "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 36,
-                            "openAppointmentSlots": 36,
-                            "manufacturer": "Other"
                         }
                     ],
-                    "openTimeslots": 83,
-                    "openFluTimeslots": 36,
-                    "openFluAppointmentSlots": 36,
-                    "openAppointmentSlots": 83,
+                    "openTimeslots": 108,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 108,
                     "name": "H-E-B Market at Northpark",
                     "longitude": -95.25033,
                     "latitude": 30.06864,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2FQAU",
+                    "fluUrl": "",
                     "city": "KINGWOOD"
                 },
                 {
                     "zip": "78253-0",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuemQAC",
                     "type": "store",
                     "street": "14325 POTRANCO RD.",
                     "storeNumber": 771,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 158,
+                            "openAppointmentSlots": 158,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 157,
+                            "openAppointmentSlots": 157,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 315,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 315,
                     "name": "211 and Potranco H-E-B",
                     "longitude": -98.77966,
                     "latitude": 29.42367,
@@ -5483,20 +5711,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 84,
-                            "openAppointmentSlots": 84,
+                            "openTimeslots": 37,
+                            "openAppointmentSlots": 37,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 170,
+                            "openAppointmentSlots": 170,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 39,
-                            "openAppointmentSlots": 39,
+                            "openTimeslots": 89,
+                            "openAppointmentSlots": 89,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 123,
+                    "openTimeslots": 296,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 123,
+                    "openAppointmentSlots": 296,
                     "name": "Lubbock H-E-B",
                     "longitude": -101.90638,
                     "latitude": 33.48958,
@@ -5505,16 +5738,27 @@
                 },
                 {
                     "zip": "79720-5437",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaUQAS",
                     "type": "store",
                     "street": "2000 SOUTH GREGG",
                     "storeNumber": 51,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 10,
+                            "openAppointmentSlots": 10,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 10,
+                            "openAppointmentSlots": 10,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 20,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 20,
                     "name": "Big Spring H-E-B",
                     "longitude": -101.47211,
                     "latitude": 32.23493,
@@ -5530,25 +5774,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 220,
-                            "openAppointmentSlots": 220,
+                            "openTimeslots": 118,
+                            "openAppointmentSlots": 118,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 199,
-                            "openAppointmentSlots": 199,
+                            "openTimeslots": 120,
+                            "openAppointmentSlots": 120,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 240,
-                            "openAppointmentSlots": 240,
+                            "openTimeslots": 120,
+                            "openAppointmentSlots": 120,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 659,
+                    "openTimeslots": 358,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 659,
+                    "openAppointmentSlots": 358,
                     "name": "Sherwood Avenue N H-E-B",
                     "longitude": -100.47977,
                     "latitude": 31.44511,
@@ -5557,16 +5801,32 @@
                 },
                 {
                     "zip": "77075-2246",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaWQAS",
                     "type": "store",
                     "street": "9828 BLACKHAWK BLVD.",
                     "storeNumber": 54,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 24,
+                            "openAppointmentSlots": 24,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 21,
+                            "openAppointmentSlots": 21,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 10,
+                            "openAppointmentSlots": 10,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 55,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 55,
                     "name": "Blackhawk H-E-B",
                     "longitude": -95.24868,
                     "latitude": 29.60234,
@@ -5582,15 +5842,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 14,
-                            "openAppointmentSlots": 14,
+                            "openTimeslots": 5,
+                            "openAppointmentSlots": 5,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 21,
+                            "openAppointmentSlots": 21,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 14,
+                    "openTimeslots": 26,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 14,
+                    "openAppointmentSlots": 26,
                     "name": "Flour Bluff H-E-B plus!",
                     "longitude": -97.28288,
                     "latitude": 27.66767,
@@ -5606,25 +5871,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 342,
-                            "openAppointmentSlots": 342,
+                            "openTimeslots": 484,
+                            "openAppointmentSlots": 484,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 342,
-                            "openAppointmentSlots": 342,
+                            "openTimeslots": 489,
+                            "openAppointmentSlots": 489,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 273,
-                            "openAppointmentSlots": 273,
+                            "openTimeslots": 312,
+                            "openAppointmentSlots": 312,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 957,
+                    "openTimeslots": 1285,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 957,
+                    "openAppointmentSlots": 1285,
                     "name": "Pearland H-E-B plus!",
                     "longitude": -95.39002,
                     "latitude": 29.55932,
@@ -5640,20 +5905,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 25,
-                            "openAppointmentSlots": 25,
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 6,
-                            "openAppointmentSlots": 6,
+                            "openTimeslots": 31,
+                            "openAppointmentSlots": 31,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 25,
+                            "openAppointmentSlots": 25,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 31,
+                    "openTimeslots": 76,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 31,
+                    "openAppointmentSlots": 76,
                     "name": "19th and Meridian H-E-B",
                     "longitude": -97.17255,
                     "latitude": 31.5804,
@@ -5662,26 +5932,31 @@
                 },
                 {
                     "zip": "78749-6507",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaaQAC",
                     "type": "store",
                     "street": "5800 W. SLAUGHTER LANE",
                     "storeNumber": 68,
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 113,
-                            "openAppointmentSlots": 113,
-                            "manufacturer": "Other"
+                            "openTimeslots": 60,
+                            "openAppointmentSlots": 60,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 48,
+                            "openAppointmentSlots": 48,
+                            "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 0,
-                    "openFluTimeslots": 113,
-                    "openFluAppointmentSlots": 113,
-                    "openAppointmentSlots": 0,
+                    "openTimeslots": 108,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 108,
                     "name": "Slaughter and Escarpment H-E-B",
                     "longitude": -97.87642,
                     "latitude": 30.20247,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4TQAU",
+                    "fluUrl": "",
                     "city": "AUSTIN"
                 },
                 {
@@ -5722,16 +5997,32 @@
                 },
                 {
                     "zip": "78738-6517",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubxQAC",
                     "type": "store",
                     "street": "12400 W HIGHWAY 71",
                     "storeNumber": 404,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 36,
+                            "openAppointmentSlots": 36,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 12,
+                            "openAppointmentSlots": 12,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 7,
+                            "openAppointmentSlots": 7,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 55,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 55,
                     "name": "Bee Cave H-E-B",
                     "longitude": -97.93238,
                     "latitude": 30.30489,
@@ -5747,25 +6038,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 68,
-                            "openAppointmentSlots": 68,
+                            "openTimeslots": 9,
+                            "openAppointmentSlots": 9,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 68,
-                            "openAppointmentSlots": 68,
+                            "openTimeslots": 16,
+                            "openAppointmentSlots": 16,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 63,
-                            "openAppointmentSlots": 63,
+                            "openTimeslots": 19,
+                            "openAppointmentSlots": 19,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 199,
+                    "openTimeslots": 44,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 199,
+                    "openAppointmentSlots": 44,
                     "name": "Marbach and 410 H-E-B plus!",
                     "longitude": -98.65227,
                     "latitude": 29.41837,
@@ -5774,65 +6065,54 @@
                 },
                 {
                     "zip": "77044-6087",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudRQAS",
+                    "url": null,
                     "type": "store",
                     "street": "12680 W.LAKE HOUSTON PKWY",
                     "storeNumber": 614,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 55,
-                            "openAppointmentSlots": 55,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 115,
-                            "openAppointmentSlots": 115,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 84,
-                            "openAppointmentSlots": 84,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 42,
-                            "openAppointmentSlots": 42,
-                            "manufacturer": "Other"
-                        }
-                    ],
-                    "openTimeslots": 254,
-                    "openFluTimeslots": 42,
-                    "openFluAppointmentSlots": 42,
-                    "openAppointmentSlots": 254,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
                     "name": "Summerwood Market H-E-B",
                     "longitude": -95.19697,
                     "latitude": 29.92325,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF49QAE",
+                    "fluUrl": "",
                     "city": "HOUSTON"
                 },
                 {
                     "zip": "77494-5904",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudSQAS",
                     "type": "store",
                     "street": "25675 NELSON WAY",
                     "storeNumber": 615,
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 300,
-                            "openAppointmentSlots": 300,
-                            "manufacturer": "Other"
+                            "openTimeslots": 29,
+                            "openAppointmentSlots": 29,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 30,
+                            "openAppointmentSlots": 30,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 27,
+                            "openAppointmentSlots": 27,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 0,
-                    "openFluTimeslots": 300,
-                    "openFluAppointmentSlots": 300,
-                    "openAppointmentSlots": 0,
+                    "openTimeslots": 86,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 86,
                     "name": "Katy Market H-E-B",
                     "longitude": -95.82005,
                     "latitude": 29.77644,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4AQAU",
+                    "fluUrl": "",
                     "city": "KATY"
                 },
                 {
@@ -5898,25 +6178,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 154,
-                            "openAppointmentSlots": 154,
+                            "openTimeslots": 159,
+                            "openAppointmentSlots": 159,
                             "manufacturer": "Moderna"
                         },
                         {
                             "openTimeslots": 159,
                             "openAppointmentSlots": 159,
                             "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 20,
-                            "openAppointmentSlots": 20,
-                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 333,
+                    "openTimeslots": 318,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 333,
+                    "openAppointmentSlots": 318,
                     "name": "H-E-B Pharmacy at the UTHTB",
                     "longitude": -97.73507,
                     "latitude": 30.27747,
@@ -5932,34 +6207,29 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 60,
-                            "openAppointmentSlots": 60,
+                            "openTimeslots": 38,
+                            "openAppointmentSlots": 38,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 105,
-                            "openAppointmentSlots": 105,
+                            "openTimeslots": 82,
+                            "openAppointmentSlots": 82,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 29,
-                            "openAppointmentSlots": 29,
+                            "openTimeslots": 51,
+                            "openAppointmentSlots": 51,
                             "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 195,
-                            "openAppointmentSlots": 195,
-                            "manufacturer": "Other"
                         }
                     ],
-                    "openTimeslots": 194,
-                    "openFluTimeslots": 195,
-                    "openFluAppointmentSlots": 195,
-                    "openAppointmentSlots": 194,
+                    "openTimeslots": 171,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 171,
                     "name": "Abilene H-E-B",
                     "longitude": -99.75934,
                     "latitude": 32.43348,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4VQAU",
+                    "fluUrl": "",
                     "city": "ABILENE"
                 },
                 {
@@ -5989,20 +6259,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 73,
-                            "openAppointmentSlots": 73,
+                            "openTimeslots": 78,
+                            "openAppointmentSlots": 78,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 81,
-                            "openAppointmentSlots": 81,
+                            "openTimeslots": 179,
+                            "openAppointmentSlots": 179,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 52,
+                            "openAppointmentSlots": 52,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 154,
+                    "openTimeslots": 309,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 154,
+                    "openAppointmentSlots": 309,
                     "name": "Boerne H-E-B plus!",
                     "longitude": -98.73481,
                     "latitude": 29.78173,
@@ -6018,25 +6293,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 20,
-                            "openAppointmentSlots": 20,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 54,
-                            "openAppointmentSlots": 54,
+                            "openTimeslots": 40,
+                            "openAppointmentSlots": 40,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 66,
-                            "openAppointmentSlots": 66,
+                            "openTimeslots": 69,
+                            "openAppointmentSlots": 69,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 30,
+                            "openAppointmentSlots": 30,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 140,
+                    "openTimeslots": 139,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 140,
+                    "openAppointmentSlots": 139,
                     "name": "Bulverde H-E-B plus!",
                     "longitude": -98.43022,
                     "latitude": 29.79882,
@@ -6117,16 +6392,32 @@
                 },
                 {
                     "zip": "77406-0",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P00000003PiQAI",
                     "type": "store",
                     "street": "9211 FM 723 RD",
                     "storeNumber": 749,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 48,
+                            "openAppointmentSlots": 48,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 38,
+                            "openAppointmentSlots": 38,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 136,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 136,
                     "name": "Spring Green Market H-E-B",
                     "longitude": -95.81427,
                     "latitude": 29.69558,
@@ -6142,20 +6433,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 83,
-                            "openAppointmentSlots": 83,
+                            "openTimeslots": 94,
+                            "openAppointmentSlots": 94,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 55,
-                            "openAppointmentSlots": 55,
+                            "openTimeslots": 96,
+                            "openAppointmentSlots": 96,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 59,
+                            "openAppointmentSlots": 59,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 138,
+                    "openTimeslots": 249,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 138,
+                    "openAppointmentSlots": 249,
                     "name": "New Braunfels H-E-B at Hwy 46",
                     "longitude": -98.16041,
                     "latitude": 29.71309,
@@ -6171,39 +6467,29 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 216,
-                            "openAppointmentSlots": 216,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 432,
-                            "openAppointmentSlots": 432,
+                            "openTimeslots": 437,
+                            "openAppointmentSlots": 437,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 534,
-                            "openAppointmentSlots": 534,
+                            "openTimeslots": 451,
+                            "openAppointmentSlots": 451,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 32,
-                            "openAppointmentSlots": 32,
+                            "openTimeslots": 85,
+                            "openAppointmentSlots": 85,
                             "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 432,
-                            "openAppointmentSlots": 432,
-                            "manufacturer": "Other"
                         }
                     ],
-                    "openTimeslots": 1214,
-                    "openFluTimeslots": 432,
-                    "openFluAppointmentSlots": 432,
-                    "openAppointmentSlots": 1214,
+                    "openTimeslots": 973,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 973,
                     "name": "Zarzamora and Military H-E-B plus!",
                     "longitude": -98.5339,
                     "latitude": 29.35787,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4nQAE",
+                    "fluUrl": "",
                     "city": "SAN ANTONIO"
                 },
                 {
@@ -6213,46 +6499,29 @@
                     "street": "10718 POTRANCO ROAD",
                     "storeNumber": 85,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 336,
-                            "openAppointmentSlots": 336,
-                            "manufacturer": "Other"
-                        }
-                    ],
+                    "slotDetails": [],
                     "openTimeslots": 0,
-                    "openFluTimeslots": 336,
-                    "openFluAppointmentSlots": 336,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
                     "openAppointmentSlots": 0,
                     "name": "Potranco and 1604 H-E-B plus!",
                     "longitude": -98.70445,
                     "latitude": 29.43536,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4oQAE",
+                    "fluUrl": "",
                     "city": "SAN ANTONIO"
                 },
                 {
                     "zip": "78028-0",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuahQAC",
+                    "url": null,
                     "type": "store",
                     "street": "300 W. MAIN ST.",
                     "storeNumber": 770,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 120,
-                            "openAppointmentSlots": 120,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 131,
-                            "openAppointmentSlots": 131,
-                            "manufacturer": "Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 251,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 251,
+                    "openAppointmentSlots": 0,
                     "name": "Kerrville H-E-B On Main Street",
                     "longitude": -99.14287,
                     "latitude": 30.05056,
@@ -6279,16 +6548,37 @@
                 },
                 {
                     "zip": "77904-1767",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuajQAC",
                     "type": "store",
                     "street": "6106 N. NAVARRO",
                     "storeNumber": 92,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 195,
+                            "openAppointmentSlots": 195,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 195,
+                            "openAppointmentSlots": 195,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 192,
+                            "openAppointmentSlots": 192,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 117,
+                            "openAppointmentSlots": 117,
+                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 699,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 699,
                     "name": "Victoria H-E-B plus!",
                     "longitude": -96.99736,
                     "latitude": 28.85159,
@@ -6304,48 +6594,54 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 33,
-                            "openAppointmentSlots": 33,
-                            "manufacturer": "Other"
+                            "openTimeslots": 62,
+                            "openAppointmentSlots": 62,
+                            "manufacturer": "Moderna"
                         },
+                        {
+                            "openTimeslots": 57,
+                            "openAppointmentSlots": 57,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 40,
+                            "openAppointmentSlots": 40,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 159,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 159,
+                    "name": "Bunker Hill H-E-B",
+                    "longitude": -95.53206,
+                    "latitude": 29.78485,
+                    "fluUrl": "",
+                    "city": "HOUSTON"
+                },
+                {
+                    "zip": "77459-6931",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuatQAC",
+                    "type": "store",
+                    "street": "8900 HWY 6",
+                    "storeNumber": 110,
+                    "state": "TX",
+                    "slotDetails": [
                         {
                             "openTimeslots": 55,
                             "openAppointmentSlots": 55,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
+                            "openTimeslots": 49,
+                            "openAppointmentSlots": 49,
                             "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 20,
-                            "openAppointmentSlots": 20,
-                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 125,
-                    "openFluTimeslots": 33,
-                    "openFluAppointmentSlots": 33,
-                    "openAppointmentSlots": 125,
-                    "name": "Bunker Hill H-E-B",
-                    "longitude": -95.53206,
-                    "latitude": 29.78485,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF0aQAE",
-                    "city": "HOUSTON"
-                },
-                {
-                    "zip": "77459-6931",
-                    "url": null,
-                    "type": "store",
-                    "street": "8900 HWY 6",
-                    "storeNumber": 110,
-                    "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "openTimeslots": 104,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 104,
                     "name": "Sienna Market H-E-B",
                     "longitude": -95.53497,
                     "latitude": 29.53928,
@@ -6354,16 +6650,32 @@
                 },
                 {
                     "zip": "78550-7708",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuauQAC",
                     "type": "store",
                     "street": "1213 S. COMMERCE",
                     "storeNumber": 136,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 14,
+                            "openAppointmentSlots": 14,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 61,
+                            "openAppointmentSlots": 61,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 54,
+                            "openAppointmentSlots": 54,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 129,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 129,
                     "name": "Southland and 12th St H-E-B",
                     "longitude": -97.68171,
                     "latitude": 26.18251,
@@ -6390,16 +6702,27 @@
                 },
                 {
                     "zip": "78723-2924",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuawQAC",
                     "type": "store",
                     "street": "7112 ED BLUESTEIN_#125",
                     "storeNumber": 161,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 47,
+                            "openAppointmentSlots": 47,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 222,
+                            "openAppointmentSlots": 222,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 269,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 269,
                     "name": "Ed Bluestein H-E-B",
                     "longitude": -97.66465,
                     "latitude": 30.31211,
@@ -6444,16 +6767,27 @@
                 },
                 {
                     "zip": "78045-6596",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GualQAC",
                     "type": "store",
                     "street": "1911 NE BOB BULLOCK LOOP",
                     "storeNumber": 95,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 15,
+                            "openAppointmentSlots": 15,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 4,
+                            "openAppointmentSlots": 4,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 19,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 19,
                     "name": "Laredo H-E-B plus!",
                     "longitude": -99.47435,
                     "latitude": 27.60863,
@@ -6487,34 +6821,29 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 56,
-                            "openAppointmentSlots": 56,
+                            "openTimeslots": 175,
+                            "openAppointmentSlots": 175,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 57,
-                            "openAppointmentSlots": 57,
+                            "openTimeslots": 179,
+                            "openAppointmentSlots": 179,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 68,
-                            "openAppointmentSlots": 68,
+                            "openTimeslots": 180,
+                            "openAppointmentSlots": 180,
                             "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 80,
-                            "openAppointmentSlots": 80,
-                            "manufacturer": "Other"
                         }
                     ],
-                    "openTimeslots": 181,
-                    "openFluTimeslots": 80,
-                    "openFluAppointmentSlots": 80,
-                    "openAppointmentSlots": 181,
+                    "openTimeslots": 534,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 534,
                     "name": "Vintage Park Market H-E-B",
                     "longitude": -95.57661,
                     "latitude": 29.9967,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4vQAE",
+                    "fluUrl": "",
                     "city": "HOUSTON"
                 },
                 {
@@ -6526,34 +6855,29 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 167,
-                            "openAppointmentSlots": 167,
+                            "openTimeslots": 95,
+                            "openAppointmentSlots": 95,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 488,
-                            "openAppointmentSlots": 488,
+                            "openTimeslots": 224,
+                            "openAppointmentSlots": 224,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 90,
-                            "openAppointmentSlots": 90,
+                            "openTimeslots": 49,
+                            "openAppointmentSlots": 49,
                             "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 506,
-                            "openAppointmentSlots": 506,
-                            "manufacturer": "Other"
                         }
                     ],
-                    "openTimeslots": 745,
-                    "openFluTimeslots": 506,
-                    "openFluAppointmentSlots": 506,
-                    "openAppointmentSlots": 745,
+                    "openTimeslots": 368,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 368,
                     "name": "Alon Market H-E-B",
                     "longitude": -98.53463,
                     "latitude": 29.55254,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4wQAE",
+                    "fluUrl": "",
                     "city": "SAN ANTONIO"
                 },
                 {
@@ -6565,20 +6889,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 11,
-                            "openAppointmentSlots": 11,
+                            "openTimeslots": 15,
+                            "openAppointmentSlots": 15,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 15,
-                            "openAppointmentSlots": 15,
+                            "openTimeslots": 24,
+                            "openAppointmentSlots": 24,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 26,
+                    "openTimeslots": 39,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 26,
+                    "openAppointmentSlots": 39,
                     "name": "Brodie Lane H-E-B",
                     "longitude": -97.83076,
                     "latitude": 30.21489,
@@ -6612,34 +6936,29 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 65,
-                            "openAppointmentSlots": 65,
+                            "openTimeslots": 35,
+                            "openAppointmentSlots": 35,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 79,
+                            "openAppointmentSlots": 79,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 67,
-                            "openAppointmentSlots": 67,
+                            "openTimeslots": 80,
+                            "openAppointmentSlots": 80,
                             "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 30,
-                            "openAppointmentSlots": 30,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 158,
-                            "openAppointmentSlots": 158,
-                            "manufacturer": "Other"
                         }
                     ],
-                    "openTimeslots": 162,
-                    "openFluTimeslots": 158,
-                    "openFluAppointmentSlots": 158,
-                    "openAppointmentSlots": 162,
+                    "openTimeslots": 194,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 194,
                     "name": "Montrose Market H-E-B",
                     "longitude": -95.40284,
                     "latitude": 29.7379,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4YQAU",
+                    "fluUrl": "",
                     "city": "HOUSTON"
                 },
                 {
@@ -6651,25 +6970,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 116,
-                            "openAppointmentSlots": 116,
+                            "openTimeslots": 104,
+                            "openAppointmentSlots": 104,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 118,
-                            "openAppointmentSlots": 118,
+                            "openTimeslots": 104,
+                            "openAppointmentSlots": 104,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 58,
-                            "openAppointmentSlots": 58,
+                            "openTimeslots": 104,
+                            "openAppointmentSlots": 104,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 292,
+                    "openTimeslots": 312,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 292,
+                    "openAppointmentSlots": 312,
                     "name": "Granbury H-E-B",
                     "longitude": -97.73026,
                     "latitude": 32.45528,
@@ -6685,25 +7004,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 80,
-                            "openAppointmentSlots": 80,
+                            "openTimeslots": 101,
+                            "openAppointmentSlots": 101,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 66,
-                            "openAppointmentSlots": 66,
+                            "openTimeslots": 64,
+                            "openAppointmentSlots": 64,
                             "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 9,
-                            "openAppointmentSlots": 9,
-                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 155,
+                    "openTimeslots": 165,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 155,
+                    "openAppointmentSlots": 165,
                     "name": "North Woodlands Market H-E-B",
                     "longitude": -95.51296,
                     "latitude": 30.22918,
@@ -6773,25 +7087,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 9,
-                            "openAppointmentSlots": 9,
+                            "openTimeslots": 16,
+                            "openAppointmentSlots": 16,
                             "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 24,
-                            "openAppointmentSlots": 24,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
-                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 43,
+                    "openTimeslots": 16,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 43,
+                    "openAppointmentSlots": 16,
                     "name": "Kostoryz and Gollihar H-E-B",
                     "longitude": -97.40516,
                     "latitude": 27.73917,
@@ -6800,16 +7104,32 @@
                 },
                 {
                     "zip": "77803-1828",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudiQAC",
                     "type": "store",
                     "street": "1609 NORTH TEXAS AVENUE",
                     "storeNumber": 644,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 18,
+                            "openAppointmentSlots": 18,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 10,
+                            "openAppointmentSlots": 10,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 48,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 48,
                     "name": "Hwy 21 and N Texas Ave H-E-B",
                     "longitude": -96.3717,
                     "latitude": 30.6901,
@@ -6836,37 +7156,16 @@
                 },
                 {
                     "zip": "78028-5916",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudkQAC",
+                    "url": null,
                     "type": "store",
                     "street": "313 SIDNEY BAKER SOUTH",
                     "storeNumber": 655,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 200,
-                            "openAppointmentSlots": 200,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 198,
-                            "openAppointmentSlots": 198,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 197,
-                            "openAppointmentSlots": 197,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 117,
-                            "openAppointmentSlots": 117,
-                            "manufacturer": "Pediatric_Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 712,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 712,
+                    "openAppointmentSlots": 0,
                     "name": "Kerrville H-E-B on Sidney Baker St",
                     "longitude": -99.14342,
                     "latitude": 30.04152,
@@ -6882,34 +7181,29 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 35,
-                            "openAppointmentSlots": 35,
-                            "manufacturer": "Other"
-                        },
-                        {
-                            "openTimeslots": 34,
-                            "openAppointmentSlots": 34,
+                            "openTimeslots": 31,
+                            "openAppointmentSlots": 31,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 34,
-                            "openAppointmentSlots": 34,
+                            "openTimeslots": 38,
+                            "openAppointmentSlots": 38,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 35,
-                            "openAppointmentSlots": 35,
+                            "openTimeslots": 44,
+                            "openAppointmentSlots": 44,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 103,
-                    "openFluTimeslots": 35,
-                    "openFluAppointmentSlots": 35,
-                    "openAppointmentSlots": 103,
+                    "openTimeslots": 113,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 113,
                     "name": "Morgan and Grimes H-E-B",
                     "longitude": -97.67639,
                     "latitude": 26.20337,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF0gQAE",
+                    "fluUrl": "",
                     "city": "HARLINGEN"
                 },
                 {
@@ -6932,16 +7226,27 @@
                 },
                 {
                     "zip": "78216-7202",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gub0QAC",
                     "type": "store",
                     "street": "6839 SAN PEDRO",
                     "storeNumber": 178,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 13,
+                            "openAppointmentSlots": 13,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 9,
+                            "openAppointmentSlots": 9,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 22,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 22,
                     "name": "San Pedro and Oblate H-E-B",
                     "longitude": -98.4995,
                     "latitude": 29.50282,
@@ -6975,20 +7280,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 47,
-                            "openAppointmentSlots": 47,
+                            "openTimeslots": 118,
+                            "openAppointmentSlots": 118,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 46,
-                            "openAppointmentSlots": 46,
+                            "openTimeslots": 101,
+                            "openAppointmentSlots": 101,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 93,
+                    "openTimeslots": 219,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 93,
+                    "openAppointmentSlots": 219,
                     "name": "Lamar and Rundberg H-E-B",
                     "longitude": -97.69689,
                     "latitude": 30.36357,
@@ -7015,16 +7320,22 @@
                 },
                 {
                     "zip": "78041-5435",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gub4QAC",
                     "type": "store",
                     "street": "2310 E SAUNDERS ST",
                     "storeNumber": 186,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 38,
+                            "openAppointmentSlots": 38,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 38,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 38,
                     "name": "Saunders St H-E-B",
                     "longitude": -99.47131,
                     "latitude": 27.53071,
@@ -7033,16 +7344,32 @@
                 },
                 {
                     "zip": "78745-0",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P00000003PYQAY",
                     "type": "store",
                     "street": "8801 SOUTH CONGRESS AVENUE",
                     "storeNumber": 710,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 52,
+                            "openAppointmentSlots": 52,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 52,
+                            "openAppointmentSlots": 52,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 29,
+                            "openAppointmentSlots": 29,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 133,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 133,
                     "name": "Slaughter and South Congress H-E-B",
                     "longitude": -97.78723,
                     "latitude": 30.16862,
@@ -7051,16 +7378,27 @@
                 },
                 {
                     "zip": "78220-2530",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuapQAC",
                     "type": "store",
                     "street": "1015 S.W.W. WHITE ROAD",
                     "storeNumber": 106,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 110,
+                            "openAppointmentSlots": 110,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 110,
+                            "openAppointmentSlots": 110,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 220,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 220,
                     "name": "W. W. White H-E-B",
                     "longitude": -98.40568,
                     "latitude": 29.41476,
@@ -7087,16 +7425,32 @@
                 },
                 {
                     "zip": "78258-7587",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuarQAC",
                     "type": "store",
                     "street": "20935 US HIGHWAY 281 NORTH",
                     "storeNumber": 108,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 240,
+                            "openAppointmentSlots": 240,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 154,
+                            "openAppointmentSlots": 154,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 18,
+                            "openAppointmentSlots": 18,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 412,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 412,
                     "name": "281 and Evans Road H-E-B plus!",
                     "longitude": -98.45756,
                     "latitude": 29.63886,
@@ -7105,16 +7459,32 @@
                 },
                 {
                     "zip": "77433-4288",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudlQAC",
                     "type": "store",
                     "street": "28550 US- 290",
                     "storeNumber": 656,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 310,
+                            "openAppointmentSlots": 310,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 335,
+                            "openAppointmentSlots": 335,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 84,
+                            "openAppointmentSlots": 84,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 729,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 729,
                     "name": "Fairfield Market H-E-B",
                     "longitude": -95.74599,
                     "latitude": 29.9925,
@@ -7130,48 +7500,58 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 2,
-                            "openAppointmentSlots": 2,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 6,
+                            "openAppointmentSlots": 6,
+                            "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 13,
-                            "openAppointmentSlots": 13,
-                            "manufacturer": "Other"
+                            "openTimeslots": 14,
+                            "openAppointmentSlots": 14,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 18,
+                            "openAppointmentSlots": 18,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 2,
-                    "openFluTimeslots": 13,
-                    "openFluAppointmentSlots": 13,
-                    "openAppointmentSlots": 2,
+                    "openTimeslots": 38,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 38,
                     "name": "Jones and West H-E-B",
                     "longitude": -95.5859,
                     "latitude": 29.91104,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4jQAE",
+                    "fluUrl": "",
                     "city": "HOUSTON"
                 },
                 {
                     "zip": "78258-0",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudnQAC",
                     "type": "store",
                     "street": "23635 WILDERNESS OAK",
                     "storeNumber": 658,
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 6,
-                            "openAppointmentSlots": 6,
-                            "manufacturer": "Other"
+                            "openTimeslots": 64,
+                            "openAppointmentSlots": 64,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 77,
+                            "openAppointmentSlots": 77,
+                            "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 0,
-                    "openFluTimeslots": 6,
-                    "openFluAppointmentSlots": 6,
-                    "openAppointmentSlots": 0,
+                    "openTimeslots": 141,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 141,
                     "name": "The Market at Stone Oak",
                     "longitude": -98.50062,
                     "latitude": 29.662,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4kQAE",
+                    "fluUrl": "",
                     "city": "SAN ANTONIO"
                 },
                 {
@@ -7183,34 +7563,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 34,
-                            "openAppointmentSlots": 34,
+                            "openTimeslots": 18,
+                            "openAppointmentSlots": 18,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 34,
-                            "openAppointmentSlots": 34,
+                            "openTimeslots": 16,
+                            "openAppointmentSlots": 16,
                             "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 12,
-                            "openAppointmentSlots": 12,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 20,
-                            "openAppointmentSlots": 20,
-                            "manufacturer": "Other"
                         }
                     ],
-                    "openTimeslots": 80,
-                    "openFluTimeslots": 20,
-                    "openFluAppointmentSlots": 20,
-                    "openAppointmentSlots": 80,
+                    "openTimeslots": 34,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 34,
                     "name": "Lakeline H-E-B plus!",
                     "longitude": -97.8034,
                     "latitude": 30.47786,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4lQAE",
+                    "fluUrl": "",
                     "city": "AUSTIN"
                 },
                 {
@@ -7222,20 +7592,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 338,
-                            "openAppointmentSlots": 338,
+                            "openTimeslots": 349,
+                            "openAppointmentSlots": 349,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 338,
-                            "openAppointmentSlots": 338,
+                            "openTimeslots": 392,
+                            "openAppointmentSlots": 392,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 676,
+                    "openTimeslots": 741,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 676,
+                    "openAppointmentSlots": 741,
                     "name": "Conroe Market H-E-B",
                     "longitude": -95.49817,
                     "latitude": 30.32647,
@@ -7251,34 +7621,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 49,
-                            "openAppointmentSlots": 49,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 138,
-                            "openAppointmentSlots": 138,
+                            "openTimeslots": 10,
+                            "openAppointmentSlots": 10,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 20,
-                            "openAppointmentSlots": 20,
+                            "openTimeslots": 10,
+                            "openAppointmentSlots": 10,
                             "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 120,
-                            "openAppointmentSlots": 120,
-                            "manufacturer": "Other"
                         }
                     ],
-                    "openTimeslots": 207,
-                    "openFluTimeslots": 120,
-                    "openFluAppointmentSlots": 120,
-                    "openAppointmentSlots": 207,
+                    "openTimeslots": 20,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 20,
                     "name": "Texas City H-E-B",
                     "longitude": -94.94893,
                     "latitude": 29.39535,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF51QAE",
+                    "fluUrl": "",
                     "city": "TEXAS CITY"
                 },
                 {
@@ -7308,30 +7668,30 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 20,
-                            "openAppointmentSlots": 20,
+                            "openTimeslots": 22,
+                            "openAppointmentSlots": 22,
                             "manufacturer": "Janssen"
                         },
                         {
-                            "openTimeslots": 70,
-                            "openAppointmentSlots": 70,
+                            "openTimeslots": 100,
+                            "openAppointmentSlots": 100,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 52,
-                            "openAppointmentSlots": 52,
+                            "openTimeslots": 80,
+                            "openAppointmentSlots": 80,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 36,
-                            "openAppointmentSlots": 36,
+                            "openTimeslots": 89,
+                            "openAppointmentSlots": 89,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 178,
+                    "openTimeslots": 291,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 178,
+                    "openAppointmentSlots": 291,
                     "name": "Broadway Central Market",
                     "longitude": -98.46408,
                     "latitude": 29.47069,
@@ -7365,20 +7725,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 35,
-                            "openAppointmentSlots": 35,
+                            "openTimeslots": 10,
+                            "openAppointmentSlots": 10,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 30,
+                            "openAppointmentSlots": 30,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 55,
-                            "openAppointmentSlots": 55,
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 90,
+                    "openTimeslots": 60,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 90,
+                    "openAppointmentSlots": 60,
                     "name": "Carrizo Springs H-E-B",
                     "longitude": -99.85102,
                     "latitude": 28.53642,
@@ -7394,15 +7759,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 16,
-                            "openAppointmentSlots": 16,
+                            "openTimeslots": 35,
+                            "openAppointmentSlots": 35,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 28,
+                            "openAppointmentSlots": 28,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 32,
+                            "openAppointmentSlots": 32,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 16,
+                    "openTimeslots": 95,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 16,
+                    "openAppointmentSlots": 95,
                     "name": "Valley Mills H-E-B plus!",
                     "longitude": -97.13916,
                     "latitude": 31.52508,
@@ -7418,20 +7793,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 29,
-                            "openAppointmentSlots": 29,
+                            "openTimeslots": 35,
+                            "openAppointmentSlots": 35,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 6,
-                            "openAppointmentSlots": 6,
+                            "openTimeslots": 17,
+                            "openAppointmentSlots": 17,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 35,
+                    "openTimeslots": 52,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 35,
+                    "openAppointmentSlots": 52,
                     "name": "University Blvd H-E-B",
                     "longitude": -97.68859,
                     "latitude": 30.56107,
@@ -7447,34 +7822,29 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 23,
-                            "openAppointmentSlots": 23,
+                            "openTimeslots": 5,
+                            "openAppointmentSlots": 5,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 44,
-                            "openAppointmentSlots": 44,
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
                             "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 20,
-                            "openAppointmentSlots": 20,
-                            "manufacturer": "Pediatric_Pfizer"
                         },
                         {
                             "openTimeslots": 25,
                             "openAppointmentSlots": 25,
-                            "manufacturer": "Other"
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 87,
-                    "openFluTimeslots": 25,
-                    "openFluAppointmentSlots": 25,
-                    "openAppointmentSlots": 87,
+                    "openTimeslots": 80,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 80,
                     "name": "Palmhurst H-E-B",
                     "longitude": -98.31816,
                     "latitude": 26.25684,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF56QAE",
+                    "fluUrl": "",
                     "city": "PALMHURST"
                 },
                 {
@@ -7486,20 +7856,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 66,
-                            "openAppointmentSlots": 66,
+                            "openTimeslots": 97,
+                            "openAppointmentSlots": 97,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 59,
-                            "openAppointmentSlots": 59,
+                            "openTimeslots": 69,
+                            "openAppointmentSlots": 69,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 19,
+                            "openAppointmentSlots": 19,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 125,
+                    "openTimeslots": 185,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 125,
+                    "openAppointmentSlots": 185,
                     "name": "Pearland Market H-E-B",
                     "longitude": -95.26499,
                     "latitude": 29.55812,
@@ -7548,15 +7923,15 @@
             "Content-Type",
             "binary/octet-stream",
             "Content-Length",
-            "153993",
+            "159190",
             "Connection",
             "close",
             "Date",
-            "Mon, 18 Apr 2022 00:17:49 GMT",
+            "Sat, 18 Jun 2022 23:54:24 GMT",
             "Last-Modified",
-            "Mon, 18 Apr 2022 00:17:27 GMT",
+            "Sat, 18 Jun 2022 23:53:48 GMT",
             "ETag",
-            "\"452eba1e00f3703a9d42ac0e92fb526d\"",
+            "\"957ade97aabbebbd1f6dedf02e3481f7\"",
             "Cache-Control",
             "max-age:0",
             "Accept-Ranges",
@@ -7566,11 +7941,11 @@
             "X-Cache",
             "Miss from cloudfront",
             "Via",
-            "1.1 61729b32280fd6715c2a3b0dbb7e571a.cloudfront.net (CloudFront)",
+            "1.1 7189b8cad57dc2d1ab0dd5f90144f2a2.cloudfront.net (CloudFront)",
             "X-Amz-Cf-Pop",
-            "SFO5-C1",
+            "SFO5-P1",
             "X-Amz-Cf-Id",
-            "fPM7nj2l4KhwEl8rL1AqA1TIZvu-2Eg6m7AUf_mrgtuienSTGkRPqQ=="
+            "sRPz8SMbBY6UHkK1IxL28sYr52kURoistIjjiWS5e5SK9tra8ah5JA=="
         ],
         "responseIsBinary": false
     }


### PR DESCRIPTION
H-E-B is using `Ultra_Pediatric_Pfizer` to represent the new early childhood vaccine (6 months - < 5 years). They don't yet appear to have added anything for Moderna.

Fixes https://sentry.io/organizations/usdr/issues/3359245720