### PR TITLE
Increase POST body limit to 2.5 MB

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -49,7 +49,7 @@ app.use(Sentry.Handlers.requestHandler());
 app.use(logRequest);
 app.use(datadogMiddleware);
 app.use(compression());
-app.use(bodyParser.json({ limit: "1mb" }));
+app.use(bodyParser.json({ limit: "2.5mb" }));
 app.use(cors());
 app.use(authorizeRequest);
 app.use(urlDecodeSpecialPathChars);


### PR DESCRIPTION
We are now seeing a handful of GIANT listings from PrepMod which appear to be legit, so this updates the allowed body size to handle them.

For example, a clinic in Puyallup, WA has 3897 slots (!) from 47 separate events (looks like a morning & afternoon event each Wednesday - Saturday) for the next 6 weeks. They’re really scheduling ahead (probably because of the new early pediatric vaccines).