### PR TITLE
Add warnings to deprecated loaders

### DIFF
--- a/loader/src/sources/cvs/api.js
+++ b/loader/src/sources/cvs/api.js
@@ -1,4 +1,6 @@
 /**
+ * WARNING: THIS LOADER IS DEPRECATED AND NO LONGER IN ACTIVE USE.
+ *
  * CVS appointment checker based based on their official API.
  * Docs: https://devportal-test.cvshealth.com/api/196
  *
@@ -11,7 +13,7 @@
 const got = require("got");
 const { HttpApiError } = require("../../exceptions");
 const { Available, LocationType } = require("../../model");
-const { httpClient, oneLine, warn } = require("../../utils");
+const { httpClient, oneLine, createWarningLogger } = require("../../utils");
 const {
   CVS_CORPORATE_PHARMACY_PHONE_NUMBER,
   CVS_BOOKING_URL,
@@ -20,6 +22,8 @@ const {
 
 const API_URL = "https://api.cvshealth.com/";
 const AVAILABILITY_ENDPOINT = "/immunization-status/v1/covax-availability";
+
+const warn = createWarningLogger("cvsApi");
 
 /**
  * @typedef {Object} CvsApiLocation
@@ -126,6 +130,8 @@ function parseApiLocation(location, lastUpdated) {
  * @param {string} [apiUrl] Base URL for the CVS API.
  */
 async function checkAvailability(handler, _options) {
+  warn("WARNING: cvsApi is deprecated and no longer maintained.");
+
   const apiKey = process.env.CVS_API_KEY;
   let apiUrl = process.env.CVS_API_URL || API_URL;
 

--- a/loader/src/sources/cvs/scraper.js
+++ b/loader/src/sources/cvs/scraper.js
@@ -1,5 +1,5 @@
 /**
- * THIS LOADER IS DEPRECATED AND NO LONGER IN ACTIVE USE.
+ * WARNING: THIS LOADER IS DEPRECATED AND NO LONGER IN ACTIVE USE.
  *
  * Scrape appointment availability from CVS's website.
  * Note this scraper was originally focused only on the state of New Jersey,
@@ -8,13 +8,20 @@
  */
 
 const knownStores = require("./known-stores");
-const { httpClient, randomInt, randomUserAgent, warn } = require("../../utils");
+const {
+  httpClient,
+  randomInt,
+  randomUserAgent,
+  createWarningLogger,
+} = require("../../utils");
 const { LocationType, Available } = require("../../model");
 const {
   CVS_BOOKING_URL,
   CVS_CORPORATE_PHARMACY_PHONE_NUMBER,
   getStoreCounty,
 } = require("./shared");
+
+const warn = createWarningLogger("cvsScraper");
 
 // The zip code selected are reverse engineered based on CVS' advertised
 // vaccine location. The city/town with CVS that provides that provide COVID
@@ -358,6 +365,8 @@ function sleep(ms) {
  * @return {array} Array of results conforming to the scraper standard.
  */
 async function checkAvailability(handler, _options) {
+  warn("WARNING: cvsScraper is deprecated and no longer maintained.");
+
   const clinicsZip = njClinicZip;
 
   const standardResults = {};

--- a/loader/src/sources/vaccinespotter/index.js
+++ b/loader/src/sources/vaccinespotter/index.js
@@ -1,3 +1,15 @@
+/**
+ * WARNING: THIS LOADER IS DEPRECATED AND NO LONGER IN ACTIVE USE.
+ *
+ * Load data from vaccinespotter.org, a similar project to this one. They pull
+ * data from some sources we don't, and vice-versa.
+ *
+ * VaccineSpotter.org is no longer operational, and this loader is retained
+ * mainly for historical purposes and for reference when diagnosing issues in
+ * data that may have originally been sourced from VaccineSpotter.org. It is no
+ * longer actually usable.
+ */
+
 const Sentry = require("@sentry/node");
 const { Available, LocationType } = require("../../model");
 const {
@@ -5,13 +17,11 @@ const {
   titleCase,
   unpadNumber,
   getUniqueExternalIds,
+  createWarningLogger,
 } = require("../../utils");
 const walgreens_store_list = require("./walgreens_base");
 
-function warn(message, context) {
-  console.warn(`VaccineSpotter: ${message}`, context);
-  Sentry.captureMessage(message, Sentry.Severity.Info);
-}
+const warn = createWarningLogger("vaccinespotter");
 
 async function queryState(state) {
   try {
@@ -426,6 +436,8 @@ function formatStore(store) {
 }
 
 async function checkAvailability(handler, options) {
+  warn("WARNING: vaccinespotter is deprecated and no longer maintained.");
+
   let states = ["NJ"];
   if (options.vaccinespotterStates) {
     states = options.vaccinespotterStates

--- a/loader/src/sources/vts/geo.js
+++ b/loader/src/sources/vts/geo.js
@@ -1,3 +1,19 @@
+/**
+ * WARNING: THIS LOADER IS DEPRECATED AND NO LONGER IN ACTIVE USE.
+ *
+ * Load data from a final snapshot of Vaccinate the States's database. UNIVAF
+ * originally partnered with Vaccinate the States, who had a sizable and
+ * dedicated volunteer force working to identify and source detailed information
+ * about locations, while UNIVAF worked to find and organize corresponding
+ * appointment availability data for those locations.
+ *
+ * Vaccinate the States has since shut down, and this loader was used to pull in
+ * and make use of data from a final snapshot of their database. This loader is
+ * retained for historical purposes and for reference when diagnosing issues in
+ * data that may have originally been sourced from Vaccinate the States. It is
+ * no longer meaningfully usable.
+ */
+
 const Sentry = require("@sentry/node");
 const { httpClient, splitOnce, oneLine } = require("../../utils");
 


### PR DESCRIPTION
Add comments and log deprecation warnings for loaders that are no longer maintained or in use. Fixes #325.