### PR TITLE
Use the standard loader logger everywhere

### DIFF
--- a/loader/src/sources/cvs/shared.js
+++ b/loader/src/sources/cvs/shared.js
@@ -1,4 +1,4 @@
-const { warn } = require("../../utils");
+const { createWarningLogger } = require("../../utils");
 const knownStores = require("./known-stores");
 
 // Show the corporate number instead of individual pharmacies' numbers because:
@@ -9,6 +9,8 @@ const CVS_CORPORATE_PHARMACY_PHONE_NUMBER = "(800) 746-7287";
 const CVS_BOOKING_URL = "https://www.cvs.com/vaccine/intake/store/cvd-schedule";
 
 const TESTING = process.env.NODE_ENV === "test";
+
+const warn = createWarningLogger("cvs/shared");
 
 /**
  * Helper function to return a county string based on CVS store number
@@ -41,7 +43,7 @@ function getStoreCounty(storeNumber) {
   // This is the worst case. We are going to show the user "Unknown County"
   // We should avoid this whenever possible.
   if (!TESTING) {
-    warn(`CVS store address ${knownStores[storeNumber].address} has no county`);
+    warn(`Store address ${knownStores[storeNumber].address} has no county`);
   }
   return null;
 }

--- a/loader/src/sources/hyvee/index.js
+++ b/loader/src/sources/hyvee/index.js
@@ -15,7 +15,7 @@
  */
 
 const Sentry = require("@sentry/node");
-const { httpClient } = require("../../utils");
+const { httpClient, createWarningLogger } = require("../../utils");
 const { LocationType, Available, VaccineProduct } = require("../../model");
 
 const API_URL = "https://www.hy-vee.com/my-pharmacy/api/graphql";
@@ -31,15 +31,7 @@ const VACCINE_NAMES = {
   Janssen: VaccineProduct.janssen,
 };
 
-function warn(message, context) {
-  console.warn(`HyVee: ${message}`, context);
-  // Sentry does better fingerprinting with an actual exception object.
-  if (message instanceof Error) {
-    Sentry.captureException(message, { level: Sentry.Severity.Info });
-  } else {
-    Sentry.captureMessage(message, Sentry.Severity.Info);
-  }
-}
+const warn = createWarningLogger("hyvee");
 
 /**
  * Get an array of raw store & covid availability records from the HyVee API.

--- a/loader/src/sources/riteaid/api.js
+++ b/loader/src/sources/riteaid/api.js
@@ -19,7 +19,7 @@ const {
   getLocationName,
 } = require("./common");
 
-const warn = createWarningLogger("Rite Aid API");
+const warn = createWarningLogger("riteAidApi");
 
 // Log a warning if a location has more than this many slots in a given day.
 const MAXIMUM_SLOT_COUNT = 500;

--- a/loader/src/sources/riteaid/scraper.js
+++ b/loader/src/sources/riteaid/scraper.js
@@ -53,7 +53,7 @@ const VACCINE_IDS = {
 // response.
 const VACCINE_IDS_SHORT = mapKeys(VACCINE_IDS, (_, key) => key.split("-")[0]);
 
-const warn = createWarningLogger("Rite Aid Scraper");
+const warn = createWarningLogger("riteAidScraper");
 
 async function queryZipCode(zip, radius = 100, stores = null) {
   const response = await httpClient({

--- a/loader/src/sources/wa-doh.js
+++ b/loader/src/sources/wa-doh.js
@@ -1,11 +1,16 @@
 // Washington State DoH hosts data for multiple states for some providers where
 // they have API access. (In practice, this is pretty much only Costco.)
 
-const Sentry = require("@sentry/node");
 const { Available, LocationType } = require("../model");
-const { httpClient, matchVaccineProduct } = require("../utils");
+const {
+  httpClient,
+  matchVaccineProduct,
+  createWarningLogger,
+} = require("../utils");
 const { HttpApiError } = require("../exceptions");
 const allStates = require("../states.json");
+
+const warn = createWarningLogger("waDoh");
 
 // You can also navigate to this URL in a browser and get an interactive
 // GraphQL testing console.
@@ -73,16 +78,6 @@ const INVALID_LOCATIONS = [
   "riteaid-5288",
   "prep-mod-3696ec0d-3869-4ff4-88ce-1030db1639ef",
 ];
-
-function warn(message, context) {
-  console.warn(`WA DoH: ${message}`, context);
-  // Sentry does better fingerprinting with an actual exception object.
-  if (message instanceof Error) {
-    Sentry.captureException(message, { level: Sentry.Severity.Info });
-  } else {
-    Sentry.captureMessage(message, Sentry.Severity.Info);
-  }
-}
 
 class WaDohApiError extends HttpApiError {
   parse(response) {

--- a/loader/src/sources/walgreens.js
+++ b/loader/src/sources/walgreens.js
@@ -7,7 +7,7 @@
 
 const Sentry = require("@sentry/node");
 const { Available, LocationType } = require("../model");
-const { titleCase, unpadNumber } = require("../utils");
+const { titleCase, unpadNumber, createWarningLogger } = require("../utils");
 const {
   EXTENSIONS,
   SmartSchedulingLinksApi,
@@ -23,6 +23,8 @@ const API_URL =
 
 // System used for Walgreens store IDs.
 const WALGREENS_ID_SYSTEM = "https://walgreens.com";
+
+const warn = createWarningLogger("walgreensSmart");
 
 /**
  * Get an array of UNIVAF-formatted locations & availabilities from the
@@ -153,24 +155,12 @@ function formatCapacity(slots) {
           // (*some* appointments) rather than actual capacity estimates. It
           // doesn't indicate this in any way, so watch for unexpected values in
           // case something in their implementation to be more detailed.
-          console.warn(`Got unexpected != 5 capacity for Walgreens: ${slot}`);
-          Sentry.captureMessage(`Unexpected != 5 capacity for Walgreens`, {
-            level: Sentry.Severity.Info,
-            contexts: {
-              raw_slot: slot,
-            },
-          });
+          warn("Unexpected != 5 capacity", { slot }, true);
         }
       } else if (extension.url === EXTENSIONS.BOOKING_DEEP_LINK) {
         booking_url = extension.valueUrl;
       } else {
-        console.warn(`Got unexpected slot extension for Walgreens: ${slot}`);
-        Sentry.captureMessage(`Unexpected slot extension for Walgreens`, {
-          level: Sentry.Severity.Info,
-          contexts: {
-            raw_slot: slot,
-          },
-        });
+        warn("Unexpected slot extension", { slot }, true);
       }
     }
 

--- a/loader/test/albertsons.test.js
+++ b/loader/test/albertsons.test.js
@@ -10,6 +10,9 @@ const { expectDatetimeString, splitHostAndPath } = require("./support");
 const { locationSchema } = require("./support/schemas");
 const { ParseError } = require("../src/exceptions");
 
+// Mock utils so we can track logs.
+jest.mock("../src/utils");
+
 const [API_URL_BASE, API_URL_PATH] = splitHostAndPath(API_URL);
 
 const basicLocation = {

--- a/loader/test/api-client.test.js
+++ b/loader/test/api-client.test.js
@@ -1,6 +1,9 @@
 const { UpdateQueue, ApiClient } = require("../src/api-client");
 const nock = require("nock");
 
+// Mock utils so we can track logs.
+jest.mock("../src/utils");
+
 const MOCK_HOST = "http://univaf.test";
 
 describe("API Client", () => {

--- a/loader/test/cdc.api.test.js
+++ b/loader/test/cdc.api.test.js
@@ -10,6 +10,9 @@ const {
 const { Available } = require("../src/model");
 const { locationSchema } = require("./support/schemas");
 
+// Mock utils so we can track logs.
+jest.mock("../src/utils");
+
 describe("CDC Open Data API", () => {
   afterEach(() => {
     nock.cleanAll();

--- a/loader/test/cvs.api.test.js
+++ b/loader/test/cvs.api.test.js
@@ -6,6 +6,9 @@ const {
 } = require("../src/sources/cvs/shared");
 const { expectDatetimeString } = require("./support");
 
+// Mock utils so we can track logs.
+jest.mock("../src/utils");
+
 describe("CVS API", () => {
   const API_URL = "http://api.cvs.com/";
 

--- a/loader/test/cvs.scraper.test.js
+++ b/loader/test/cvs.scraper.test.js
@@ -11,6 +11,9 @@ const {
 
 const { expectDatetimeString } = require("./support");
 
+// Mock utils so we can track logs.
+jest.mock("../src/utils");
+
 // const geocoding = require("../src/geocoding");
 // const { dataSources, callsToAction } = require("../src/model");
 

--- a/loader/test/cvs.smart.test.js
+++ b/loader/test/cvs.smart.test.js
@@ -12,6 +12,9 @@ const { locationSchema } = require("./support/schemas");
 const fixtures = require("./fixtures/cvs.smart.fixtures");
 const { Available } = require("../src/model");
 
+// Mock utils so we can track logs.
+jest.mock("../src/utils");
+
 describe("CVS SMART Scheduling Links API", () => {
   const [CVS_BASE, CVS_MANIFEST_PATH] = splitHostAndPath(CVS_SMART_API_URL);
 

--- a/loader/test/heb.test.js
+++ b/loader/test/heb.test.js
@@ -3,6 +3,9 @@ const { LocationType, Available } = require("../src/model");
 const { expectDatetimeString } = require("./support");
 const { locationSchema } = require("./support/schemas");
 
+// Mock utils so we can track logs.
+jest.mock("../src/utils");
+
 describe("H-E-B", () => {
   it.nock("should output valid data", { ignoreQuery: ["v"] }, async () => {
     const result = await checkAvailability(() => {}, { states: "TX" });

--- a/loader/test/hyvee.test.js
+++ b/loader/test/hyvee.test.js
@@ -4,6 +4,9 @@ const { expectDatetimeString } = require("./support");
 const { locationSchema } = require("./support/schemas");
 const stateData = require("../src/states.json");
 
+// Mock utils so we can track logs.
+jest.mock("../src/utils");
+
 const RawLocation = {
   locationId: "fa22572e-ad2b-4cec-a787-dec0fb3ea086",
   name: "Waterloo #2",

--- a/loader/test/kroger.smart.test.js
+++ b/loader/test/kroger.smart.test.js
@@ -9,6 +9,9 @@ const { locationSchema } = require("./support/schemas");
 const fixtures = require("./fixtures/kroger.smart.fixtures");
 const { Available } = require("../src/model");
 
+// Mock utils so we can track logs.
+jest.mock("../src/utils");
+
 describe("Kroger SMART Scheduling Links API", () => {
   const [API_BASE, MANIFEST_PATH] = splitHostAndPath(API_URL);
 

--- a/loader/test/prepmod.test.js
+++ b/loader/test/prepmod.test.js
@@ -15,6 +15,9 @@ const { locationSchema } = require("./support/schemas");
 const { VaccineProduct } = require("../src/model");
 const { EXTENSIONS } = require("../src/smart-scheduling-links");
 
+// Mock utils so we can track logs.
+jest.mock("../src/utils");
+
 describe("PrepMod API", () => {
   jest.setTimeout(60000);
 

--- a/loader/test/server.test.js
+++ b/loader/test/server.test.js
@@ -2,6 +2,9 @@ const got = require("got");
 const nock = require("nock");
 const { runServer } = require("../src/server");
 
+// Mock utils so we can track logs.
+jest.mock("../src/utils");
+
 describe("Server", () => {
   let server;
 

--- a/loader/test/smart-scheduling-links.test.js
+++ b/loader/test/smart-scheduling-links.test.js
@@ -4,6 +4,9 @@ const {
   formatExternalIds,
 } = require("../src/smart-scheduling-links");
 
+// Mock utils so we can track logs.
+jest.mock("../src/utils");
+
 describe("smart-scheduling-links", () => {
   describe("valuesAsObject", () => {
     it("should combine a list of FHIR values into an object", () => {

--- a/loader/test/vaccinespotter.test.js
+++ b/loader/test/vaccinespotter.test.js
@@ -2,6 +2,9 @@ const { Available } = require("../src/model");
 const { formatStore } = require("../src/sources/vaccinespotter/index");
 const { expectDatetimeString } = require("./support");
 
+// Mock utils so we can track logs.
+jest.mock("../src/utils");
+
 describe("VaccineSpotter", () => {
   const basicVaccineSpotterStore = {
     type: "Feature",

--- a/loader/test/vts.geo.test.js
+++ b/loader/test/vts.geo.test.js
@@ -1,6 +1,9 @@
 const nock = require("nock");
 const { checkAvailability } = require("../src/sources/vts/geo");
 
+// Mock utils so we can track logs.
+jest.mock("../src/utils");
+
 const apiResponse = require("./fixtures/vts.geo.test.json");
 const noopHandler = () => {};
 

--- a/loader/test/wa-doh.test.js
+++ b/loader/test/wa-doh.test.js
@@ -9,6 +9,9 @@ const {
 const { expectDatetimeString, splitHostAndPath } = require("./support");
 const { locationSchema } = require("./support/schemas");
 
+// Mock utils so we can track logs.
+jest.mock("../src/utils");
+
 const [API_URL_BASE, API_URL_PATH] = splitHostAndPath(API_URL);
 
 describe("Washington DoH API", () => {

--- a/loader/test/walgreens.test.js
+++ b/loader/test/walgreens.test.js
@@ -9,6 +9,9 @@ const { locationSchema } = require("./support/schemas");
 const fixtures = require("./fixtures/walgreens.smart.fixtures");
 const { Available } = require("../src/model");
 
+// Mock utils so we can track logs.
+jest.mock("../src/utils");
+
 describe("Walgreens SMART Scheduling Links API", () => {
   const [API_BASE, API_MANIFEST_PATH] = splitHostAndPath(API_URL);
 


### PR DESCRIPTION
**This is a follow-on to/depends on #725.** Since I was updating logging, it seemed like it made sense to normalize everything. But I hadn’t realized how many loaders we never updated, and this turned into a *way* bigger job than expected. 😬

There is probably some good refactoring to be done on the logging tools, but that'll be easier after making everything use the tools we currently have.

This also sends a bit more context data to Sentry. I’m thinking we should just always do that instead of making it optional (I think I may have originally been under the impression that Sentry couldn’t take complex objects in the context, but [this test shows it actually works great](https://sentry.io/organizations/usdr/issues/3368356106/)), but that’s a refactor that should probably be reserved for a separate PR.