### PR TITLE
Add manual corrections to NJVSS

### DIFF
--- a/loader/src/sources/njvss/corrections.js
+++ b/loader/src/sources/njvss/corrections.js
@@ -1,0 +1,19 @@
+/**
+ * Manual corrections for misformatted/bad source data. The keys are the
+ * `res_id` property for the location, and the value is any properties that
+ * should be overridden.
+ */
+module.exports.corrections = {
+  "d591d023-b457-eb11-a812-001dd8018866": {
+    vras_provideraddress: "187 North Ave, Dunellen, NJ 08812",
+  },
+  "c96a8022-b457-eb11-a812-001dd8020dc1": {
+    vras_provideraddress: "174 Passaic St, Garfield, NJ 07026",
+  },
+  "1498cb6f-8c91-eb11-a812-001dd802f301": {
+    vras_provideraddress: "307 1st Street, Hoboken, NJ 07030",
+  },
+  "b951acec-32f1-eb11-bacb-001dd80283f5": {
+    vras_provideraddress: "1400 Parkway Ave # A2, Ewing, NJ 08628",
+  },
+};

--- a/loader/src/sources/njvss/index.js
+++ b/loader/src/sources/njvss/index.js
@@ -13,6 +13,7 @@ const {
   titleCase,
   createWarningLogger,
 } = require("../../utils");
+const { corrections } = require("./corrections");
 
 const NJVSS_WEBSITE = "https://covidvaccine.nj.gov";
 const NJVSS_AWS_KEY_ID =
@@ -438,6 +439,11 @@ async function checkAvailability(handler, _options) {
   let result = [];
   for (const location of locations) {
     let provider = PROVIDER.njvss;
+
+    // Apply corrections for known-bad source data.
+    if (location.res_id in corrections) {
+      Object.assign(location, corrections[location.res_id]);
+    }
 
     // FIXME: there are some fields we should not try to update if
     // `_options.send` is true (we expect NJVSS to have messy data, and


### PR DESCRIPTION
This follows the pattern of corrections we added for Albertsons, and solves issues with a few bad addresses. (This was triggered by changes in #726, which put some of these ongoing address errors a little more in my face — which is a good thing.)