### PR TITLE
Match NJVSS locations with different providers

### DIFF
--- a/loader/src/sources/njvss/index.js
+++ b/loader/src/sources/njvss/index.js
@@ -240,10 +240,12 @@ function filterActualNjvssLocations(locations) {
  * @returns {Array<object>}
  */
 async function findLocationIds(locations) {
+  // FIXME: a lot has changed about how we manage locations and IDs since this
+  // was written. We can probably just use external_ids for this job now!
   let savedLocations;
   try {
     const client = ApiClient.fromEnv();
-    savedLocations = await client.getLocations({ provider: PROVIDER.njvss });
+    savedLocations = await client.getLocations({ state: "NJ" });
   } catch (error) {
     warn(
       `Could not contact API. This may output already known locations with different IDs. (${error})`


### PR DESCRIPTION
In https://sentry.io/organizations/usdr/issues/3373843306, we're getting a warning because the NJVSS loader can't match an NJVSS location to one we've previously saved. It turns out this is because it has a different provider (`walmart`) which is pretty reasonable. The real problem is that we were only considering locations with NJVSS as a provider for matching, when we should instead be considering all locations in New Jersey.