### PR TITLE
Identify early child age range in Albertsons names

### DIFF
--- a/loader/src/model.js
+++ b/loader/src/model.js
@@ -50,9 +50,19 @@ const PediatricVaccineProducts = new Set([
   VaccineProduct.modernaAge6_11,
 ]);
 
+/**
+ * `VaccineProduct` values that are for very young children.
+ * @readonly
+ */
+const EarlyPediatricVaccineProducts = new Set([
+  VaccineProduct.pfizerAge0_4,
+  VaccineProduct.modernaAge0_5,
+]);
+
 module.exports = {
   Available,
   LocationType,
   VaccineProduct,
   PediatricVaccineProducts,
+  EarlyPediatricVaccineProducts,
 };


### PR DESCRIPTION
Between authoring #734 yesterday night and merging today, the actual data has changed quite a bit. "infant" is no longer the only way that early childhood vaccines are indicated; listings now sometimes say pediatric (age 3-5). This modifies our expressions to match it and loosens some other checks that are no longer applicable.

Fixes https://sentry.io/organizations/usdr/issues/3376638147/

Here’s a quick report-out of how this identifies “infant” vs. “pediatric”: https://gist.github.com/Mr0grog/cf10c09b138a2318ce9c3f6b3ac703be