### PR TITLE
Extend availability merge window form 2 days to 7

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -29,7 +29,7 @@ const DEFAULT_BATCH_SIZE = 2000;
 // was disabled).
 // When merging records from multiple sources, we only include records from
 // within this many milliseconds of each other.
-const AVAILABILITY_MERGE_TIMEFRAME = 48 * 60 * 60 * 1000;
+const AVAILABILITY_MERGE_TIMEFRAME = 7 * 24 * 60 * 60 * 1000;
 
 export const db = Knex(loadDbConfig());
 


### PR DESCRIPTION
It turns out we have a lot of locations whose CDC data is dropping out of our availability listings because reporting frequency has dropped over time — they only report every few days, and the CDC only updates the public data once a day. Since a lot of locations don’t provide product info in their appointment listings, the CDC is a critical source for the `products` field and it makes sense to extend the timeframe we consider valid to contribute to the merged `availability` object.

Fixes #739.