### PR TITLE
Handle H-E-B's new "Multiple" vaccine type

### DIFF
--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -352,6 +352,7 @@ const locationSystems = [
   // vaccine scheduling system (rxtouch.com). Not sure if these are just
   // arbitrarily different, or if they are a pharmacy-specific ID or something.
   { system: "hannaford", pattern: /^Hannaford/i },
+  { system: "heb", pattern: /^H[\s-]?E[\s-]?B\b/i },
 ];
 
 // FIXME: these need to be able to correct more than just the ID.

--- a/loader/src/sources/heb/index.js
+++ b/loader/src/sources/heb/index.js
@@ -98,7 +98,13 @@ function formatAvailableProducts(raw) {
     .map((value) => {
       const productType = value.manufacturer.toLowerCase();
       const formatted = PRODUCT_NAMES[productType];
-      if (productType != "other" && !formatted) {
+      // "other" denotes non-COVID vaccines, like the flu vaccine.
+      // "multiple" denotes more than one possible vaccine in a time slot.
+      // Unfortunately, there doesn't seem to be a way to get details without
+      // making an additional call for each location, which we don't want to
+      // do. On the other hand, we can get usually get the list of products from
+      // the CDC, so this is probably OK.
+      if (productType !== "other" && productType !== "multiple" && !formatted) {
         warn(`Unknown product type`, value.manufacturer, true);
       }
       if (value.openAppointmentSlots > 0) {

--- a/loader/test/fixtures/nock/h-e-b_should_output_valid_data.json
+++ b/loader/test/fixtures/nock/h-e-b_should_output_valid_data.json
@@ -2,7 +2,7 @@
     {
         "scope": "https://heb-ecom-covid-vaccine.hebdigital-prd.com:443",
         "method": "GET",
-        "path": "/vaccine_locations.json?v=869017758056.0217",
+        "path": "/vaccine_locations.json?v=365490625576.8615",
         "body": "",
         "status": 200,
         "response": {
@@ -16,25 +16,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 59,
-                            "openAppointmentSlots": 59,
+                            "openTimeslots": 116,
+                            "openAppointmentSlots": 116,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 93,
-                            "openAppointmentSlots": 93,
+                            "openTimeslots": 143,
+                            "openAppointmentSlots": 143,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 79,
-                            "openAppointmentSlots": 79,
+                            "openTimeslots": 114,
+                            "openAppointmentSlots": 114,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 231,
+                    "openTimeslots": 373,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 231,
+                    "openAppointmentSlots": 373,
                     "name": "Round Rock H-E-B plus!",
                     "longitude": -97.65978,
                     "latitude": 30.5177,
@@ -50,25 +50,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 95,
-                            "openAppointmentSlots": 95,
+                            "openTimeslots": 79,
+                            "openAppointmentSlots": 79,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 52,
-                            "openAppointmentSlots": 52,
+                            "openTimeslots": 80,
+                            "openAppointmentSlots": 80,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 45,
-                            "openAppointmentSlots": 45,
+                            "openTimeslots": 77,
+                            "openAppointmentSlots": 77,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 192,
+                    "openTimeslots": 236,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 192,
+                    "openAppointmentSlots": 236,
                     "name": "Taylor H-E-B",
                     "longitude": -97.4167,
                     "latitude": 30.6007,
@@ -77,16 +77,32 @@
                 },
                 {
                     "zip": "78654-4902",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueXQAS",
                     "type": "store",
                     "street": "1503 FM 1431",
                     "storeNumber": 735,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 5,
+                            "openAppointmentSlots": 5,
+                            "manufacturer": "Pediatric_Moderna"
+                        },
+                        {
+                            "openTimeslots": 56,
+                            "openAppointmentSlots": 56,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 4,
+                            "openAppointmentSlots": 4,
+                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 65,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 65,
                     "name": "Marble Falls H-E-B",
                     "longitude": -98.27972,
                     "latitude": 30.58301,
@@ -102,20 +118,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 110,
-                            "openAppointmentSlots": 110,
+                            "openTimeslots": 135,
+                            "openAppointmentSlots": 135,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
+                            "openTimeslots": 119,
+                            "openAppointmentSlots": 119,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 48,
+                            "openAppointmentSlots": 48,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 160,
+                    "openTimeslots": 302,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 160,
+                    "openAppointmentSlots": 302,
                     "name": "Wells Branch H-E-B",
                     "longitude": -97.66419,
                     "latitude": 30.44263,
@@ -131,20 +152,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 16,
-                            "openAppointmentSlots": 16,
+                            "openTimeslots": 38,
+                            "openAppointmentSlots": 38,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 11,
-                            "openAppointmentSlots": 11,
+                            "openTimeslots": 39,
+                            "openAppointmentSlots": 39,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 6,
+                            "openAppointmentSlots": 6,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 27,
+                    "openTimeslots": 83,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 27,
+                    "openAppointmentSlots": 83,
                     "name": "Louis Henna Blvd H-E-B",
                     "longitude": -97.65938,
                     "latitude": 30.48179,
@@ -160,20 +186,40 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 104,
-                            "openAppointmentSlots": 104,
+                            "openTimeslots": 35,
+                            "openAppointmentSlots": 35,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 19,
+                            "openAppointmentSlots": 19,
+                            "manufacturer": "Pediatric_Moderna"
+                        },
+                        {
+                            "openTimeslots": 28,
+                            "openAppointmentSlots": 28,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 75,
-                            "openAppointmentSlots": 75,
+                            "openTimeslots": 43,
+                            "openAppointmentSlots": 43,
                             "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 21,
+                            "openAppointmentSlots": 21,
+                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 52,
+                            "openAppointmentSlots": 52,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 179,
+                    "openTimeslots": 198,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 179,
+                    "openAppointmentSlots": 198,
                     "name": "H-E-B at Ronald Reagan Blvd",
                     "longitude": -97.82446,
                     "latitude": 30.63307,
@@ -189,25 +235,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 105,
-                            "openAppointmentSlots": 105,
+                            "openTimeslots": 96,
+                            "openAppointmentSlots": 96,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 104,
-                            "openAppointmentSlots": 104,
+                            "openTimeslots": 99,
+                            "openAppointmentSlots": 99,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 105,
-                            "openAppointmentSlots": 105,
+                            "openTimeslots": 66,
+                            "openAppointmentSlots": 66,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 314,
+                    "openTimeslots": 261,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 314,
+                    "openAppointmentSlots": 261,
                     "name": "El Dorado H-E-B",
                     "longitude": -95.14874,
                     "latitude": 29.55117,
@@ -241,24 +287,34 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 70,
-                            "openAppointmentSlots": 70,
+                            "openTimeslots": 21,
+                            "openAppointmentSlots": 21,
+                            "manufacturer": "Other"
+                        },
+                        {
+                            "openTimeslots": 21,
+                            "openAppointmentSlots": 21,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 30,
-                            "openAppointmentSlots": 30,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
+                            "manufacturer": "Pediatric_Moderna"
+                        },
+                        {
+                            "openTimeslots": 21,
+                            "openAppointmentSlots": 21,
+                            "manufacturer": "Ultra_Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 100,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 100,
+                    "openTimeslots": 62,
+                    "openFluTimeslots": 21,
+                    "openFluAppointmentSlots": 21,
+                    "openAppointmentSlots": 62,
                     "name": "Falfurrias H-E-B",
                     "longitude": -98.14572,
                     "latitude": 27.22043,
-                    "fluUrl": "",
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF15QAE",
                     "city": "FALFURRIAS"
                 },
                 {
@@ -270,25 +326,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 39,
-                            "openAppointmentSlots": 39,
+                            "openTimeslots": 32,
+                            "openAppointmentSlots": 32,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 15,
-                            "openAppointmentSlots": 15,
+                            "openTimeslots": 12,
+                            "openAppointmentSlots": 12,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 19,
-                            "openAppointmentSlots": 19,
+                            "openTimeslots": 16,
+                            "openAppointmentSlots": 16,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 73,
+                    "openTimeslots": 60,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 73,
+                    "openAppointmentSlots": 60,
                     "name": "Burnet Rd H-E-B",
                     "longitude": -97.74016,
                     "latitude": 30.33374,
@@ -297,16 +353,32 @@
                 },
                 {
                     "zip": "78237-3134",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubAQAS",
                     "type": "store",
                     "street": "721 CASTROVILLE RD",
                     "storeNumber": 205,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 221,
+                            "openAppointmentSlots": 221,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 220,
+                            "openAppointmentSlots": 220,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 222,
+                            "openAppointmentSlots": 222,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 663,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 663,
                     "name": "Las Palmas H-E-B",
                     "longitude": -98.55132,
                     "latitude": 29.41734,
@@ -322,19 +394,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 11,
-                            "openAppointmentSlots": 11,
+                            "openTimeslots": 7,
+                            "openAppointmentSlots": 7,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 17,
-                            "openAppointmentSlots": 17,
+                            "openTimeslots": 9,
+                            "openAppointmentSlots": 9,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 4,
-                            "openAppointmentSlots": 4,
+                            "openTimeslots": 2,
+                            "openAppointmentSlots": 2,
                             "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 14,
+                            "openAppointmentSlots": 14,
+                            "manufacturer": "Multiple"
                         }
                     ],
                     "openTimeslots": 32,
@@ -349,16 +426,22 @@
                 },
                 {
                     "zip": "78412-2412",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubCQAS",
                     "type": "store",
                     "street": "4320 S. ALAMEDA ST.",
                     "storeNumber": 210,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 13,
+                            "openAppointmentSlots": 13,
+                            "manufacturer": "Moderna"
+                        }
+                    ],
+                    "openTimeslots": 13,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 13,
                     "name": "Alameda and Robert H-E-B",
                     "longitude": -97.37175,
                     "latitude": 27.73002,
@@ -410,20 +493,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 168,
-                            "openAppointmentSlots": 168,
+                            "openTimeslots": 55,
+                            "openAppointmentSlots": 55,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 148,
-                            "openAppointmentSlots": 148,
+                            "openTimeslots": 79,
+                            "openAppointmentSlots": 79,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 316,
+                    "openTimeslots": 134,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 316,
+                    "openAppointmentSlots": 134,
                     "name": "Parmer and Mopac H-E-B",
                     "longitude": -97.70326,
                     "latitude": 30.41883,
@@ -439,25 +522,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 88,
-                            "openAppointmentSlots": 88,
+                            "openTimeslots": 139,
+                            "openAppointmentSlots": 139,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 78,
-                            "openAppointmentSlots": 78,
+                            "openTimeslots": 137,
+                            "openAppointmentSlots": 137,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 80,
-                            "openAppointmentSlots": 80,
+                            "openTimeslots": 138,
+                            "openAppointmentSlots": 138,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 246,
+                    "openTimeslots": 414,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 246,
+                    "openAppointmentSlots": 414,
                     "name": "Pleasanton H-E-B",
                     "longitude": -98.48567,
                     "latitude": 28.95696,
@@ -473,15 +556,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 146,
-                            "openAppointmentSlots": 146,
+                            "openTimeslots": 28,
+                            "openAppointmentSlots": 28,
                             "manufacturer": "Moderna"
                         }
                     ],
-                    "openTimeslots": 146,
+                    "openTimeslots": 28,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 146,
+                    "openAppointmentSlots": 28,
                     "name": "Beeville H-E-B",
                     "longitude": -97.74667,
                     "latitude": 28.40071,
@@ -490,16 +573,32 @@
                 },
                 {
                     "zip": "78404-2505",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Guc0QAC",
                     "type": "store",
                     "street": "3133 S. ALAMEDA",
                     "storeNumber": 413,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 45,
+                            "openAppointmentSlots": 45,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 54,
+                            "openAppointmentSlots": 54,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 29,
+                            "openAppointmentSlots": 29,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 128,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 128,
                     "name": "Alameda / Texan Trail (Medical District)",
                     "longitude": -97.3912,
                     "latitude": 27.75745,
@@ -515,25 +614,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 185,
-                            "openAppointmentSlots": 185,
+                            "openTimeslots": 71,
+                            "openAppointmentSlots": 71,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 124,
-                            "openAppointmentSlots": 124,
+                            "openTimeslots": 114,
+                            "openAppointmentSlots": 114,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 129,
-                            "openAppointmentSlots": 129,
+                            "openTimeslots": 97,
+                            "openAppointmentSlots": 97,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 438,
+                    "openTimeslots": 282,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 438,
+                    "openAppointmentSlots": 282,
                     "name": "Brenham H-E-B",
                     "longitude": -96.39591,
                     "latitude": 30.14381,
@@ -542,16 +641,27 @@
                 },
                 {
                     "zip": "78154-1264",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Guc2QAC",
                     "type": "store",
                     "street": "17460 I.H. 35 NORTH",
                     "storeNumber": 415,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 32,
+                            "openAppointmentSlots": 32,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 80,
+                            "openAppointmentSlots": 80,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 112,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 112,
                     "name": "Schertz H-E-B plus!",
                     "longitude": -98.27742,
                     "latitude": 29.59717,
@@ -567,25 +677,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 90,
-                            "openAppointmentSlots": 90,
+                            "openTimeslots": 27,
+                            "openAppointmentSlots": 27,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 135,
-                            "openAppointmentSlots": 135,
+                            "openTimeslots": 27,
+                            "openAppointmentSlots": 27,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 90,
-                            "openAppointmentSlots": 90,
+                            "openTimeslots": 27,
+                            "openAppointmentSlots": 27,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 315,
+                    "openTimeslots": 81,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 315,
+                    "openAppointmentSlots": 81,
                     "name": "La Grange H-E-B",
                     "longitude": -96.87264,
                     "latitude": 29.9073,
@@ -601,25 +711,30 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 17,
-                            "openAppointmentSlots": 17,
+                            "openTimeslots": 13,
+                            "openAppointmentSlots": 13,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
+                            "openTimeslots": 14,
+                            "openAppointmentSlots": 14,
+                            "manufacturer": "Pediatric_Moderna"
+                        },
+                        {
+                            "openTimeslots": 1,
+                            "openAppointmentSlots": 1,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 15,
-                            "openAppointmentSlots": 15,
+                            "openTimeslots": 6,
+                            "openAppointmentSlots": 6,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 42,
+                    "openTimeslots": 34,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 42,
+                    "openAppointmentSlots": 34,
                     "name": "Avenue F and Gibbs H-E-B",
                     "longitude": -100.8998,
                     "latitude": 29.36632,
@@ -628,16 +743,22 @@
                 },
                 {
                     "zip": "78852-4718",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Guc5QAC",
                     "type": "store",
                     "street": "2135 E. MAIN",
                     "storeNumber": 419,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 8,
+                            "openAppointmentSlots": 8,
+                            "manufacturer": "Pediatric_Moderna"
+                        }
+                    ],
+                    "openTimeslots": 8,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 8,
                     "name": "Eagle Pass H-E-B",
                     "longitude": -100.48583,
                     "latitude": 28.70894,
@@ -646,16 +767,37 @@
                 },
                 {
                     "zip": "78516-2315",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Guc6QAC",
                     "type": "store",
                     "street": "1211 EAST FRONTAGE RD.",
                     "storeNumber": 421,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 15,
+                            "openAppointmentSlots": 15,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 15,
+                            "openAppointmentSlots": 15,
+                            "manufacturer": "Pediatric_Moderna"
+                        },
+                        {
+                            "openTimeslots": 14,
+                            "openAppointmentSlots": 14,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 14,
+                            "openAppointmentSlots": 14,
+                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 58,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 58,
                     "name": "Alamo H-E-B",
                     "longitude": -98.12414,
                     "latitude": 26.19073,
@@ -707,25 +849,30 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 163,
-                            "openAppointmentSlots": 163,
+                            "openTimeslots": 198,
+                            "openAppointmentSlots": 198,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 164,
-                            "openAppointmentSlots": 164,
+                            "openTimeslots": 198,
+                            "openAppointmentSlots": 198,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 58,
-                            "openAppointmentSlots": 58,
+                            "openTimeslots": 95,
+                            "openAppointmentSlots": 95,
                             "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 60,
+                            "openAppointmentSlots": 60,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 385,
+                    "openTimeslots": 551,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 385,
+                    "openAppointmentSlots": 551,
                     "name": "Hancock Center H-E-B",
                     "longitude": -97.71973,
                     "latitude": 30.30057,
@@ -741,30 +888,40 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 48,
-                            "openAppointmentSlots": 48,
+                            "openTimeslots": 51,
+                            "openAppointmentSlots": 51,
                             "manufacturer": "Janssen"
                         },
                         {
-                            "openTimeslots": 74,
-                            "openAppointmentSlots": 74,
+                            "openTimeslots": 32,
+                            "openAppointmentSlots": 32,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 89,
-                            "openAppointmentSlots": 89,
+                            "openTimeslots": 29,
+                            "openAppointmentSlots": 29,
+                            "manufacturer": "Pediatric_Moderna"
+                        },
+                        {
+                            "openTimeslots": 36,
+                            "openAppointmentSlots": 36,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 58,
-                            "openAppointmentSlots": 58,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 24,
+                            "openAppointmentSlots": 24,
+                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 63,
+                            "openAppointmentSlots": 63,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 269,
+                    "openTimeslots": 235,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 269,
+                    "openAppointmentSlots": 235,
                     "name": "Waxahachie H-E-B",
                     "longitude": -96.83983,
                     "latitude": 32.41159,
@@ -773,16 +930,32 @@
                 },
                 {
                     "zip": "78221-1642",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucBQAS",
                     "type": "store",
                     "street": "735 SW MILITARY",
                     "storeNumber": 427,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 119,
+                            "openAppointmentSlots": 119,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 120,
+                            "openAppointmentSlots": 120,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 41,
+                            "openAppointmentSlots": 41,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 280,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 280,
                     "name": "Military and Pleasanton H-E-B",
                     "longitude": -98.50277,
                     "latitude": 29.35666,
@@ -798,20 +971,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 133,
-                            "openAppointmentSlots": 133,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 79,
+                            "openAppointmentSlots": 79,
+                            "manufacturer": "Janssen"
                         },
                         {
-                            "openTimeslots": 136,
-                            "openAppointmentSlots": 136,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 69,
+                            "openAppointmentSlots": 69,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 168,
+                            "openAppointmentSlots": 168,
+                            "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 269,
+                    "openTimeslots": 316,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 269,
+                    "openAppointmentSlots": 316,
                     "name": "Blanco and West Ave H-E-B",
                     "longitude": -98.51025,
                     "latitude": 29.54526,
@@ -827,25 +1005,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 182,
-                            "openAppointmentSlots": 182,
+                            "openTimeslots": 208,
+                            "openAppointmentSlots": 208,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 182,
-                            "openAppointmentSlots": 182,
+                            "openTimeslots": 211,
+                            "openAppointmentSlots": 211,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 182,
-                            "openAppointmentSlots": 182,
+                            "openTimeslots": 211,
+                            "openAppointmentSlots": 211,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 546,
+                    "openTimeslots": 630,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 546,
+                    "openAppointmentSlots": 630,
                     "name": "Pflugerville H-E-B",
                     "longitude": -97.6133,
                     "latitude": 30.4373,
@@ -861,25 +1039,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 90,
-                            "openAppointmentSlots": 90,
+                            "openTimeslots": 45,
+                            "openAppointmentSlots": 45,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 87,
-                            "openAppointmentSlots": 87,
+                            "openTimeslots": 42,
+                            "openAppointmentSlots": 42,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 45,
-                            "openAppointmentSlots": 45,
+                            "openTimeslots": 22,
+                            "openAppointmentSlots": 22,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 222,
+                    "openTimeslots": 109,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 222,
+                    "openAppointmentSlots": 109,
                     "name": "I10 and Wurzbach H-E-B",
                     "longitude": -98.5595,
                     "latitude": 29.5336,
@@ -888,16 +1066,22 @@
                 },
                 {
                     "zip": "78596-2700",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucaQAC",
                     "type": "store",
                     "street": "310 N. WESTGATE DRIVE",
                     "storeNumber": 485,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 24,
+                            "openAppointmentSlots": 24,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 24,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 24,
                     "name": "83 and Westgate H-E-B",
                     "longitude": -97.98934,
                     "latitude": 26.17109,
@@ -949,25 +1133,40 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 201,
-                            "openAppointmentSlots": 201,
+                            "openTimeslots": 420,
+                            "openAppointmentSlots": 420,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 199,
-                            "openAppointmentSlots": 199,
+                            "openTimeslots": 41,
+                            "openAppointmentSlots": 41,
+                            "manufacturer": "Pediatric_Moderna"
+                        },
+                        {
+                            "openTimeslots": 829,
+                            "openAppointmentSlots": 829,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 201,
-                            "openAppointmentSlots": 201,
+                            "openTimeslots": 70,
+                            "openAppointmentSlots": 70,
                             "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 69,
+                            "openAppointmentSlots": 69,
+                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 30,
+                            "openAppointmentSlots": 30,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 601,
+                    "openTimeslots": 1459,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 601,
+                    "openAppointmentSlots": 1459,
                     "name": "Valley Hi H-E-B",
                     "longitude": -98.64021,
                     "latitude": 29.38099,
@@ -976,16 +1175,27 @@
                 },
                 {
                     "zip": "76033-4830",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudzQAC",
                     "type": "store",
                     "street": "600 W HENDERSON",
                     "storeNumber": 679,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 44,
+                            "openAppointmentSlots": 44,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 82,
+                            "openAppointmentSlots": 82,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 126,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 126,
                     "name": "Cleburne H-E-B",
                     "longitude": -97.39485,
                     "latitude": 32.3478,
@@ -1001,25 +1211,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 79,
-                            "openAppointmentSlots": 79,
+                            "openTimeslots": 55,
+                            "openAppointmentSlots": 55,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 91,
-                            "openAppointmentSlots": 91,
+                            "openTimeslots": 53,
+                            "openAppointmentSlots": 53,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
+                            "openTimeslots": 27,
+                            "openAppointmentSlots": 27,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 220,
+                    "openTimeslots": 135,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 220,
+                    "openAppointmentSlots": 135,
                     "name": "Creekside Park H-E-B",
                     "longitude": -95.55072,
                     "latitude": 30.14362,
@@ -1035,8 +1245,8 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 98,
-                            "openAppointmentSlots": 98,
+                            "openTimeslots": 93,
+                            "openAppointmentSlots": 93,
                             "manufacturer": "Moderna"
                         },
                         {
@@ -1045,10 +1255,10 @@
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 176,
+                    "openTimeslots": 171,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 176,
+                    "openAppointmentSlots": 171,
                     "name": "San Felipe H-E-B",
                     "longitude": -95.48512,
                     "latitude": 29.74797,
@@ -1057,27 +1267,16 @@
                 },
                 {
                     "zip": "78332-5046",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubGQAS",
+                    "url": null,
                     "type": "store",
                     "street": "1115 E. MAIN",
                     "storeNumber": 223,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 47,
-                            "openAppointmentSlots": 47,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 78,
-                            "openAppointmentSlots": 78,
-                            "manufacturer": "Pediatric_Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 125,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 125,
+                    "openAppointmentSlots": 0,
                     "name": "Alice H-E-B",
                     "longitude": -98.06425,
                     "latitude": 27.75141,
@@ -1093,25 +1292,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 185,
-                            "openAppointmentSlots": 185,
+                            "openTimeslots": 239,
+                            "openAppointmentSlots": 239,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 196,
-                            "openAppointmentSlots": 196,
+                            "openTimeslots": 253,
+                            "openAppointmentSlots": 253,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
+                            "openTimeslots": 67,
+                            "openAppointmentSlots": 67,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 431,
+                    "openTimeslots": 559,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 431,
+                    "openAppointmentSlots": 559,
                     "name": "Bandera and Guilbeau H-E-B",
                     "longitude": -98.64364,
                     "latitude": 29.51985,
@@ -1127,25 +1326,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 30,
-                            "openAppointmentSlots": 30,
+                            "openTimeslots": 9,
+                            "openAppointmentSlots": 9,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 36,
-                            "openAppointmentSlots": 36,
+                            "openTimeslots": 12,
+                            "openAppointmentSlots": 12,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 4,
-                            "openAppointmentSlots": 4,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 40,
+                            "openAppointmentSlots": 40,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 70,
+                    "openTimeslots": 61,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 70,
+                    "openAppointmentSlots": 61,
                     "name": "Oak Hill H-E-B",
                     "longitude": -97.88755,
                     "latitude": 30.22696,
@@ -1161,15 +1360,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 626,
-                            "openAppointmentSlots": 626,
+                            "openTimeslots": 629,
+                            "openAppointmentSlots": 629,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 626,
+                    "openTimeslots": 629,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 626,
+                    "openAppointmentSlots": 629,
                     "name": "Burnet H-E-B",
                     "longitude": -98.22452,
                     "latitude": 30.7588,
@@ -1221,25 +1420,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 120,
-                            "openAppointmentSlots": 120,
+                            "openTimeslots": 70,
+                            "openAppointmentSlots": 70,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 120,
-                            "openAppointmentSlots": 120,
+                            "openTimeslots": 69,
+                            "openAppointmentSlots": 69,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 120,
-                            "openAppointmentSlots": 120,
+                            "openTimeslots": 72,
+                            "openAppointmentSlots": 72,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 360,
+                    "openTimeslots": 211,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 360,
+                    "openAppointmentSlots": 211,
                     "name": "Military and Goliad H-E-B",
                     "longitude": -98.4362,
                     "latitude": 29.35194,
@@ -1255,20 +1454,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 120,
-                            "openAppointmentSlots": 120,
+                            "openTimeslots": 140,
+                            "openAppointmentSlots": 140,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 120,
-                            "openAppointmentSlots": 120,
+                            "openTimeslots": 140,
+                            "openAppointmentSlots": 140,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 240,
+                    "openTimeslots": 280,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 240,
+                    "openAppointmentSlots": 280,
                     "name": "Lockhart H-E-B",
                     "longitude": -97.66994,
                     "latitude": 29.88213,
@@ -1356,25 +1555,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 7,
-                            "openAppointmentSlots": 7,
+                            "openTimeslots": 16,
+                            "openAppointmentSlots": 16,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 9,
-                            "openAppointmentSlots": 9,
+                            "openTimeslots": 16,
+                            "openAppointmentSlots": 16,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 9,
-                            "openAppointmentSlots": 9,
+                            "openTimeslots": 16,
+                            "openAppointmentSlots": 16,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 25,
+                    "openTimeslots": 48,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 25,
+                    "openAppointmentSlots": 48,
                     "name": "Fry Rd and I10 H-E-B",
                     "longitude": -95.7189,
                     "latitude": 29.7898,
@@ -1390,30 +1589,45 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 61,
-                            "openAppointmentSlots": 61,
+                            "openTimeslots": 63,
+                            "openAppointmentSlots": 63,
                             "manufacturer": "Janssen"
                         },
                         {
-                            "openTimeslots": 241,
-                            "openAppointmentSlots": 241,
+                            "openTimeslots": 88,
+                            "openAppointmentSlots": 88,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 626,
-                            "openAppointmentSlots": 626,
+                            "openTimeslots": 7,
+                            "openAppointmentSlots": 7,
+                            "manufacturer": "Pediatric_Moderna"
+                        },
+                        {
+                            "openTimeslots": 627,
+                            "openAppointmentSlots": 627,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 173,
-                            "openAppointmentSlots": 173,
+                            "openTimeslots": 39,
+                            "openAppointmentSlots": 39,
                             "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 7,
+                            "openAppointmentSlots": 7,
+                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 1101,
+                    "openTimeslots": 881,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 1101,
+                    "openAppointmentSlots": 881,
                     "name": "Culebra and 1604 H-E-B",
                     "longitude": -98.70445,
                     "latitude": 29.49292,
@@ -1429,30 +1643,30 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 33,
-                            "openAppointmentSlots": 33,
+                            "openTimeslots": 30,
+                            "openAppointmentSlots": 30,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 35,
-                            "openAppointmentSlots": 35,
+                            "openTimeslots": 34,
+                            "openAppointmentSlots": 34,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 35,
-                            "openAppointmentSlots": 35,
+                            "openTimeslots": 38,
+                            "openAppointmentSlots": 38,
                             "manufacturer": "Pediatric_Pfizer"
                         },
                         {
-                            "openTimeslots": 18,
-                            "openAppointmentSlots": 18,
+                            "openTimeslots": 40,
+                            "openAppointmentSlots": 40,
                             "manufacturer": "Other"
                         }
                     ],
-                    "openTimeslots": 103,
-                    "openFluTimeslots": 18,
-                    "openFluAppointmentSlots": 18,
-                    "openAppointmentSlots": 103,
+                    "openTimeslots": 102,
+                    "openFluTimeslots": 40,
+                    "openFluAppointmentSlots": 40,
+                    "openAppointmentSlots": 102,
                     "name": "Beaumont 6 H-E-B",
                     "longitude": -94.12834,
                     "latitude": 30.06853,
@@ -1486,20 +1700,30 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 42,
-                            "openAppointmentSlots": 42,
-                            "manufacturer": "Moderna"
+                            "openTimeslots": 29,
+                            "openAppointmentSlots": 29,
+                            "manufacturer": "Pediatric_Moderna"
                         },
                         {
-                            "openTimeslots": 180,
-                            "openAppointmentSlots": 180,
+                            "openTimeslots": 175,
+                            "openAppointmentSlots": 175,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 105,
+                            "openAppointmentSlots": 105,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 60,
+                            "openAppointmentSlots": 60,
+                            "manufacturer": "Ultra_Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 222,
+                    "openTimeslots": 369,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 222,
+                    "openAppointmentSlots": 369,
                     "name": "New Braunfels H-E-B plus!",
                     "longitude": -98.0782,
                     "latitude": 29.731,
@@ -1515,25 +1739,30 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 245,
-                            "openAppointmentSlots": 245,
+                            "openTimeslots": 94,
+                            "openAppointmentSlots": 94,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 235,
-                            "openAppointmentSlots": 235,
+                            "openTimeslots": 88,
+                            "openAppointmentSlots": 88,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 131,
-                            "openAppointmentSlots": 131,
+                            "openTimeslots": 67,
+                            "openAppointmentSlots": 67,
                             "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 471,
+                            "openAppointmentSlots": 471,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 611,
+                    "openTimeslots": 720,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 611,
+                    "openAppointmentSlots": 720,
                     "name": "Hutto 130 and Gattis School H-E-B plus!",
                     "longitude": -97.58284,
                     "latitude": 30.50112,
@@ -1549,13 +1778,13 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 203,
-                            "openAppointmentSlots": 203,
+                            "openTimeslots": 179,
+                            "openAppointmentSlots": 179,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 203,
-                            "openAppointmentSlots": 203,
+                            "openTimeslots": 156,
+                            "openAppointmentSlots": 156,
                             "manufacturer": "Pfizer"
                         },
                         {
@@ -1564,11 +1793,11 @@
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 446,
+                    "openTimeslots": 375,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 446,
-                    "name": "League City H-E-B",
+                    "openAppointmentSlots": 375,
+                    "name": "League City Market H-E-B",
                     "longitude": -95.04131,
                     "latitude": 29.50588,
                     "fluUrl": "",
@@ -1583,30 +1812,35 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 36,
-                            "openAppointmentSlots": 36,
+                            "openTimeslots": 52,
+                            "openAppointmentSlots": 52,
                             "manufacturer": "Janssen"
                         },
                         {
-                            "openTimeslots": 34,
-                            "openAppointmentSlots": 34,
+                            "openTimeslots": 51,
+                            "openAppointmentSlots": 51,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 58,
-                            "openAppointmentSlots": 58,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 47,
+                            "openAppointmentSlots": 47,
+                            "manufacturer": "Pediatric_Moderna"
                         },
                         {
                             "openTimeslots": 16,
                             "openAppointmentSlots": 16,
                             "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 73,
+                            "openAppointmentSlots": 73,
+                            "manufacturer": "Ultra_Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 144,
+                    "openTimeslots": 239,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 144,
+                    "openAppointmentSlots": 239,
                     "name": "Odessa H-E-B University Blvd",
                     "longitude": -102.41008,
                     "latitude": 31.86213,
@@ -1640,25 +1874,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 19,
-                            "openAppointmentSlots": 19,
+                            "openTimeslots": 194,
+                            "openAppointmentSlots": 194,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 12,
-                            "openAppointmentSlots": 12,
+                            "openTimeslots": 119,
+                            "openAppointmentSlots": 119,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
+                            "openTimeslots": 100,
+                            "openAppointmentSlots": 100,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 41,
+                    "openTimeslots": 413,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 41,
+                    "openAppointmentSlots": 413,
                     "name": "Clear Lake Marketplace H-E-B",
                     "longitude": -95.12473,
                     "latitude": 29.60563,
@@ -1674,20 +1908,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
+                            "openTimeslots": 14,
+                            "openAppointmentSlots": 14,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 9,
-                            "openAppointmentSlots": 9,
+                            "openTimeslots": 14,
+                            "openAppointmentSlots": 14,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 19,
+                    "openTimeslots": 28,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 19,
+                    "openAppointmentSlots": 28,
                     "name": "Lakeway H-E-B",
                     "longitude": -97.96662,
                     "latitude": 30.34368,
@@ -1757,20 +1991,35 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 22,
-                            "openAppointmentSlots": 22,
+                            "openTimeslots": 31,
+                            "openAppointmentSlots": 31,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 19,
+                            "openAppointmentSlots": 19,
+                            "manufacturer": "Pediatric_Moderna"
+                        },
+                        {
+                            "openTimeslots": 35,
+                            "openAppointmentSlots": 35,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 16,
-                            "openAppointmentSlots": 16,
+                            "openTimeslots": 28,
+                            "openAppointmentSlots": 28,
                             "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
+                            "manufacturer": "Ultra_Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 38,
+                    "openTimeslots": 133,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 38,
+                    "openAppointmentSlots": 133,
                     "name": "Tomball Pkwy and Graham H-E-B",
                     "longitude": -95.63218,
                     "latitude": 30.08868,
@@ -1786,15 +2035,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 28,
-                            "openAppointmentSlots": 28,
+                            "openTimeslots": 22,
+                            "openAppointmentSlots": 22,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 5,
+                            "openAppointmentSlots": 5,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 28,
+                    "openTimeslots": 27,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 28,
+                    "openAppointmentSlots": 27,
                     "name": "Louetta and Stuebner H-E-B",
                     "longitude": -95.5243,
                     "latitude": 30.0209,
@@ -1837,16 +2091,32 @@
                 },
                 {
                     "zip": "77380-1531",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gud6QAC",
                     "type": "store",
                     "street": "9595 SIX PINES RD",
                     "storeNumber": 579,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 24,
+                            "openAppointmentSlots": 24,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 15,
+                            "openAppointmentSlots": 15,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 17,
+                            "openAppointmentSlots": 17,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 56,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 56,
                     "name": "Woodlands Market H-E-B",
                     "longitude": -95.46575,
                     "latitude": 30.16409,
@@ -1862,30 +2132,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 109,
-                            "openAppointmentSlots": 109,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 100,
-                            "openAppointmentSlots": 100,
+                            "openTimeslots": 489,
+                            "openAppointmentSlots": 489,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 294,
-                            "openAppointmentSlots": 294,
+                            "openTimeslots": 449,
+                            "openAppointmentSlots": 449,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 12,
-                            "openAppointmentSlots": 12,
+                            "openTimeslots": 216,
+                            "openAppointmentSlots": 216,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 515,
+                    "openTimeslots": 1154,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 515,
+                    "openAppointmentSlots": 1154,
                     "name": "Parmer and Whitestone H-E-B",
                     "longitude": -97.78545,
                     "latitude": 30.5328,
@@ -1901,25 +2166,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
+                            "openTimeslots": 82,
+                            "openAppointmentSlots": 82,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
+                            "openTimeslots": 84,
+                            "openAppointmentSlots": 84,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
+                            "openTimeslots": 43,
+                            "openAppointmentSlots": 43,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 30,
+                    "openTimeslots": 209,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 30,
+                    "openAppointmentSlots": 209,
                     "name": "Stephenville H-E-B",
                     "longitude": -98.22569,
                     "latitude": 32.20975,
@@ -1935,25 +2200,35 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 86,
-                            "openAppointmentSlots": 86,
+                            "openTimeslots": 84,
+                            "openAppointmentSlots": 84,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 41,
-                            "openAppointmentSlots": 41,
+                            "openTimeslots": 28,
+                            "openAppointmentSlots": 28,
+                            "manufacturer": "Pediatric_Moderna"
+                        },
+                        {
+                            "openTimeslots": 70,
+                            "openAppointmentSlots": 70,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 26,
-                            "openAppointmentSlots": 26,
+                            "openTimeslots": 46,
+                            "openAppointmentSlots": 46,
                             "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 28,
+                            "openAppointmentSlots": 28,
+                            "manufacturer": "Ultra_Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 153,
+                    "openTimeslots": 256,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 153,
+                    "openAppointmentSlots": 256,
                     "name": "Slaughter and Manchaca H-E-B",
                     "longitude": -97.82509,
                     "latitude": 30.17524,
@@ -1969,25 +2244,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 15,
-                            "openAppointmentSlots": 15,
+                            "openTimeslots": 6,
+                            "openAppointmentSlots": 6,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 30,
-                            "openAppointmentSlots": 30,
+                            "openTimeslots": 4,
+                            "openAppointmentSlots": 4,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 1,
-                            "openAppointmentSlots": 1,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 31,
+                            "openAppointmentSlots": 31,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 46,
+                    "openTimeslots": 41,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 46,
+                    "openAppointmentSlots": 41,
                     "name": "I 35 and William Cannon H-E-B",
                     "longitude": -97.76922,
                     "latitude": 30.19107,
@@ -2003,25 +2278,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 12,
-                            "openAppointmentSlots": 12,
+                            "openTimeslots": 122,
+                            "openAppointmentSlots": 122,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 590,
-                            "openAppointmentSlots": 590,
+                            "openTimeslots": 156,
+                            "openAppointmentSlots": 156,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 49,
-                            "openAppointmentSlots": 49,
+                            "openTimeslots": 58,
+                            "openAppointmentSlots": 58,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 651,
+                    "openTimeslots": 336,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 651,
+                    "openAppointmentSlots": 336,
                     "name": "Nacogdoches and O'Connor H-E-B",
                     "longitude": -98.3856,
                     "latitude": 29.56937,
@@ -2030,16 +2305,42 @@
                 },
                 {
                     "zip": "78596-4511",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubNQAS",
                     "type": "store",
                     "street": "1004 N. TEXAS",
                     "storeNumber": 231,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 104,
+                            "openAppointmentSlots": 104,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 17,
+                            "openAppointmentSlots": 17,
+                            "manufacturer": "Pediatric_Moderna"
+                        },
+                        {
+                            "openTimeslots": 94,
+                            "openAppointmentSlots": 94,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 103,
+                            "openAppointmentSlots": 103,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 14,
+                            "openAppointmentSlots": 14,
+                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 332,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 332,
                     "name": "83 and N Texas H-E-B",
                     "longitude": -97.99096,
                     "latitude": 26.17103,
@@ -2091,20 +2392,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
+                            "openTimeslots": 67,
+                            "openAppointmentSlots": 67,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 46,
-                            "openAppointmentSlots": 46,
+                            "openTimeslots": 69,
+                            "openAppointmentSlots": 69,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 96,
+                    "openTimeslots": 136,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 96,
+                    "openAppointmentSlots": 136,
                     "name": "Atascocita H-E-B",
                     "longitude": -95.1642,
                     "latitude": 29.9983,
@@ -2120,25 +2421,35 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 24,
-                            "openAppointmentSlots": 24,
+                            "openTimeslots": 106,
+                            "openAppointmentSlots": 106,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 47,
+                            "openAppointmentSlots": 47,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 72,
-                            "openAppointmentSlots": 72,
+                            "openTimeslots": 88,
+                            "openAppointmentSlots": 88,
+                            "manufacturer": "Pediatric_Moderna"
+                        },
+                        {
+                            "openTimeslots": 105,
+                            "openAppointmentSlots": 105,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 48,
-                            "openAppointmentSlots": 48,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 87,
+                            "openAppointmentSlots": 87,
+                            "manufacturer": "Ultra_Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 144,
+                    "openTimeslots": 433,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 144,
+                    "openAppointmentSlots": 433,
                     "name": "Gulfgate H-E-B",
                     "longitude": -95.2968,
                     "latitude": 29.6994,
@@ -2147,16 +2458,27 @@
                 },
                 {
                     "zip": "77072-5000",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuckQAC",
                     "type": "store",
                     "street": "10100 BEECHNUT",
                     "storeNumber": 541,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 10,
+                            "openAppointmentSlots": 10,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 30,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 30,
                     "name": "Beechnut H-E-B",
                     "longitude": -95.5604,
                     "latitude": 29.6896,
@@ -2172,20 +2494,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 74,
-                            "openAppointmentSlots": 74,
+                            "openTimeslots": 92,
+                            "openAppointmentSlots": 92,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 63,
-                            "openAppointmentSlots": 63,
+                            "openTimeslots": 100,
+                            "openAppointmentSlots": 100,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 137,
+                    "openTimeslots": 192,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 137,
+                    "openAppointmentSlots": 192,
                     "name": "Texas Avenue H-E-B",
                     "longitude": -96.3165,
                     "latitude": 30.6131,
@@ -2201,15 +2523,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 11,
-                            "openAppointmentSlots": 11,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 46,
+                            "openAppointmentSlots": 46,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 24,
+                            "openAppointmentSlots": 24,
+                            "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 11,
+                    "openTimeslots": 70,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 11,
+                    "openAppointmentSlots": 70,
                     "name": "Grant and Spring Cypress H-E-B",
                     "longitude": -95.63698,
                     "latitude": 30.00365,
@@ -2225,25 +2552,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 409,
-                            "openAppointmentSlots": 409,
+                            "openTimeslots": 104,
+                            "openAppointmentSlots": 104,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 409,
-                            "openAppointmentSlots": 409,
+                            "openTimeslots": 104,
+                            "openAppointmentSlots": 104,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 409,
-                            "openAppointmentSlots": 409,
+                            "openTimeslots": 104,
+                            "openAppointmentSlots": 104,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 1227,
+                    "openTimeslots": 312,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 1227,
+                    "openAppointmentSlots": 312,
                     "name": "Nogalitos H-E-B",
                     "longitude": -98.51485,
                     "latitude": 29.39799,
@@ -2288,16 +2615,22 @@
                 },
                 {
                     "zip": "78501-2951",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueBQAS",
                     "type": "store",
                     "street": "200 US EXPRESSWAY 83",
                     "storeNumber": 702,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 2,
+                            "openAppointmentSlots": 2,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 2,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 2,
                     "name": "South 2nd Street H-E-B",
                     "longitude": -98.22546,
                     "latitude": 26.18953,
@@ -2306,16 +2639,32 @@
                 },
                 {
                     "zip": "77386-4343",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueCQAS",
                     "type": "store",
                     "street": "3540 RAYFORD RD",
                     "storeNumber": 705,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 119,
+                            "openAppointmentSlots": 119,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 176,
+                            "openAppointmentSlots": 176,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 119,
+                            "openAppointmentSlots": 119,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 414,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 414,
                     "name": "Spring Creek Market H-E-B",
                     "longitude": -95.38801,
                     "latitude": 30.11036,
@@ -2324,16 +2673,22 @@
                 },
                 {
                     "zip": "78155-5131",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueLQAS",
                     "type": "store",
                     "street": "1340 E COURT ST",
                     "storeNumber": 716,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 363,
+                            "openAppointmentSlots": 363,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 363,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 363,
                     "name": "Seguin H-E-B",
                     "longitude": -97.94366,
                     "latitude": 29.57065,
@@ -2360,16 +2715,27 @@
                 },
                 {
                     "zip": "77345-2621",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueNQAS",
                     "type": "store",
                     "street": "4517 KINGWOOD DRIVE",
                     "storeNumber": 720,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 28,
+                            "openAppointmentSlots": 28,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 30,
+                            "openAppointmentSlots": 30,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 58,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 58,
                     "name": "Kingwood Market H-E-B",
                     "longitude": -95.18375,
                     "latitude": 30.05329,
@@ -2378,16 +2744,32 @@
                 },
                 {
                     "zip": "76542-0",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueOQAS",
                     "type": "store",
                     "street": "1101 W. STAN SCHLUETER LOOP",
                     "storeNumber": 721,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 15,
+                            "openAppointmentSlots": 15,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 41,
+                            "openAppointmentSlots": 41,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 15,
+                            "openAppointmentSlots": 15,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 71,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 71,
                     "name": "Fort Hood Stan Schlueter H-E-B",
                     "longitude": -97.75988,
                     "latitude": 31.07989,
@@ -2396,32 +2778,16 @@
                 },
                 {
                     "zip": "77354-1611",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuePQAS",
+                    "url": null,
                     "type": "store",
                     "street": "7988 FM 1488",
                     "storeNumber": 722,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 7,
-                            "openAppointmentSlots": 7,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 12,
-                            "openAppointmentSlots": 12,
-                            "manufacturer": "Pediatric_Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 29,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 29,
+                    "openAppointmentSlots": 0,
                     "name": "Magnolia Market H-E-B",
                     "longitude": -95.5837,
                     "latitude": 30.2217,
@@ -2437,25 +2803,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 28,
-                            "openAppointmentSlots": 28,
+                            "openTimeslots": 29,
+                            "openAppointmentSlots": 29,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 121,
-                            "openAppointmentSlots": 121,
+                            "openTimeslots": 32,
+                            "openAppointmentSlots": 32,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
+                            "openTimeslots": 47,
+                            "openAppointmentSlots": 47,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 159,
+                    "openTimeslots": 108,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 159,
+                    "openAppointmentSlots": 108,
                     "name": "Aliana Market H-E-B",
                     "longitude": -95.7137,
                     "latitude": 29.6597,
@@ -2489,13 +2855,13 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 46,
-                            "openAppointmentSlots": 46,
+                            "openTimeslots": 31,
+                            "openAppointmentSlots": 31,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 57,
-                            "openAppointmentSlots": 57,
+                            "openTimeslots": 24,
+                            "openAppointmentSlots": 24,
                             "manufacturer": "Pfizer"
                         },
                         {
@@ -2504,10 +2870,10 @@
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 113,
+                    "openTimeslots": 65,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 113,
+                    "openAppointmentSlots": 65,
                     "name": "Four Points H-E-B",
                     "longitude": -97.85202,
                     "latitude": 30.40458,
@@ -2516,16 +2882,27 @@
                 },
                 {
                     "zip": "78666-5615",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucNQAS",
                     "type": "store",
                     "street": "200 WEST HOPKINS ST.",
                     "storeNumber": 455,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 18,
+                            "openAppointmentSlots": 18,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 12,
+                            "openAppointmentSlots": 12,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 30,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 30,
                     "name": "West Hopkins H-E-B",
                     "longitude": -97.94292,
                     "latitude": 29.88305,
@@ -2534,22 +2911,16 @@
                 },
                 {
                     "zip": "78405-2040",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucOQAS",
+                    "url": null,
                     "type": "store",
                     "street": "3033 SOUTH PORT ST.",
                     "storeNumber": 462,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 23,
-                            "openAppointmentSlots": 23,
-                            "manufacturer": "Moderna"
-                        }
-                    ],
-                    "openTimeslots": 23,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 23,
+                    "openAppointmentSlots": 0,
                     "name": "S Port and Tarlton H-E-B",
                     "longitude": -97.42137,
                     "latitude": 27.76687,
@@ -2565,25 +2936,35 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 468,
-                            "openAppointmentSlots": 468,
+                            "openTimeslots": 424,
+                            "openAppointmentSlots": 424,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 600,
-                            "openAppointmentSlots": 600,
+                            "openTimeslots": 13,
+                            "openAppointmentSlots": 13,
+                            "manufacturer": "Pediatric_Moderna"
+                        },
+                        {
+                            "openTimeslots": 499,
+                            "openAppointmentSlots": 499,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 464,
-                            "openAppointmentSlots": 464,
+                            "openTimeslots": 415,
+                            "openAppointmentSlots": 415,
                             "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 18,
+                            "openAppointmentSlots": 18,
+                            "manufacturer": "Ultra_Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 1532,
+                    "openTimeslots": 1369,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 1532,
+                    "openAppointmentSlots": 1369,
                     "name": "Loop 1604 and Blanco Rd H-E-B plus!",
                     "longitude": -98.50968,
                     "latitude": 29.60792,
@@ -2599,15 +2980,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 175,
-                            "openAppointmentSlots": 175,
+                            "openTimeslots": 150,
+                            "openAppointmentSlots": 150,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 303,
+                            "openAppointmentSlots": 303,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 175,
+                    "openTimeslots": 453,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 175,
+                    "openAppointmentSlots": 453,
                     "name": "7th Street H-E-B",
                     "longitude": -97.71143,
                     "latitude": 30.26046,
@@ -2616,16 +3002,27 @@
                 },
                 {
                     "zip": "78207-3706",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucRQAS",
                     "type": "store",
                     "street": "108 N ROSILLO",
                     "storeNumber": 466,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 30,
+                            "openAppointmentSlots": 30,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 30,
+                            "openAppointmentSlots": 30,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 60,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 60,
                     "name": "Commerce and Rosillo H-E-B",
                     "longitude": -98.5256,
                     "latitude": 29.4281,
@@ -2659,25 +3056,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 168,
-                            "openAppointmentSlots": 168,
+                            "openTimeslots": 195,
+                            "openAppointmentSlots": 195,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 196,
-                            "openAppointmentSlots": 196,
+                            "openTimeslots": 214,
+                            "openAppointmentSlots": 214,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 143,
-                            "openAppointmentSlots": 143,
+                            "openTimeslots": 163,
+                            "openAppointmentSlots": 163,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 507,
+                    "openTimeslots": 572,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 507,
+                    "openAppointmentSlots": 572,
                     "name": "Fairmont Pkwy H-E-B",
                     "longitude": -95.14512,
                     "latitude": 29.6497,
@@ -2693,20 +3090,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 52,
-                            "openAppointmentSlots": 52,
+                            "openTimeslots": 51,
+                            "openAppointmentSlots": 51,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 43,
+                            "openAppointmentSlots": 43,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 52,
-                            "openAppointmentSlots": 52,
+                            "openTimeslots": 38,
+                            "openAppointmentSlots": 38,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 104,
+                    "openTimeslots": 132,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 104,
+                    "openAppointmentSlots": 132,
                     "name": "Lake Colony H-E-B",
                     "longitude": -95.58244,
                     "latitude": 29.58032,
@@ -2722,25 +3124,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 40,
-                            "openAppointmentSlots": 40,
+                            "openTimeslots": 36,
+                            "openAppointmentSlots": 36,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 100,
-                            "openAppointmentSlots": 100,
+                            "openTimeslots": 69,
+                            "openAppointmentSlots": 69,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 150,
+                    "openTimeslots": 125,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 150,
+                    "openAppointmentSlots": 125,
                     "name": "Elgin H-E-B",
                     "longitude": -97.38258,
                     "latitude": 30.34701,
@@ -2749,16 +3151,47 @@
                 },
                 {
                     "zip": "78753-1632",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucWQAS",
                     "type": "store",
                     "street": "500 CANYON RIDGE DR.",
                     "storeNumber": 476,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 9,
+                            "openAppointmentSlots": 9,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 1,
+                            "openAppointmentSlots": 1,
+                            "manufacturer": "Pediatric_Moderna"
+                        },
+                        {
+                            "openTimeslots": 5,
+                            "openAppointmentSlots": 5,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 10,
+                            "openAppointmentSlots": 10,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 23,
+                            "openAppointmentSlots": 23,
+                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 9,
+                            "openAppointmentSlots": 9,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 57,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 57,
                     "name": "Tech Ridge H-E-B",
                     "longitude": -97.67201,
                     "latitude": 30.40443,
@@ -2774,15 +3207,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 55,
-                            "openAppointmentSlots": 55,
+                            "openTimeslots": 49,
+                            "openAppointmentSlots": 49,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 55,
+                    "openTimeslots": 49,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 55,
+                    "openAppointmentSlots": 49,
                     "name": "Buda H-E-B",
                     "longitude": -97.82074,
                     "latitude": 30.08769,
@@ -2798,25 +3231,30 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 104,
-                            "openAppointmentSlots": 104,
+                            "openTimeslots": 61,
+                            "openAppointmentSlots": 61,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 108,
-                            "openAppointmentSlots": 108,
+                            "openTimeslots": 59,
+                            "openAppointmentSlots": 59,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 108,
-                            "openAppointmentSlots": 108,
+                            "openTimeslots": 63,
+                            "openAppointmentSlots": 63,
                             "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 112,
+                            "openAppointmentSlots": 112,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 320,
+                    "openTimeslots": 295,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 320,
+                    "openAppointmentSlots": 295,
                     "name": "Grissom and Tezel H-E-B",
                     "longitude": -98.66574,
                     "latitude": 29.48432,
@@ -2825,16 +3263,32 @@
                 },
                 {
                     "zip": "78626-5400",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubRQAS",
                     "type": "store",
                     "street": "1100 SOUTH IH35",
                     "storeNumber": 237,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 29,
+                            "openAppointmentSlots": 29,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 44,
+                            "openAppointmentSlots": 44,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 26,
+                            "openAppointmentSlots": 26,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 99,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 99,
                     "name": "35 and West University H-E-B",
                     "longitude": -97.69028,
                     "latitude": 30.63446,
@@ -2868,25 +3322,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
+                            "openTimeslots": 28,
+                            "openAppointmentSlots": 28,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 59,
-                            "openAppointmentSlots": 59,
+                            "openTimeslots": 33,
+                            "openAppointmentSlots": 33,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 20,
-                            "openAppointmentSlots": 20,
+                            "openTimeslots": 9,
+                            "openAppointmentSlots": 9,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 89,
+                    "openTimeslots": 70,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 89,
+                    "openAppointmentSlots": 70,
                     "name": "East Hopkins H-E-B",
                     "longitude": -97.93132,
                     "latitude": 29.88489,
@@ -2902,20 +3356,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 672,
-                            "openAppointmentSlots": 672,
+                            "openTimeslots": 666,
+                            "openAppointmentSlots": 666,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 75,
-                            "openAppointmentSlots": 75,
+                            "openTimeslots": 72,
+                            "openAppointmentSlots": 72,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 83,
+                            "openAppointmentSlots": 83,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 747,
+                    "openTimeslots": 821,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 747,
+                    "openAppointmentSlots": 821,
                     "name": "Leopard and Nueces Bay H-E-B",
                     "longitude": -97.42774,
                     "latitude": 27.79695,
@@ -2931,25 +3390,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 176,
-                            "openAppointmentSlots": 176,
+                            "openTimeslots": 186,
+                            "openAppointmentSlots": 186,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 201,
-                            "openAppointmentSlots": 201,
+                            "openTimeslots": 190,
+                            "openAppointmentSlots": 190,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 47,
-                            "openAppointmentSlots": 47,
+                            "openTimeslots": 60,
+                            "openAppointmentSlots": 60,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 424,
+                    "openTimeslots": 436,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 424,
+                    "openAppointmentSlots": 436,
                     "name": "Tejas Center H-E-B",
                     "longitude": -96.3513,
                     "latitude": 30.64506,
@@ -2965,15 +3424,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 49,
-                            "openAppointmentSlots": 49,
+                            "openTimeslots": 36,
+                            "openAppointmentSlots": 36,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 47,
+                            "openAppointmentSlots": 47,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 49,
+                    "openTimeslots": 83,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 49,
+                    "openAppointmentSlots": 83,
                     "name": "Westheimer and Kirkwood H-E-B",
                     "longitude": -95.587,
                     "latitude": 29.7363,
@@ -2989,25 +3453,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 45,
-                            "openAppointmentSlots": 45,
+                            "openTimeslots": 55,
+                            "openAppointmentSlots": 55,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 54,
-                            "openAppointmentSlots": 54,
+                            "openTimeslots": 107,
+                            "openAppointmentSlots": 107,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 30,
-                            "openAppointmentSlots": 30,
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 129,
+                    "openTimeslots": 212,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 129,
+                    "openAppointmentSlots": 212,
                     "name": "Bear Creek H-E-B",
                     "longitude": -95.6457,
                     "latitude": 29.8487,
@@ -3059,15 +3523,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 104,
-                            "openAppointmentSlots": 104,
+                            "openTimeslots": 183,
+                            "openAppointmentSlots": 183,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 104,
+                    "openTimeslots": 183,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 104,
+                    "openAppointmentSlots": 183,
                     "name": "Deco District H-E-B",
                     "longitude": -98.5261,
                     "latitude": 29.4646,
@@ -3101,20 +3565,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 485,
-                            "openAppointmentSlots": 485,
+                            "openTimeslots": 464,
+                            "openAppointmentSlots": 464,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 490,
-                            "openAppointmentSlots": 490,
+                            "openTimeslots": 468,
+                            "openAppointmentSlots": 468,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 88,
+                            "openAppointmentSlots": 88,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 975,
+                    "openTimeslots": 1020,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 975,
+                    "openAppointmentSlots": 1020,
                     "name": "Friendswood H-E-B",
                     "longitude": -95.1912,
                     "latitude": 29.5066,
@@ -3130,25 +3599,30 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 126,
-                            "openAppointmentSlots": 126,
+                            "openTimeslots": 32,
+                            "openAppointmentSlots": 32,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 124,
-                            "openAppointmentSlots": 124,
+                            "openTimeslots": 29,
+                            "openAppointmentSlots": 29,
+                            "manufacturer": "Pediatric_Moderna"
+                        },
+                        {
+                            "openTimeslots": 32,
+                            "openAppointmentSlots": 32,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 57,
-                            "openAppointmentSlots": 57,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 29,
+                            "openAppointmentSlots": 29,
+                            "manufacturer": "Ultra_Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 307,
+                    "openTimeslots": 122,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 307,
+                    "openAppointmentSlots": 122,
                     "name": "Lake Jackson H-E-B",
                     "longitude": -95.44554,
                     "latitude": 29.04151,
@@ -3164,15 +3638,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
+                            "openTimeslots": 94,
+                            "openAppointmentSlots": 94,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 72,
+                            "openAppointmentSlots": 72,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 10,
+                    "openTimeslots": 166,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 10,
+                    "openAppointmentSlots": 166,
                     "name": "Wimberley H-E-B",
                     "longitude": -98.10174,
                     "latitude": 30.00144,
@@ -3188,20 +3667,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 165,
-                            "openAppointmentSlots": 165,
+                            "openTimeslots": 38,
+                            "openAppointmentSlots": 38,
+                            "manufacturer": "Pediatric_Moderna"
+                        },
+                        {
+                            "openTimeslots": 164,
+                            "openAppointmentSlots": 164,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 115,
-                            "openAppointmentSlots": 115,
+                            "openTimeslots": 48,
+                            "openAppointmentSlots": 48,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 280,
+                    "openTimeslots": 250,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 280,
+                    "openAppointmentSlots": 250,
                     "name": "H-E-B Market at Tuckerton",
                     "longitude": -95.72501,
                     "latitude": 29.92737,
@@ -3217,20 +3701,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 89,
-                            "openAppointmentSlots": 89,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 86,
-                            "openAppointmentSlots": 86,
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 175,
+                    "openTimeslots": 50,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 175,
+                    "openAppointmentSlots": 50,
                     "name": "Champion Forest Market H-E-B",
                     "longitude": -95.57475,
                     "latitude": 30.0551,
@@ -3246,25 +3725,30 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 18,
-                            "openAppointmentSlots": 18,
+                            "openTimeslots": 9,
+                            "openAppointmentSlots": 9,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 68,
-                            "openAppointmentSlots": 68,
+                            "openTimeslots": 4,
+                            "openAppointmentSlots": 4,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 75,
-                            "openAppointmentSlots": 75,
+                            "openTimeslots": 6,
+                            "openAppointmentSlots": 6,
                             "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 18,
+                            "openAppointmentSlots": 18,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 161,
+                    "openTimeslots": 37,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 161,
+                    "openAppointmentSlots": 37,
                     "name": "Richmond Market H-E-B",
                     "longitude": -95.74781,
                     "latitude": 29.55142,
@@ -3280,20 +3764,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 4,
-                            "openAppointmentSlots": 4,
+                            "openTimeslots": 59,
+                            "openAppointmentSlots": 59,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 8,
-                            "openAppointmentSlots": 8,
+                            "openTimeslots": 60,
+                            "openAppointmentSlots": 60,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 59,
+                            "openAppointmentSlots": 59,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 12,
+                    "openTimeslots": 178,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 12,
+                    "openAppointmentSlots": 178,
                     "name": "Huntsville H-E-B",
                     "longitude": -95.56075,
                     "latitude": 30.72274,
@@ -3309,25 +3798,35 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 247,
-                            "openAppointmentSlots": 247,
+                            "openTimeslots": 194,
+                            "openAppointmentSlots": 194,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 329,
-                            "openAppointmentSlots": 329,
+                            "openTimeslots": 16,
+                            "openAppointmentSlots": 16,
+                            "manufacturer": "Pediatric_Moderna"
+                        },
+                        {
+                            "openTimeslots": 252,
+                            "openAppointmentSlots": 252,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 250,
-                            "openAppointmentSlots": 250,
+                            "openTimeslots": 185,
+                            "openAppointmentSlots": 185,
                             "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 25,
+                            "openAppointmentSlots": 25,
+                            "manufacturer": "Ultra_Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 826,
+                    "openTimeslots": 672,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 826,
+                    "openAppointmentSlots": 672,
                     "name": "Bulverde and 1604 H-E-B",
                     "longitude": -98.41746,
                     "latitude": 29.59497,
@@ -3343,15 +3842,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 1,
-                            "openAppointmentSlots": 1,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 18,
+                            "openAppointmentSlots": 18,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 1,
+                    "openTimeslots": 18,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 1,
+                    "openAppointmentSlots": 18,
                     "name": "35 and Calton H-E-B",
                     "longitude": -99.50182,
                     "latitude": 27.54172,
@@ -3385,25 +3884,35 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 55,
-                            "openAppointmentSlots": 55,
+                            "openTimeslots": 59,
+                            "openAppointmentSlots": 59,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
+                            "openTimeslots": 14,
+                            "openAppointmentSlots": 14,
+                            "manufacturer": "Pediatric_Moderna"
+                        },
+                        {
+                            "openTimeslots": 51,
+                            "openAppointmentSlots": 51,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 40,
-                            "openAppointmentSlots": 40,
+                            "openTimeslots": 32,
+                            "openAppointmentSlots": 32,
                             "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 14,
+                            "openAppointmentSlots": 14,
+                            "manufacturer": "Ultra_Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 145,
+                    "openTimeslots": 170,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 145,
+                    "openAppointmentSlots": 170,
                     "name": "Central Blvd H-E-B",
                     "longitude": -97.51093,
                     "latitude": 25.92849,
@@ -3419,25 +3928,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 59,
-                            "openAppointmentSlots": 59,
+                            "openTimeslots": 65,
+                            "openAppointmentSlots": 65,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 73,
-                            "openAppointmentSlots": 73,
+                            "openTimeslots": 57,
+                            "openAppointmentSlots": 57,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 49,
-                            "openAppointmentSlots": 49,
+                            "openTimeslots": 17,
+                            "openAppointmentSlots": 17,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 181,
+                    "openTimeslots": 139,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 181,
+                    "openAppointmentSlots": 139,
                     "name": "Hwy 183 and Whitestone Blvd H-E-B",
                     "longitude": -97.82911,
                     "latitude": 30.5225,
@@ -3453,15 +3962,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 4,
-                            "openAppointmentSlots": 4,
+                            "openTimeslots": 32,
+                            "openAppointmentSlots": 32,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 27,
+                            "openAppointmentSlots": 27,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 13,
+                            "openAppointmentSlots": 13,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 4,
+                    "openTimeslots": 72,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 4,
+                    "openAppointmentSlots": 72,
                     "name": "North Hills H-E-B",
                     "longitude": -97.74832,
                     "latitude": 30.39868,
@@ -3477,20 +3996,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 6,
-                            "openAppointmentSlots": 6,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 25,
+                            "openAppointmentSlots": 25,
+                            "manufacturer": "Pediatric_Moderna"
                         },
                         {
-                            "openTimeslots": 49,
-                            "openAppointmentSlots": 49,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 25,
+                            "openAppointmentSlots": 25,
+                            "manufacturer": "Ultra_Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 55,
+                    "openTimeslots": 50,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 55,
+                    "openAppointmentSlots": 50,
                     "name": "Moore Plaza H-E-B",
                     "longitude": -97.37238,
                     "latitude": 27.70605,
@@ -3506,20 +4025,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 79,
-                            "openAppointmentSlots": 79,
+                            "openTimeslots": 17,
+                            "openAppointmentSlots": 17,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 80,
-                            "openAppointmentSlots": 80,
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 159,
+                    "openTimeslots": 37,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 159,
+                    "openAppointmentSlots": 37,
                     "name": "Fredericksburg H-E-B",
                     "longitude": -98.87538,
                     "latitude": 30.27006,
@@ -3553,15 +4072,30 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 12,
-                            "openAppointmentSlots": 12,
+                            "openTimeslots": 36,
+                            "openAppointmentSlots": 36,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 93,
+                            "openAppointmentSlots": 93,
+                            "manufacturer": "Pediatric_Moderna"
+                        },
+                        {
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 8,
+                            "openAppointmentSlots": 8,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 12,
+                    "openTimeslots": 157,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 12,
+                    "openAppointmentSlots": 157,
                     "name": "Riverpark H-E-B",
                     "longitude": -95.6815,
                     "latitude": 29.5636,
@@ -3595,25 +4129,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 166,
-                            "openAppointmentSlots": 166,
+                            "openTimeslots": 56,
+                            "openAppointmentSlots": 56,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 157,
-                            "openAppointmentSlots": 157,
+                            "openTimeslots": 43,
+                            "openAppointmentSlots": 43,
                             "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
-                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 333,
+                    "openTimeslots": 99,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 333,
+                    "openAppointmentSlots": 99,
                     "name": "Leon Springs H-E-B",
                     "longitude": -98.63218,
                     "latitude": 29.6659,
@@ -3647,15 +4176,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 322,
-                            "openAppointmentSlots": 322,
+                            "openTimeslots": 218,
+                            "openAppointmentSlots": 218,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 322,
+                    "openTimeslots": 218,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 322,
+                    "openAppointmentSlots": 218,
                     "name": "Perrin Beitel and Thousand Oaks H-E-B",
                     "longitude": -98.4082,
                     "latitude": 29.5491,
@@ -3664,16 +4193,42 @@
                 },
                 {
                     "zip": "78582-4815",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaEQAS",
                     "type": "store",
                     "street": "4031 EAST HWY 83",
                     "storeNumber": 13,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 54,
+                            "openAppointmentSlots": 54,
+                            "manufacturer": "Pediatric_Moderna"
+                        },
+                        {
+                            "openTimeslots": 54,
+                            "openAppointmentSlots": 54,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 48,
+                            "openAppointmentSlots": 48,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 54,
+                            "openAppointmentSlots": 54,
+                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 260,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 260,
                     "name": "Rio Grande City H-E-B plus!",
                     "longitude": -98.80031,
                     "latitude": 26.37244,
@@ -3707,20 +4262,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 42,
-                            "openAppointmentSlots": 42,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
+                            "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 42,
-                            "openAppointmentSlots": 42,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 28,
+                            "openAppointmentSlots": 28,
+                            "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 84,
+                    "openTimeslots": 48,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 84,
+                    "openAppointmentSlots": 48,
                     "name": "Bay City H-E-B",
                     "longitude": -95.95804,
                     "latitude": 28.98306,
@@ -3736,25 +4291,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 27,
-                            "openAppointmentSlots": 27,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 27,
-                            "openAppointmentSlots": 27,
+                            "openTimeslots": 15,
+                            "openAppointmentSlots": 15,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 20,
-                            "openAppointmentSlots": 20,
+                            "openTimeslots": 15,
+                            "openAppointmentSlots": 15,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 74,
+                    "openTimeslots": 30,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 74,
+                    "openAppointmentSlots": 30,
                     "name": "Foster Rd H-E-B",
                     "longitude": -98.3591,
                     "latitude": 29.48109,
@@ -3763,16 +4313,32 @@
                 },
                 {
                     "zip": "78521-4787",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubeQAC",
                     "type": "store",
                     "street": "2950 SOUTHMOST ROAD",
                     "storeNumber": 332,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 72,
+                            "openAppointmentSlots": 72,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 57,
+                            "openAppointmentSlots": 57,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 48,
+                            "openAppointmentSlots": 48,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 177,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 177,
                     "name": "Southmost and 30th H-E-B",
                     "longitude": -97.46481,
                     "latitude": 25.90552,
@@ -3806,25 +4372,30 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 33,
-                            "openAppointmentSlots": 33,
+                            "openTimeslots": 19,
+                            "openAppointmentSlots": 19,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 12,
-                            "openAppointmentSlots": 12,
+                            "openTimeslots": 17,
+                            "openAppointmentSlots": 17,
+                            "manufacturer": "Pediatric_Moderna"
+                        },
+                        {
+                            "openTimeslots": 29,
+                            "openAppointmentSlots": 29,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 11,
-                            "openAppointmentSlots": 11,
+                            "openTimeslots": 29,
+                            "openAppointmentSlots": 29,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 56,
+                    "openTimeslots": 94,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 56,
+                    "openAppointmentSlots": 94,
                     "name": "Pecan and Ware H-E-B",
                     "longitude": -98.25799,
                     "latitude": 26.21925,
@@ -3840,25 +4411,30 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 24,
-                            "openAppointmentSlots": 24,
+                            "openTimeslots": 21,
+                            "openAppointmentSlots": 21,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 53,
-                            "openAppointmentSlots": 53,
+                            "openTimeslots": 7,
+                            "openAppointmentSlots": 7,
+                            "manufacturer": "Pediatric_Moderna"
+                        },
+                        {
+                            "openTimeslots": 24,
+                            "openAppointmentSlots": 24,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 25,
-                            "openAppointmentSlots": 25,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 15,
+                            "openAppointmentSlots": 15,
+                            "manufacturer": "Ultra_Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 102,
+                    "openTimeslots": 67,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 102,
+                    "openAppointmentSlots": 67,
                     "name": "Kyle H-E-B plus!",
                     "longitude": -97.86258,
                     "latitude": 30.01533,
@@ -3874,15 +4450,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 24,
-                            "openAppointmentSlots": 24,
+                            "openTimeslots": 60,
+                            "openAppointmentSlots": 60,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 68,
+                            "openAppointmentSlots": 68,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 51,
+                            "openAppointmentSlots": 51,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 24,
+                    "openTimeslots": 179,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 24,
+                    "openAppointmentSlots": 179,
                     "name": "Burleson H-E-B plus!",
                     "longitude": -97.34901,
                     "latitude": 32.52083,
@@ -3898,25 +4484,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 126,
-                            "openAppointmentSlots": 126,
+                            "openTimeslots": 119,
+                            "openAppointmentSlots": 119,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 102,
-                            "openAppointmentSlots": 102,
+                            "openTimeslots": 88,
+                            "openAppointmentSlots": 88,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 124,
-                            "openAppointmentSlots": 124,
+                            "openTimeslots": 82,
+                            "openAppointmentSlots": 82,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 352,
+                    "openTimeslots": 289,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 352,
+                    "openAppointmentSlots": 289,
                     "name": "Lytle H-E-B plus!",
                     "longitude": -98.78924,
                     "latitude": 29.23224,
@@ -3932,20 +4518,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 31,
-                            "openAppointmentSlots": 31,
+                            "openTimeslots": 38,
+                            "openAppointmentSlots": 38,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 24,
-                            "openAppointmentSlots": 24,
+                            "openTimeslots": 46,
+                            "openAppointmentSlots": 46,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 26,
+                            "openAppointmentSlots": 26,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 55,
+                    "openTimeslots": 110,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 55,
+                    "openAppointmentSlots": 110,
                     "name": "Cypress Market H-E-B",
                     "longitude": -95.6765,
                     "latitude": 29.95569,
@@ -3961,25 +4552,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 16,
-                            "openAppointmentSlots": 16,
+                            "openTimeslots": 7,
+                            "openAppointmentSlots": 7,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 33,
-                            "openAppointmentSlots": 33,
+                            "openTimeslots": 26,
+                            "openAppointmentSlots": 26,
                             "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 74,
-                            "openAppointmentSlots": 74,
-                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 123,
+                    "openTimeslots": 33,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 123,
+                    "openAppointmentSlots": 33,
                     "name": "Anderson Mill H-E-B plus!",
                     "longitude": -97.82626,
                     "latitude": 30.45495,
@@ -3995,25 +4581,30 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 169,
-                            "openAppointmentSlots": 169,
+                            "openTimeslots": 72,
+                            "openAppointmentSlots": 72,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 163,
-                            "openAppointmentSlots": 163,
+                            "openTimeslots": 23,
+                            "openAppointmentSlots": 23,
+                            "manufacturer": "Pediatric_Moderna"
+                        },
+                        {
+                            "openTimeslots": 67,
+                            "openAppointmentSlots": 67,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
+                            "openTimeslots": 26,
+                            "openAppointmentSlots": 26,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 382,
+                    "openTimeslots": 188,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 382,
+                    "openAppointmentSlots": 188,
                     "name": "Trimmier H-E-B plus!",
                     "longitude": -97.7338,
                     "latitude": 31.0909,
@@ -4083,20 +4674,30 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 119,
-                            "openAppointmentSlots": 119,
+                            "openTimeslots": 8,
+                            "openAppointmentSlots": 8,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 44,
+                            "openAppointmentSlots": 44,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 120,
-                            "openAppointmentSlots": 120,
+                            "openTimeslots": 51,
+                            "openAppointmentSlots": 51,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 16,
+                            "openAppointmentSlots": 16,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 239,
+                    "openTimeslots": 119,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 239,
+                    "openAppointmentSlots": 119,
                     "name": "Austin Highway H-E-B",
                     "longitude": -98.43132,
                     "latitude": 29.4937,
@@ -4112,8 +4713,8 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 14,
-                            "openAppointmentSlots": 14,
+                            "openTimeslots": 10,
+                            "openAppointmentSlots": 10,
                             "manufacturer": "Moderna"
                         },
                         {
@@ -4122,15 +4723,20 @@
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 15,
-                            "openAppointmentSlots": 15,
+                            "openTimeslots": 9,
+                            "openAppointmentSlots": 9,
                             "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 36,
+                            "openAppointmentSlots": 36,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 39,
+                    "openTimeslots": 65,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 39,
+                    "openAppointmentSlots": 65,
                     "name": "Zapata Highway H-E-B",
                     "longitude": -99.47479,
                     "latitude": 27.47673,
@@ -4139,27 +4745,16 @@
                 },
                 {
                     "zip": "78253-0",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueVQAS",
+                    "url": null,
                     "type": "store",
                     "street": "12125 ALAMO RANCH PKWY",
                     "storeNumber": 733,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 121,
-                            "openAppointmentSlots": 121,
-                            "manufacturer": "Pediatric_Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 131,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 131,
+                    "openAppointmentSlots": 0,
                     "name": "Alamo Ranch H-E-B",
                     "longitude": -98.73294,
                     "latitude": 29.48572,
@@ -4193,25 +4788,30 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 44,
-                            "openAppointmentSlots": 44,
+                            "openTimeslots": 5,
+                            "openAppointmentSlots": 5,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 30,
-                            "openAppointmentSlots": 30,
+                            "openTimeslots": 5,
+                            "openAppointmentSlots": 5,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 19,
-                            "openAppointmentSlots": 19,
+                            "openTimeslots": 13,
+                            "openAppointmentSlots": 13,
                             "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 63,
+                            "openAppointmentSlots": 63,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 93,
+                    "openTimeslots": 86,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 93,
+                    "openAppointmentSlots": 86,
                     "name": "Cross Creek Ranch H-E-B",
                     "longitude": -95.84788,
                     "latitude": 29.71936,
@@ -4227,20 +4827,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 116,
-                            "openAppointmentSlots": 116,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 168,
-                            "openAppointmentSlots": 168,
+                            "openTimeslots": 39,
+                            "openAppointmentSlots": 39,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 284,
+                    "openTimeslots": 39,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 284,
+                    "openAppointmentSlots": 39,
                     "name": "The Heights H-E-B",
                     "longitude": -95.40865,
                     "latitude": 29.80735,
@@ -4256,20 +4851,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 7,
-                            "openAppointmentSlots": 7,
+                            "openTimeslots": 6,
+                            "openAppointmentSlots": 6,
                             "manufacturer": "Moderna"
                         },
                         {
                             "openTimeslots": 4,
                             "openAppointmentSlots": 4,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 94,
+                            "openAppointmentSlots": 94,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 11,
+                    "openTimeslots": 104,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 11,
+                    "openAppointmentSlots": 104,
                     "name": "Bellaire Market H-E-B",
                     "longitude": -95.46938,
                     "latitude": 29.70764,
@@ -4285,25 +4885,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 30,
-                            "openAppointmentSlots": 30,
+                            "openTimeslots": 44,
+                            "openAppointmentSlots": 44,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 30,
-                            "openAppointmentSlots": 30,
+                            "openTimeslots": 29,
+                            "openAppointmentSlots": 29,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 20,
-                            "openAppointmentSlots": 20,
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 80,
+                    "openTimeslots": 123,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 80,
+                    "openAppointmentSlots": 123,
                     "name": "Mont Belvieu H-E-B",
                     "longitude": -94.84973,
                     "latitude": 29.82755,
@@ -4312,16 +4912,27 @@
                 },
                 {
                     "zip": "78114-1851",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaKQAS",
                     "type": "store",
                     "street": "925 10TH STREET",
                     "storeNumber": 25,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 12,
+                            "openAppointmentSlots": 12,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 23,
+                            "openAppointmentSlots": 23,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 35,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 35,
                     "name": "Floresville H-E-B",
                     "longitude": -98.15681,
                     "latitude": 29.14284,
@@ -4342,20 +4953,25 @@
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 304,
-                            "openAppointmentSlots": 304,
+                            "openTimeslots": 37,
+                            "openAppointmentSlots": 37,
+                            "manufacturer": "Pediatric_Moderna"
+                        },
+                        {
+                            "openTimeslots": 188,
+                            "openAppointmentSlots": 188,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 308,
-                            "openAppointmentSlots": 308,
+                            "openTimeslots": 126,
+                            "openAppointmentSlots": 126,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 642,
+                    "openTimeslots": 381,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 642,
+                    "openAppointmentSlots": 381,
                     "name": "McCreless Market H-E-B plus!",
                     "longitude": -98.46115,
                     "latitude": 29.37828,
@@ -4371,20 +4987,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 61,
-                            "openAppointmentSlots": 61,
+                            "openTimeslots": 77,
+                            "openAppointmentSlots": 77,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 47,
+                            "openAppointmentSlots": 47,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 60,
-                            "openAppointmentSlots": 60,
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 121,
+                    "openTimeslots": 174,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 121,
+                    "openAppointmentSlots": 174,
                     "name": "Bay Colony H-E-B",
                     "longitude": -95.0926,
                     "latitude": 29.4677,
@@ -4400,8 +5021,8 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 18,
-                            "openAppointmentSlots": 18,
+                            "openTimeslots": 12,
+                            "openAppointmentSlots": 12,
                             "manufacturer": "Moderna"
                         },
                         {
@@ -4410,10 +5031,10 @@
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 30,
+                    "openTimeslots": 24,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 30,
+                    "openAppointmentSlots": 24,
                     "name": "Westlake H-E-B",
                     "longitude": -97.82813,
                     "latitude": 30.2928,
@@ -4429,25 +5050,35 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 25,
-                            "openAppointmentSlots": 25,
+                            "openTimeslots": 84,
+                            "openAppointmentSlots": 84,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 23,
-                            "openAppointmentSlots": 23,
+                            "openTimeslots": 15,
+                            "openAppointmentSlots": 15,
+                            "manufacturer": "Pediatric_Moderna"
+                        },
+                        {
+                            "openTimeslots": 11,
+                            "openAppointmentSlots": 11,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 29,
-                            "openAppointmentSlots": 29,
+                            "openTimeslots": 55,
+                            "openAppointmentSlots": 55,
                             "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 19,
+                            "openAppointmentSlots": 19,
+                            "manufacturer": "Ultra_Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 77,
+                    "openTimeslots": 184,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 77,
+                    "openAppointmentSlots": 184,
                     "name": "Spicewood Springs H-E-B",
                     "longitude": -97.7713,
                     "latitude": 30.43494,
@@ -4463,25 +5094,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 275,
-                            "openAppointmentSlots": 275,
+                            "openTimeslots": 47,
+                            "openAppointmentSlots": 47,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 220,
-                            "openAppointmentSlots": 220,
+                            "openTimeslots": 46,
+                            "openAppointmentSlots": 46,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 39,
-                            "openAppointmentSlots": 39,
+                            "openTimeslots": 9,
+                            "openAppointmentSlots": 9,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 534,
+                    "openTimeslots": 102,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 534,
+                    "openAppointmentSlots": 102,
                     "name": "Red Bud Lane and Gattis School H-E-B",
                     "longitude": -97.61475,
                     "latitude": 30.49721,
@@ -4497,25 +5128,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 25,
-                            "openAppointmentSlots": 25,
+                            "openTimeslots": 10,
+                            "openAppointmentSlots": 10,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 30,
-                            "openAppointmentSlots": 30,
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 24,
-                            "openAppointmentSlots": 24,
+                            "openTimeslots": 23,
+                            "openAppointmentSlots": 23,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 79,
+                    "openTimeslots": 53,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 79,
+                    "openAppointmentSlots": 53,
                     "name": "Edna H-E-B",
                     "longitude": -96.64731,
                     "latitude": 28.97947,
@@ -4531,25 +5162,30 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 154,
-                            "openAppointmentSlots": 154,
+                            "openTimeslots": 94,
+                            "openAppointmentSlots": 94,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 140,
-                            "openAppointmentSlots": 140,
+                            "openTimeslots": 84,
+                            "openAppointmentSlots": 84,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 79,
-                            "openAppointmentSlots": 79,
+                            "openTimeslots": 48,
+                            "openAppointmentSlots": 48,
                             "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 280,
+                            "openAppointmentSlots": 280,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 373,
+                    "openTimeslots": 506,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 373,
+                    "openAppointmentSlots": 506,
                     "name": "Oak Park H-E-B",
                     "longitude": -98.45759,
                     "latitude": 29.50774,
@@ -4565,25 +5201,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 1106,
-                            "openAppointmentSlots": 1106,
+                            "openTimeslots": 1765,
+                            "openAppointmentSlots": 1765,
                             "manufacturer": "Janssen"
                         },
                         {
-                            "openTimeslots": 1067,
-                            "openAppointmentSlots": 1067,
+                            "openTimeslots": 1761,
+                            "openAppointmentSlots": 1761,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 149,
-                            "openAppointmentSlots": 149,
+                            "openTimeslots": 1762,
+                            "openAppointmentSlots": 1762,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 2322,
+                    "openTimeslots": 5288,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 2322,
+                    "openAppointmentSlots": 5288,
                     "name": "620 and O'Connor H-E-B",
                     "longitude": -97.72218,
                     "latitude": 30.50028,
@@ -4592,37 +5228,16 @@
                 },
                 {
                     "zip": "78130-5722",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubkQAC",
+                    "url": null,
                     "type": "store",
                     "street": "651 S.WALNUT",
                     "storeNumber": 775,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 24,
-                            "openAppointmentSlots": 24,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 28,
-                            "openAppointmentSlots": 28,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 31,
-                            "openAppointmentSlots": 31,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
-                            "manufacturer": "Pediatric_Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 133,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 133,
+                    "openAppointmentSlots": 0,
                     "name": "New Braunfels H-E-B at Walnut",
                     "longitude": -98.12631,
                     "latitude": 29.68903,
@@ -4638,15 +5253,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
+                            "openTimeslots": 29,
+                            "openAppointmentSlots": 29,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 122,
+                            "openAppointmentSlots": 122,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 29,
+                            "openAppointmentSlots": 29,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 10,
+                    "openTimeslots": 180,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 10,
+                    "openAppointmentSlots": 180,
                     "name": "Harker Heights H-E-B",
                     "longitude": -97.65511,
                     "latitude": 31.07905,
@@ -4662,25 +5287,30 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 77,
-                            "openAppointmentSlots": 77,
+                            "openTimeslots": 42,
+                            "openAppointmentSlots": 42,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 70,
-                            "openAppointmentSlots": 70,
+                            "openTimeslots": 44,
+                            "openAppointmentSlots": 44,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 70,
-                            "openAppointmentSlots": 70,
+                            "openTimeslots": 21,
+                            "openAppointmentSlots": 21,
                             "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 196,
+                            "openAppointmentSlots": 196,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 217,
+                    "openTimeslots": 303,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 217,
+                    "openAppointmentSlots": 303,
                     "name": "West Wadley H-E-B",
                     "longitude": -102.12562,
                     "latitude": 32.01955,
@@ -4696,25 +5326,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 224,
-                            "openAppointmentSlots": 224,
+                            "openTimeslots": 222,
+                            "openAppointmentSlots": 222,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 282,
-                            "openAppointmentSlots": 282,
+                            "openTimeslots": 284,
+                            "openAppointmentSlots": 284,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 140,
-                            "openAppointmentSlots": 140,
+                            "openTimeslots": 135,
+                            "openAppointmentSlots": 135,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 646,
+                    "openTimeslots": 641,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 646,
+                    "openAppointmentSlots": 641,
                     "name": "Montgomery at Walzem",
                     "longitude": -98.37092,
                     "latitude": 29.5105,
@@ -4730,20 +5360,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 53,
-                            "openAppointmentSlots": 53,
+                            "openTimeslots": 65,
+                            "openAppointmentSlots": 65,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 163,
-                            "openAppointmentSlots": 163,
+                            "openTimeslots": 106,
+                            "openAppointmentSlots": 106,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 7,
+                            "openAppointmentSlots": 7,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 216,
+                    "openTimeslots": 178,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 216,
+                    "openAppointmentSlots": 178,
                     "name": "Olmos Park H-E-B",
                     "longitude": -98.497,
                     "latitude": 29.4707,
@@ -4770,16 +5405,37 @@
                 },
                 {
                     "zip": "78727-3901",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubqQAC",
                     "type": "store",
                     "street": "6001 WEST PARMER LANE",
                     "storeNumber": 388,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 5,
+                            "openAppointmentSlots": 5,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 3,
+                            "openAppointmentSlots": 3,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 36,
+                            "openAppointmentSlots": 36,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 9,
+                            "openAppointmentSlots": 9,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 53,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 53,
                     "name": "Parmer and McNeil H-E-B",
                     "longitude": -97.74278,
                     "latitude": 30.44181,
@@ -4795,15 +5451,35 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 72,
-                            "openAppointmentSlots": 72,
+                            "openTimeslots": 18,
+                            "openAppointmentSlots": 18,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 25,
+                            "openAppointmentSlots": 25,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 12,
+                            "openAppointmentSlots": 12,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 30,
+                            "openAppointmentSlots": 30,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 15,
+                            "openAppointmentSlots": 15,
+                            "manufacturer": "Ultra_Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 72,
+                    "openTimeslots": 100,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 72,
+                    "openAppointmentSlots": 100,
                     "name": "Mid County H-E-B",
                     "longitude": -93.9758,
                     "latitude": 29.966,
@@ -4812,16 +5488,22 @@
                 },
                 {
                     "zip": "78504-7705",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudFQAS",
                     "type": "store",
                     "street": "901 TRENTON RD",
                     "storeNumber": 590,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 8,
+                            "openAppointmentSlots": 8,
+                            "manufacturer": "Moderna"
+                        }
+                    ],
+                    "openTimeslots": 8,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 8,
                     "name": "10th and Trenton H-E-B",
                     "longitude": -98.2188,
                     "latitude": 26.2678,
@@ -4837,25 +5519,30 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 45,
-                            "openAppointmentSlots": 45,
+                            "openTimeslots": 40,
+                            "openAppointmentSlots": 40,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 44,
-                            "openAppointmentSlots": 44,
+                            "openTimeslots": 38,
+                            "openAppointmentSlots": 38,
                             "manufacturer": "Pfizer"
                         },
                         {
                             "openTimeslots": 9,
                             "openAppointmentSlots": 9,
                             "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 54,
+                            "openAppointmentSlots": 54,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 98,
+                    "openTimeslots": 141,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 98,
+                    "openAppointmentSlots": 141,
                     "name": "Leander H-E-B plus!",
                     "longitude": -97.8582,
                     "latitude": 30.58369,
@@ -4871,25 +5558,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 45,
-                            "openAppointmentSlots": 45,
+                            "openTimeslots": 60,
+                            "openAppointmentSlots": 60,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 45,
-                            "openAppointmentSlots": 45,
+                            "openTimeslots": 59,
+                            "openAppointmentSlots": 59,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 45,
-                            "openAppointmentSlots": 45,
+                            "openTimeslots": 60,
+                            "openAppointmentSlots": 60,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 135,
+                    "openTimeslots": 179,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 135,
+                    "openAppointmentSlots": 179,
                     "name": "Baytown H-E-B",
                     "longitude": -94.9788,
                     "latitude": 29.79503,
@@ -4905,25 +5592,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 40,
-                            "openAppointmentSlots": 40,
+                            "openTimeslots": 69,
+                            "openAppointmentSlots": 69,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 89,
-                            "openAppointmentSlots": 89,
+                            "openTimeslots": 35,
+                            "openAppointmentSlots": 35,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 39,
-                            "openAppointmentSlots": 39,
+                            "openTimeslots": 18,
+                            "openAppointmentSlots": 18,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 168,
+                    "openTimeslots": 122,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 168,
+                    "openAppointmentSlots": 122,
                     "name": "Buffalo Heights H-E-B On Washington Ave",
                     "longitude": -95.39658,
                     "latitude": 29.76901,
@@ -4939,25 +5626,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 8,
-                            "openAppointmentSlots": 8,
+                            "openTimeslots": 48,
+                            "openAppointmentSlots": 48,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 3,
-                            "openAppointmentSlots": 3,
+                            "openTimeslots": 26,
+                            "openAppointmentSlots": 26,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
+                            "openTimeslots": 18,
+                            "openAppointmentSlots": 18,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 21,
+                    "openTimeslots": 92,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 21,
+                    "openAppointmentSlots": 92,
                     "name": "Meyerland Market H-E-B",
                     "longitude": -95.46406,
                     "latitude": 29.68854,
@@ -4973,15 +5660,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 6,
-                            "openAppointmentSlots": 6,
+                            "openTimeslots": 34,
+                            "openAppointmentSlots": 34,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 6,
+                    "openTimeslots": 34,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 6,
+                    "openAppointmentSlots": 34,
                     "name": "Jones Crossing H-E-B",
                     "longitude": -96.32324,
                     "latitude": 30.58444,
@@ -4990,16 +5677,32 @@
                 },
                 {
                     "zip": "78589-3734",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaQQAS",
                     "type": "store",
                     "street": "901 WEST EXPRESSWAY 83",
                     "storeNumber": 38,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 15,
+                            "openAppointmentSlots": 15,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 17,
+                            "openAppointmentSlots": 17,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 15,
+                            "openAppointmentSlots": 15,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 47,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 47,
                     "name": "San Juan H-E-B plus!",
                     "longitude": -98.1647,
                     "latitude": 26.20274,
@@ -5033,15 +5736,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 197,
-                            "openAppointmentSlots": 197,
+                            "openTimeslots": 86,
+                            "openAppointmentSlots": 86,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 70,
+                            "openAppointmentSlots": 70,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 197,
+                    "openTimeslots": 156,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 197,
+                    "openAppointmentSlots": 156,
                     "name": "South Congress H-E-B",
                     "longitude": -97.7516,
                     "latitude": 30.23963,
@@ -5057,20 +5765,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 216,
-                            "openAppointmentSlots": 216,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 120,
+                            "openAppointmentSlots": 120,
+                            "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 84,
-                            "openAppointmentSlots": 84,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 34,
+                            "openAppointmentSlots": 34,
+                            "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 300,
+                    "openTimeslots": 154,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 300,
+                    "openAppointmentSlots": 154,
                     "name": "Beaumont H-E-B plus!",
                     "longitude": -94.1685,
                     "latitude": 30.10501,
@@ -5086,20 +5794,35 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 174,
-                            "openAppointmentSlots": 174,
+                            "openTimeslots": 73,
+                            "openAppointmentSlots": 73,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 194,
-                            "openAppointmentSlots": 194,
+                            "openTimeslots": 26,
+                            "openAppointmentSlots": 26,
+                            "manufacturer": "Pediatric_Moderna"
+                        },
+                        {
+                            "openTimeslots": 73,
+                            "openAppointmentSlots": 73,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 23,
+                            "openAppointmentSlots": 23,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 33,
+                            "openAppointmentSlots": 33,
+                            "manufacturer": "Ultra_Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 368,
+                    "openTimeslots": 228,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 368,
+                    "openAppointmentSlots": 228,
                     "name": "West Ave and Jackson Keller H-E-B",
                     "longitude": -98.52574,
                     "latitude": 29.51639,
@@ -5115,25 +5838,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 15,
-                            "openAppointmentSlots": 15,
+                            "openTimeslots": 9,
+                            "openAppointmentSlots": 9,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 15,
-                            "openAppointmentSlots": 15,
+                            "openTimeslots": 9,
+                            "openAppointmentSlots": 9,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
+                            "openTimeslots": 28,
+                            "openAppointmentSlots": 28,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 80,
+                    "openTimeslots": 46,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 80,
+                    "openAppointmentSlots": 46,
                     "name": "De Zavala H-E-B",
                     "longitude": -98.5889,
                     "latitude": 29.56222,
@@ -5149,20 +5872,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 3,
-                            "openAppointmentSlots": 3,
+                            "openTimeslots": 27,
+                            "openAppointmentSlots": 27,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 154,
-                            "openAppointmentSlots": 154,
+                            "openTimeslots": 87,
+                            "openAppointmentSlots": 87,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 157,
+                    "openTimeslots": 114,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 157,
+                    "openAppointmentSlots": 114,
                     "name": "281 and 1604 H-E-B",
                     "longitude": -98.46828,
                     "latitude": 29.60772,
@@ -5178,25 +5901,30 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 254,
-                            "openAppointmentSlots": 254,
+                            "openTimeslots": 178,
+                            "openAppointmentSlots": 178,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 228,
+                            "openAppointmentSlots": 228,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 255,
-                            "openAppointmentSlots": 255,
+                            "openTimeslots": 230,
+                            "openAppointmentSlots": 230,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 249,
-                            "openAppointmentSlots": 249,
+                            "openTimeslots": 75,
+                            "openAppointmentSlots": 75,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 758,
+                    "openTimeslots": 711,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 758,
+                    "openAppointmentSlots": 711,
                     "name": "Thousand Oaks H-E-B",
                     "longitude": -98.44108,
                     "latitude": 29.57781,
@@ -5212,25 +5940,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 134,
-                            "openAppointmentSlots": 134,
+                            "openTimeslots": 18,
+                            "openAppointmentSlots": 18,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 99,
-                            "openAppointmentSlots": 99,
+                            "openTimeslots": 36,
+                            "openAppointmentSlots": 36,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 77,
-                            "openAppointmentSlots": 77,
+                            "openTimeslots": 29,
+                            "openAppointmentSlots": 29,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 310,
+                    "openTimeslots": 83,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 310,
+                    "openAppointmentSlots": 83,
                     "name": "Kingsville H-E-B",
                     "longitude": -97.86453,
                     "latitude": 27.51658,
@@ -5239,16 +5967,27 @@
                 },
                 {
                     "zip": "77382-2772",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudJQAS",
                     "type": "store",
                     "street": "10777 KUYKENDAHL ROAD",
                     "storeNumber": 594,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 14,
+                            "openAppointmentSlots": 14,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 12,
+                            "openAppointmentSlots": 12,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 26,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 26,
                     "name": "Indian Springs H-E-B",
                     "longitude": -95.53672,
                     "latitude": 30.17791,
@@ -5264,20 +6003,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 504,
-                            "openAppointmentSlots": 504,
+                            "openTimeslots": 252,
+                            "openAppointmentSlots": 252,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 503,
-                            "openAppointmentSlots": 503,
+                            "openTimeslots": 251,
+                            "openAppointmentSlots": 251,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 280,
+                            "openAppointmentSlots": 280,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 1007,
+                    "openTimeslots": 783,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 1007,
+                    "openAppointmentSlots": 783,
                     "name": "N Frazier At Loop 336 H-E-B",
                     "longitude": -95.46548,
                     "latitude": 30.33593,
@@ -5293,25 +6037,30 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 40,
-                            "openAppointmentSlots": 40,
+                            "openTimeslots": 46,
+                            "openAppointmentSlots": 46,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 58,
+                            "openAppointmentSlots": 58,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 35,
-                            "openAppointmentSlots": 35,
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 80,
-                            "openAppointmentSlots": 80,
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 155,
+                    "openTimeslots": 204,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 155,
+                    "openAppointmentSlots": 204,
                     "name": "Grand Parkway H-E-B plus!",
                     "longitude": -95.7739,
                     "latitude": 29.7144,
@@ -5320,16 +6069,22 @@
                 },
                 {
                     "zip": "77005-4210",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudMQAS",
                     "type": "store",
                     "street": "5225 BUFFALO SPEEDWAY",
                     "storeNumber": 599,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 27,
+                            "openAppointmentSlots": 27,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 27,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 27,
                     "name": "Buffalo Market H-E-B On Buffalo Speedway",
                     "longitude": -95.4271,
                     "latitude": 29.7261,
@@ -5345,15 +6100,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 162,
+                            "openAppointmentSlots": 162,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 10,
+                    "openTimeslots": 162,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 10,
+                    "openAppointmentSlots": 162,
                     "name": "Spring Market H-E-B",
                     "longitude": -95.44894,
                     "latitude": 30.07042,
@@ -5369,25 +6124,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 47,
-                            "openAppointmentSlots": 47,
+                            "openTimeslots": 22,
+                            "openAppointmentSlots": 22,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 47,
-                            "openAppointmentSlots": 47,
+                            "openTimeslots": 22,
+                            "openAppointmentSlots": 22,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 21,
-                            "openAppointmentSlots": 21,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 102,
+                            "openAppointmentSlots": 102,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 115,
+                    "openTimeslots": 146,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 115,
+                    "openAppointmentSlots": 146,
                     "name": "Dripping Springs H-E-B",
                     "longitude": -98.08146,
                     "latitude": 30.18968,
@@ -5457,20 +6212,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 862,
-                            "openAppointmentSlots": 862,
+                            "openTimeslots": 144,
+                            "openAppointmentSlots": 144,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 864,
-                            "openAppointmentSlots": 864,
+                            "openTimeslots": 142,
+                            "openAppointmentSlots": 142,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 1726,
+                    "openTimeslots": 286,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 1726,
+                    "openAppointmentSlots": 286,
                     "name": "Hudson Oaks H-E-B",
                     "longitude": -97.69733,
                     "latitude": 32.75831,
@@ -5486,20 +6241,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 11,
-                            "openAppointmentSlots": 11,
-                            "manufacturer": "Moderna"
+                            "openTimeslots": 84,
+                            "openAppointmentSlots": 84,
+                            "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 9,
-                            "openAppointmentSlots": 9,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 48,
+                            "openAppointmentSlots": 48,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 20,
+                    "openTimeslots": 132,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 20,
+                    "openAppointmentSlots": 132,
                     "name": "MacGregor Market H-E-B",
                     "longitude": -95.37644,
                     "latitude": 29.71432,
@@ -5515,20 +6270,30 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 105,
-                            "openAppointmentSlots": 105,
+                            "openTimeslots": 104,
+                            "openAppointmentSlots": 104,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 220,
+                            "openAppointmentSlots": 220,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 164,
+                            "openAppointmentSlots": 164,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 140,
-                            "openAppointmentSlots": 140,
+                            "openTimeslots": 220,
+                            "openAppointmentSlots": 220,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 245,
+                    "openTimeslots": 708,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 245,
+                    "openAppointmentSlots": 708,
                     "name": "Harper's Trace H-E-B",
                     "longitude": -95.42563,
                     "latitude": 30.20692,
@@ -5544,25 +6309,30 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 39,
-                            "openAppointmentSlots": 39,
+                            "openTimeslots": 35,
+                            "openAppointmentSlots": 35,
                             "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 52,
+                            "openAppointmentSlots": 52,
+                            "manufacturer": "Pfizer"
                         },
                         {
                             "openTimeslots": 34,
                             "openAppointmentSlots": 34,
-                            "manufacturer": "Pfizer"
+                            "manufacturer": "Pediatric_Pfizer"
                         },
                         {
-                            "openTimeslots": 18,
-                            "openAppointmentSlots": 18,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 8,
+                            "openAppointmentSlots": 8,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 91,
+                    "openTimeslots": 129,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 91,
+                    "openAppointmentSlots": 129,
                     "name": "H-E-B Market at Northpark",
                     "longitude": -95.25033,
                     "latitude": 30.06864,
@@ -5578,20 +6348,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 158,
-                            "openAppointmentSlots": 158,
+                            "openTimeslots": 212,
+                            "openAppointmentSlots": 212,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 154,
-                            "openAppointmentSlots": 154,
+                            "openTimeslots": 215,
+                            "openAppointmentSlots": 215,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 106,
+                            "openAppointmentSlots": 106,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 312,
+                    "openTimeslots": 533,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 312,
+                    "openAppointmentSlots": 533,
                     "name": "211 and Potranco H-E-B",
                     "longitude": -98.77966,
                     "latitude": 29.42367,
@@ -5607,30 +6382,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 2,
-                            "openAppointmentSlots": 2,
+                            "openTimeslots": 97,
+                            "openAppointmentSlots": 97,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 100,
-                            "openAppointmentSlots": 100,
+                            "openTimeslots": 19,
+                            "openAppointmentSlots": 19,
                             "manufacturer": "Pediatric_Moderna"
                         },
                         {
-                            "openTimeslots": 2,
-                            "openAppointmentSlots": 2,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 1,
-                            "openAppointmentSlots": 1,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
+                            "manufacturer": "Ultra_Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 105,
+                    "openTimeslots": 166,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 105,
+                    "openAppointmentSlots": 166,
                     "name": "Lubbock H-E-B",
                     "longitude": -101.90638,
                     "latitude": 33.48958,
@@ -5646,24 +6416,34 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 5,
-                            "openAppointmentSlots": 5,
+                            "openTimeslots": 102,
+                            "openAppointmentSlots": 102,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 5,
-                            "openAppointmentSlots": 5,
+                            "openTimeslots": 150,
+                            "openAppointmentSlots": 150,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 150,
+                            "openAppointmentSlots": 150,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 150,
+                            "openAppointmentSlots": 150,
+                            "manufacturer": "Other"
                         }
                     ],
-                    "openTimeslots": 10,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 10,
+                    "openTimeslots": 402,
+                    "openFluTimeslots": 150,
+                    "openFluAppointmentSlots": 150,
+                    "openAppointmentSlots": 402,
                     "name": "Big Spring H-E-B",
                     "longitude": -101.47211,
                     "latitude": 32.23493,
-                    "fluUrl": "",
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4NQAU",
                     "city": "BIG SPRING"
                 },
                 {
@@ -5675,25 +6455,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 106,
-                            "openAppointmentSlots": 106,
+                            "openTimeslots": 89,
+                            "openAppointmentSlots": 89,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 110,
-                            "openAppointmentSlots": 110,
+                            "openTimeslots": 89,
+                            "openAppointmentSlots": 89,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 110,
-                            "openAppointmentSlots": 110,
+                            "openTimeslots": 90,
+                            "openAppointmentSlots": 90,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 326,
+                    "openTimeslots": 268,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 326,
+                    "openAppointmentSlots": 268,
                     "name": "Sherwood Avenue N H-E-B",
                     "longitude": -100.47977,
                     "latitude": 31.44511,
@@ -5709,20 +6489,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
+                            "openTimeslots": 14,
+                            "openAppointmentSlots": 14,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 9,
-                            "openAppointmentSlots": 9,
+                            "openTimeslots": 49,
+                            "openAppointmentSlots": 49,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 19,
+                    "openTimeslots": 83,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 19,
+                    "openAppointmentSlots": 83,
                     "name": "Blackhawk H-E-B",
                     "longitude": -95.24868,
                     "latitude": 29.60234,
@@ -5738,15 +6523,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 21,
-                            "openAppointmentSlots": 21,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 135,
+                            "openAppointmentSlots": 135,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 21,
+                    "openTimeslots": 135,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 21,
+                    "openAppointmentSlots": 135,
                     "name": "Flour Bluff H-E-B plus!",
                     "longitude": -97.28288,
                     "latitude": 27.66767,
@@ -5762,25 +6547,30 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 477,
-                            "openAppointmentSlots": 477,
+                            "openTimeslots": 161,
+                            "openAppointmentSlots": 161,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 482,
-                            "openAppointmentSlots": 482,
+                            "openTimeslots": 161,
+                            "openAppointmentSlots": 161,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 312,
-                            "openAppointmentSlots": 312,
+                            "openTimeslots": 108,
+                            "openAppointmentSlots": 108,
                             "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 40,
+                            "openAppointmentSlots": 40,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 1271,
+                    "openTimeslots": 470,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 1271,
+                    "openAppointmentSlots": 470,
                     "name": "Pearland H-E-B plus!",
                     "longitude": -95.39002,
                     "latitude": 29.55932,
@@ -5796,25 +6586,30 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 20,
-                            "openAppointmentSlots": 20,
+                            "openTimeslots": 55,
+                            "openAppointmentSlots": 55,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 23,
-                            "openAppointmentSlots": 23,
+                            "openTimeslots": 59,
+                            "openAppointmentSlots": 59,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 25,
-                            "openAppointmentSlots": 25,
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
                             "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 28,
+                            "openAppointmentSlots": 28,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 68,
+                    "openTimeslots": 162,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 68,
+                    "openAppointmentSlots": 162,
                     "name": "19th and Meridian H-E-B",
                     "longitude": -97.17255,
                     "latitude": 31.5804,
@@ -5830,20 +6625,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 65,
-                            "openAppointmentSlots": 65,
+                            "openTimeslots": 10,
+                            "openAppointmentSlots": 10,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 52,
-                            "openAppointmentSlots": 52,
+                            "openTimeslots": 9,
+                            "openAppointmentSlots": 9,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 156,
+                            "openAppointmentSlots": 156,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 117,
+                    "openTimeslots": 175,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 117,
+                    "openAppointmentSlots": 175,
                     "name": "Slaughter and Escarpment H-E-B",
                     "longitude": -97.87642,
                     "latitude": 30.20247,
@@ -5852,16 +6652,27 @@
                 },
                 {
                     "zip": "78413-2816",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuabQAC",
                     "type": "store",
                     "street": "5313 SARATOGA",
                     "storeNumber": 69,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 40,
+                            "openAppointmentSlots": 40,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 19,
+                            "openAppointmentSlots": 19,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 59,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 59,
                     "name": "Staples and Saratoga H-E-B plus!",
                     "longitude": -97.38802,
                     "latitude": 27.68613,
@@ -5895,20 +6706,35 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 30,
-                            "openAppointmentSlots": 30,
+                            "openTimeslots": 43,
+                            "openAppointmentSlots": 43,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 12,
-                            "openAppointmentSlots": 12,
+                            "openTimeslots": 16,
+                            "openAppointmentSlots": 16,
+                            "manufacturer": "Pediatric_Moderna"
+                        },
+                        {
+                            "openTimeslots": 5,
+                            "openAppointmentSlots": 5,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 16,
+                            "openAppointmentSlots": 16,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 8,
+                            "openAppointmentSlots": 8,
+                            "manufacturer": "Ultra_Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 42,
+                    "openTimeslots": 88,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 42,
+                    "openAppointmentSlots": 88,
                     "name": "Bee Cave H-E-B",
                     "longitude": -97.93238,
                     "latitude": 30.30489,
@@ -5929,20 +6755,20 @@
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 80,
-                            "openAppointmentSlots": 80,
+                            "openTimeslots": 56,
+                            "openAppointmentSlots": 56,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 80,
-                            "openAppointmentSlots": 80,
+                            "openTimeslots": 60,
+                            "openAppointmentSlots": 60,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 220,
+                    "openTimeslots": 176,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 220,
+                    "openAppointmentSlots": 176,
                     "name": "Marbach and 410 H-E-B plus!",
                     "longitude": -98.65227,
                     "latitude": 29.41837,
@@ -5951,16 +6777,32 @@
                 },
                 {
                     "zip": "77044-6087",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudRQAS",
                     "type": "store",
                     "street": "12680 W.LAKE HOUSTON PKWY",
                     "storeNumber": 614,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 33,
+                            "openAppointmentSlots": 33,
+                            "manufacturer": "Pediatric_Moderna"
+                        },
+                        {
+                            "openTimeslots": 58,
+                            "openAppointmentSlots": 58,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 54,
+                            "openAppointmentSlots": 54,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 145,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 145,
                     "name": "Summerwood Market H-E-B",
                     "longitude": -95.19697,
                     "latitude": 29.92325,
@@ -5976,25 +6818,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 14,
-                            "openAppointmentSlots": 14,
+                            "openTimeslots": 89,
+                            "openAppointmentSlots": 89,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 15,
-                            "openAppointmentSlots": 15,
+                            "openTimeslots": 82,
+                            "openAppointmentSlots": 82,
                             "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 13,
-                            "openAppointmentSlots": 13,
-                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 42,
+                    "openTimeslots": 171,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 42,
+                    "openAppointmentSlots": 171,
                     "name": "Katy Market H-E-B",
                     "longitude": -95.82005,
                     "latitude": 29.77644,
@@ -6021,16 +6858,47 @@
                 },
                 {
                     "zip": "77845-4638",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudUQAS",
                     "type": "store",
                     "street": "949 WILLIAM D.FITCH PARKWAY",
                     "storeNumber": 619,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 42,
+                            "openAppointmentSlots": 42,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 51,
+                            "openAppointmentSlots": 51,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 40,
+                            "openAppointmentSlots": 40,
+                            "manufacturer": "Pediatric_Moderna"
+                        },
+                        {
+                            "openTimeslots": 160,
+                            "openAppointmentSlots": 160,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 85,
+                            "openAppointmentSlots": 85,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 60,
+                            "openAppointmentSlots": 60,
+                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 438,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 438,
                     "name": "Tower Point Market H-E-B",
                     "longitude": -96.26315,
                     "latitude": 30.55969,
@@ -6064,20 +6932,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 159,
-                            "openAppointmentSlots": 159,
+                            "openTimeslots": 89,
+                            "openAppointmentSlots": 89,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 159,
-                            "openAppointmentSlots": 159,
+                            "openTimeslots": 94,
+                            "openAppointmentSlots": 94,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 318,
+                    "openTimeslots": 183,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 318,
+                    "openAppointmentSlots": 183,
                     "name": "H-E-B Pharmacy at the UTHTB",
                     "longitude": -97.73507,
                     "latitude": 30.27747,
@@ -6093,25 +6961,35 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 26,
-                            "openAppointmentSlots": 26,
+                            "openTimeslots": 55,
+                            "openAppointmentSlots": 55,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 70,
-                            "openAppointmentSlots": 70,
+                            "openTimeslots": 57,
+                            "openAppointmentSlots": 57,
+                            "manufacturer": "Pediatric_Moderna"
+                        },
+                        {
+                            "openTimeslots": 86,
+                            "openAppointmentSlots": 86,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 51,
-                            "openAppointmentSlots": 51,
+                            "openTimeslots": 25,
+                            "openAppointmentSlots": 25,
                             "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 38,
+                            "openAppointmentSlots": 38,
+                            "manufacturer": "Ultra_Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 147,
+                    "openTimeslots": 261,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 147,
+                    "openAppointmentSlots": 261,
                     "name": "Abilene H-E-B",
                     "longitude": -99.75934,
                     "latitude": 32.43348,
@@ -6145,25 +7023,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 76,
-                            "openAppointmentSlots": 76,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 193,
-                            "openAppointmentSlots": 193,
+                            "openTimeslots": 64,
+                            "openAppointmentSlots": 64,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 52,
-                            "openAppointmentSlots": 52,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 109,
+                            "openAppointmentSlots": 109,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 321,
+                    "openTimeslots": 173,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 321,
+                    "openAppointmentSlots": 173,
                     "name": "Boerne H-E-B plus!",
                     "longitude": -98.73481,
                     "latitude": 29.78173,
@@ -6179,25 +7052,35 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 40,
-                            "openAppointmentSlots": 40,
+                            "openTimeslots": 46,
+                            "openAppointmentSlots": 46,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 69,
-                            "openAppointmentSlots": 69,
+                            "openTimeslots": 19,
+                            "openAppointmentSlots": 19,
+                            "manufacturer": "Pediatric_Moderna"
+                        },
+                        {
+                            "openTimeslots": 58,
+                            "openAppointmentSlots": 58,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 30,
-                            "openAppointmentSlots": 30,
+                            "openTimeslots": 23,
+                            "openAppointmentSlots": 23,
                             "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 10,
+                            "openAppointmentSlots": 10,
+                            "manufacturer": "Ultra_Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 139,
+                    "openTimeslots": 156,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 139,
+                    "openAppointmentSlots": 156,
                     "name": "Bulverde H-E-B plus!",
                     "longitude": -98.43022,
                     "latitude": 29.79882,
@@ -6224,16 +7107,22 @@
                 },
                 {
                     "zip": "78586-4395",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudZQAS",
                     "type": "store",
                     "street": "1095 WEST BUSINESS 77",
                     "storeNumber": 626,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 152,
+                            "openAppointmentSlots": 152,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 152,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 152,
                     "name": "San Benito H-E-B",
                     "longitude": -97.63395,
                     "latitude": 26.14392,
@@ -6242,16 +7131,27 @@
                 },
                 {
                     "zip": "77478-4947",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudaQAC",
                     "type": "store",
                     "street": "530 HWY 6",
                     "storeNumber": 627,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 26,
+                            "openAppointmentSlots": 26,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 49,
+                            "openAppointmentSlots": 49,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 75,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 75,
                     "name": "Sugar Land Market H-E-B",
                     "longitude": -95.64596,
                     "latitude": 29.60871,
@@ -6285,13 +7185,13 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 39,
-                            "openAppointmentSlots": 39,
+                            "openTimeslots": 33,
+                            "openAppointmentSlots": 33,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 36,
-                            "openAppointmentSlots": 36,
+                            "openTimeslots": 33,
+                            "openAppointmentSlots": 33,
                             "manufacturer": "Pfizer"
                         },
                         {
@@ -6300,10 +7200,10 @@
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 104,
+                    "openTimeslots": 95,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 104,
+                    "openAppointmentSlots": 95,
                     "name": "Spring Green Market H-E-B",
                     "longitude": -95.81427,
                     "latitude": 29.69558,
@@ -6319,25 +7219,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 94,
-                            "openAppointmentSlots": 94,
+                            "openTimeslots": 70,
+                            "openAppointmentSlots": 70,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 96,
-                            "openAppointmentSlots": 96,
+                            "openTimeslots": 108,
+                            "openAppointmentSlots": 108,
                             "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 59,
-                            "openAppointmentSlots": 59,
-                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 249,
+                    "openTimeslots": 178,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 249,
+                    "openAppointmentSlots": 178,
                     "name": "New Braunfels H-E-B at Hwy 46",
                     "longitude": -98.16041,
                     "latitude": 29.71309,
@@ -6353,25 +7248,30 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 394,
-                            "openAppointmentSlots": 394,
+                            "openTimeslots": 285,
+                            "openAppointmentSlots": 285,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 263,
+                            "openAppointmentSlots": 263,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 393,
-                            "openAppointmentSlots": 393,
+                            "openTimeslots": 266,
+                            "openAppointmentSlots": 266,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 62,
-                            "openAppointmentSlots": 62,
+                            "openTimeslots": 260,
+                            "openAppointmentSlots": 260,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 849,
+                    "openTimeslots": 1074,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 849,
+                    "openAppointmentSlots": 1074,
                     "name": "Zarzamora and Military H-E-B plus!",
                     "longitude": -98.5339,
                     "latitude": 29.35787,
@@ -6398,16 +7298,27 @@
                 },
                 {
                     "zip": "78028-0",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuahQAC",
                     "type": "store",
                     "street": "300 W. MAIN ST.",
                     "storeNumber": 770,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 39,
+                            "openAppointmentSlots": 39,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 76,
+                            "openAppointmentSlots": 76,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 115,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 115,
                     "name": "Kerrville H-E-B On Main Street",
                     "longitude": -99.14287,
                     "latitude": 30.05056,
@@ -6416,16 +7327,32 @@
                 },
                 {
                     "zip": "78741-3037",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaiQAC",
                     "type": "store",
                     "street": "2508 EAST RIVERSIDE DRIVE",
                     "storeNumber": 91,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 52,
+                            "openAppointmentSlots": 52,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 23,
+                            "openAppointmentSlots": 23,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 5,
+                            "openAppointmentSlots": 5,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 80,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 80,
                     "name": "Riverside H-E-B plus!",
                     "longitude": -97.72401,
                     "latitude": 30.23547,
@@ -6441,30 +7368,35 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 180,
-                            "openAppointmentSlots": 180,
+                            "openTimeslots": 89,
+                            "openAppointmentSlots": 89,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 180,
-                            "openAppointmentSlots": 180,
+                            "openTimeslots": 85,
+                            "openAppointmentSlots": 85,
+                            "manufacturer": "Pediatric_Moderna"
+                        },
+                        {
+                            "openTimeslots": 89,
+                            "openAppointmentSlots": 89,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 176,
-                            "openAppointmentSlots": 176,
+                            "openTimeslots": 88,
+                            "openAppointmentSlots": 88,
                             "manufacturer": "Pediatric_Pfizer"
                         },
                         {
-                            "openTimeslots": 117,
-                            "openAppointmentSlots": 117,
+                            "openTimeslots": 86,
+                            "openAppointmentSlots": 86,
                             "manufacturer": "Ultra_Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 653,
+                    "openTimeslots": 437,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 653,
+                    "openAppointmentSlots": 437,
                     "name": "Victoria H-E-B plus!",
                     "longitude": -96.99736,
                     "latitude": 28.85159,
@@ -6480,25 +7412,35 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 56,
-                            "openAppointmentSlots": 56,
+                            "openTimeslots": 51,
+                            "openAppointmentSlots": 51,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 53,
-                            "openAppointmentSlots": 53,
+                            "openTimeslots": 35,
+                            "openAppointmentSlots": 35,
+                            "manufacturer": "Pediatric_Moderna"
+                        },
+                        {
+                            "openTimeslots": 44,
+                            "openAppointmentSlots": 44,
                             "manufacturer": "Pfizer"
                         },
                         {
                             "openTimeslots": 35,
                             "openAppointmentSlots": 35,
                             "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 35,
+                            "openAppointmentSlots": 35,
+                            "manufacturer": "Ultra_Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 144,
+                    "openTimeslots": 200,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 144,
+                    "openAppointmentSlots": 200,
                     "name": "Bunker Hill H-E-B",
                     "longitude": -95.53206,
                     "latitude": 29.78485,
@@ -6514,20 +7456,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 55,
-                            "openAppointmentSlots": 55,
+                            "openTimeslots": 40,
+                            "openAppointmentSlots": 40,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 48,
-                            "openAppointmentSlots": 48,
+                            "openTimeslots": 39,
+                            "openAppointmentSlots": 39,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 39,
+                            "openAppointmentSlots": 39,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 103,
+                    "openTimeslots": 118,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 103,
+                    "openAppointmentSlots": 118,
                     "name": "Sienna Market H-E-B",
                     "longitude": -95.53497,
                     "latitude": 29.53928,
@@ -6543,25 +7490,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 28,
+                            "openAppointmentSlots": 28,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 57,
-                            "openAppointmentSlots": 57,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
+                            "openTimeslots": 28,
+                            "openAppointmentSlots": 28,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 117,
+                    "openTimeslots": 106,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 117,
+                    "openAppointmentSlots": 106,
                     "name": "Southland and 12th St H-E-B",
                     "longitude": -97.68171,
                     "latitude": 26.18251,
@@ -6570,16 +7517,27 @@
                 },
                 {
                     "zip": "78413-3966",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuavQAC",
                     "type": "store",
                     "street": "5801 WEBER ROAD",
                     "storeNumber": 139,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 76,
+                            "openAppointmentSlots": 76,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 64,
+                            "openAppointmentSlots": 64,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 140,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 140,
                     "name": "Weber and Holly H-E-B",
                     "longitude": -97.40529,
                     "latitude": 27.71118,
@@ -6595,20 +7553,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 47,
-                            "openAppointmentSlots": 47,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 222,
-                            "openAppointmentSlots": 222,
+                            "openTimeslots": 71,
+                            "openAppointmentSlots": 71,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 269,
+                    "openTimeslots": 71,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 269,
+                    "openAppointmentSlots": 71,
                     "name": "Ed Bluestein H-E-B",
                     "longitude": -97.66465,
                     "latitude": 30.31211,
@@ -6635,16 +7588,32 @@
                 },
                 {
                     "zip": "78572-8354",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuakQAC",
                     "type": "store",
                     "street": "2409 EAST EXPRESSWAY 83",
                     "storeNumber": 94,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 13,
+                            "openAppointmentSlots": 13,
+                            "manufacturer": "Pediatric_Moderna"
+                        },
+                        {
+                            "openTimeslots": 5,
+                            "openAppointmentSlots": 5,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 6,
+                            "openAppointmentSlots": 6,
+                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 24,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 24,
                     "name": "Mission H-E-B plus!",
                     "longitude": -98.28628,
                     "latitude": 26.19755,
@@ -6660,20 +7629,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 6,
-                            "openAppointmentSlots": 6,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 7,
-                            "openAppointmentSlots": 7,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 114,
+                            "openAppointmentSlots": 114,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 13,
+                    "openTimeslots": 114,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 13,
+                    "openAppointmentSlots": 114,
                     "name": "Laredo H-E-B plus!",
                     "longitude": -99.47435,
                     "latitude": 27.60863,
@@ -6682,16 +7646,32 @@
                 },
                 {
                     "zip": "78731-3023",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuamQAC",
                     "type": "store",
                     "street": "7015 VILLAGE CTR DR.",
                     "storeNumber": 96,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 25,
+                            "openAppointmentSlots": 25,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 14,
+                            "openAppointmentSlots": 14,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 7,
+                            "openAppointmentSlots": 7,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 46,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 46,
                     "name": "Far West H-E-B",
                     "longitude": -97.75598,
                     "latitude": 30.35289,
@@ -6707,25 +7687,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 175,
-                            "openAppointmentSlots": 175,
+                            "openTimeslots": 144,
+                            "openAppointmentSlots": 144,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 179,
-                            "openAppointmentSlots": 179,
+                            "openTimeslots": 140,
+                            "openAppointmentSlots": 140,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 180,
-                            "openAppointmentSlots": 180,
+                            "openTimeslots": 146,
+                            "openAppointmentSlots": 146,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 534,
+                    "openTimeslots": 430,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 534,
+                    "openAppointmentSlots": 430,
                     "name": "Vintage Park Market H-E-B",
                     "longitude": -95.57661,
                     "latitude": 29.9967,
@@ -6741,25 +7721,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 95,
-                            "openAppointmentSlots": 95,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 222,
-                            "openAppointmentSlots": 222,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 49,
-                            "openAppointmentSlots": 49,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 612,
+                            "openAppointmentSlots": 612,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 366,
+                    "openTimeslots": 612,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 366,
+                    "openAppointmentSlots": 612,
                     "name": "Alon Market H-E-B",
                     "longitude": -98.53463,
                     "latitude": 29.55254,
@@ -6775,20 +7745,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 15,
-                            "openAppointmentSlots": 15,
+                            "openTimeslots": 6,
+                            "openAppointmentSlots": 6,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 21,
-                            "openAppointmentSlots": 21,
+                            "openTimeslots": 5,
+                            "openAppointmentSlots": 5,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 36,
+                    "openTimeslots": 11,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 36,
+                    "openAppointmentSlots": 11,
                     "name": "Brodie Lane H-E-B",
                     "longitude": -97.83076,
                     "latitude": 30.21489,
@@ -6797,20 +7767,36 @@
                 },
                 {
                     "zip": "78539-7312",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucDQAS",
                     "type": "store",
                     "street": "2700 W FREDDY GONZALES",
                     "storeNumber": 431,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 54,
+                            "openAppointmentSlots": 54,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 48,
+                            "openAppointmentSlots": 48,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 60,
+                            "openAppointmentSlots": 60,
+                            "manufacturer": "Other"
+                        }
+                    ],
+                    "openTimeslots": 102,
+                    "openFluTimeslots": 60,
+                    "openFluAppointmentSlots": 60,
+                    "openAppointmentSlots": 102,
                     "name": "Edinburg H-E-B",
                     "longitude": -98.1958,
                     "latitude": 26.29078,
-                    "fluUrl": "",
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2jQAE",
                     "city": "EDINBURG"
                 },
                 {
@@ -6822,25 +7808,35 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 29,
-                            "openAppointmentSlots": 29,
+                            "openTimeslots": 57,
+                            "openAppointmentSlots": 57,
                             "manufacturer": "Janssen"
                         },
                         {
-                            "openTimeslots": 73,
-                            "openAppointmentSlots": 73,
+                            "openTimeslots": 74,
+                            "openAppointmentSlots": 74,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 71,
-                            "openAppointmentSlots": 71,
+                            "openTimeslots": 96,
+                            "openAppointmentSlots": 96,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 24,
+                            "openAppointmentSlots": 24,
+                            "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 26,
+                            "openAppointmentSlots": 26,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 173,
+                    "openTimeslots": 277,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 173,
+                    "openAppointmentSlots": 277,
                     "name": "Montrose Market H-E-B",
                     "longitude": -95.40284,
                     "latitude": 29.7379,
@@ -6856,25 +7852,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 104,
-                            "openAppointmentSlots": 104,
+                            "openTimeslots": 36,
+                            "openAppointmentSlots": 36,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 104,
-                            "openAppointmentSlots": 104,
+                            "openTimeslots": 36,
+                            "openAppointmentSlots": 36,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 104,
-                            "openAppointmentSlots": 104,
+                            "openTimeslots": 36,
+                            "openAppointmentSlots": 36,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 312,
+                    "openTimeslots": 108,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 312,
+                    "openAppointmentSlots": 108,
                     "name": "Granbury H-E-B",
                     "longitude": -97.73026,
                     "latitude": 32.45528,
@@ -6890,20 +7886,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 92,
-                            "openAppointmentSlots": 92,
+                            "openTimeslots": 129,
+                            "openAppointmentSlots": 129,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 58,
-                            "openAppointmentSlots": 58,
+                            "openTimeslots": 92,
+                            "openAppointmentSlots": 92,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 150,
+                    "openTimeslots": 221,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 150,
+                    "openAppointmentSlots": 221,
                     "name": "North Woodlands Market H-E-B",
                     "longitude": -95.51296,
                     "latitude": 30.22918,
@@ -6912,16 +7908,32 @@
                 },
                 {
                     "zip": "78723-3014",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudeQAC",
                     "type": "store",
                     "street": "1801 E.51ST STREET",
                     "storeNumber": 639,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 16,
+                            "openAppointmentSlots": 16,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 15,
+                            "openAppointmentSlots": 15,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 4,
+                            "openAppointmentSlots": 4,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 35,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 35,
                     "name": "Mueller H-E-B",
                     "longitude": -97.69872,
                     "latitude": 30.3013,
@@ -6966,22 +7978,16 @@
                 },
                 {
                     "zip": "78415-5021",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudhQAC",
+                    "url": null,
                     "type": "store",
                     "street": "4444 KOSTORYZ",
                     "storeNumber": 643,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 7,
-                            "openAppointmentSlots": 7,
-                            "manufacturer": "Moderna"
-                        }
-                    ],
-                    "openTimeslots": 7,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 7,
+                    "openAppointmentSlots": 0,
                     "name": "Kostoryz and Gollihar H-E-B",
                     "longitude": -97.40516,
                     "latitude": 27.73917,
@@ -6997,25 +8003,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 18,
-                            "openAppointmentSlots": 18,
+                            "openTimeslots": 5,
+                            "openAppointmentSlots": 5,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 20,
-                            "openAppointmentSlots": 20,
+                            "openTimeslots": 7,
+                            "openAppointmentSlots": 7,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
+                            "openTimeslots": 12,
+                            "openAppointmentSlots": 12,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 48,
+                    "openTimeslots": 24,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 48,
+                    "openAppointmentSlots": 24,
                     "name": "Hwy 21 and N Texas Ave H-E-B",
                     "longitude": -96.3717,
                     "latitude": 30.6901,
@@ -7042,16 +8048,32 @@
                 },
                 {
                     "zip": "78028-5916",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudkQAC",
                     "type": "store",
                     "street": "313 SIDNEY BAKER SOUTH",
                     "storeNumber": 655,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 148,
+                            "openAppointmentSlots": 148,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 149,
+                            "openAppointmentSlots": 149,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 45,
+                            "openAppointmentSlots": 45,
+                            "manufacturer": "Pediatric_Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 342,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 342,
                     "name": "Kerrville H-E-B on Sidney Baker St",
                     "longitude": -99.14342,
                     "latitude": 30.04152,
@@ -7067,25 +8089,35 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 26,
-                            "openAppointmentSlots": 26,
-                            "manufacturer": "Moderna"
+                            "openTimeslots": 21,
+                            "openAppointmentSlots": 21,
+                            "manufacturer": "Pediatric_Moderna"
                         },
                         {
-                            "openTimeslots": 35,
-                            "openAppointmentSlots": 35,
+                            "openTimeslots": 19,
+                            "openAppointmentSlots": 19,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 40,
-                            "openAppointmentSlots": 40,
+                            "openTimeslots": 21,
+                            "openAppointmentSlots": 21,
                             "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 18,
+                            "openAppointmentSlots": 18,
+                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 36,
+                            "openAppointmentSlots": 36,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 101,
+                    "openTimeslots": 115,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 101,
+                    "openAppointmentSlots": 115,
                     "name": "Morgan and Grimes H-E-B",
                     "longitude": -97.67639,
                     "latitude": 26.20337,
@@ -7094,16 +8126,27 @@
                 },
                 {
                     "zip": "78539-5664",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuazQAC",
                     "type": "store",
                     "street": "1212 S CLOSNER BLVD",
                     "storeNumber": 172,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 16,
+                            "openAppointmentSlots": 16,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 15,
+                            "openAppointmentSlots": 15,
+                            "manufacturer": "Pfizer"
+                        }
+                    ],
+                    "openTimeslots": 31,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 31,
                     "name": "Closner and Baker H-E-B",
                     "longitude": -98.1642,
                     "latitude": 26.29029,
@@ -7119,15 +8162,30 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 7,
-                            "openAppointmentSlots": 7,
+                            "openTimeslots": 33,
+                            "openAppointmentSlots": 33,
+                            "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 28,
+                            "openAppointmentSlots": 28,
+                            "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
                             "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 4,
+                            "openAppointmentSlots": 4,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 7,
+                    "openTimeslots": 85,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 7,
+                    "openAppointmentSlots": 85,
                     "name": "San Pedro and Oblate H-E-B",
                     "longitude": -98.4995,
                     "latitude": 29.50282,
@@ -7161,20 +8219,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 92,
-                            "openAppointmentSlots": 92,
+                            "openTimeslots": 78,
+                            "openAppointmentSlots": 78,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 101,
-                            "openAppointmentSlots": 101,
+                            "openTimeslots": 66,
+                            "openAppointmentSlots": 66,
+                            "manufacturer": "Pediatric_Moderna"
+                        },
+                        {
+                            "openTimeslots": 107,
+                            "openAppointmentSlots": 107,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 193,
+                    "openTimeslots": 251,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 193,
+                    "openAppointmentSlots": 251,
                     "name": "Lamar and Rundberg H-E-B",
                     "longitude": -97.69689,
                     "latitude": 30.36357,
@@ -7208,15 +8271,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
+                            "openTimeslots": 42,
+                            "openAppointmentSlots": 42,
+                            "manufacturer": "Moderna"
+                        },
+                        {
                             "openTimeslots": 38,
                             "openAppointmentSlots": 38,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 12,
+                            "openAppointmentSlots": 12,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 38,
+                    "openTimeslots": 92,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 38,
+                    "openAppointmentSlots": 92,
                     "name": "Saunders St H-E-B",
                     "longitude": -99.47131,
                     "latitude": 27.53071,
@@ -7232,25 +8305,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 40,
-                            "openAppointmentSlots": 40,
+                            "openTimeslots": 84,
+                            "openAppointmentSlots": 84,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 46,
-                            "openAppointmentSlots": 46,
+                            "openTimeslots": 86,
+                            "openAppointmentSlots": 86,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 29,
-                            "openAppointmentSlots": 29,
+                            "openTimeslots": 39,
+                            "openAppointmentSlots": 39,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 115,
+                    "openTimeslots": 209,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 115,
+                    "openAppointmentSlots": 209,
                     "name": "Slaughter and South Congress H-E-B",
                     "longitude": -97.78723,
                     "latitude": 30.16862,
@@ -7266,20 +8339,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 110,
-                            "openAppointmentSlots": 110,
+                            "openTimeslots": 33,
+                            "openAppointmentSlots": 33,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 110,
-                            "openAppointmentSlots": 110,
+                            "openTimeslots": 33,
+                            "openAppointmentSlots": 33,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 220,
+                    "openTimeslots": 66,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 220,
+                    "openAppointmentSlots": 66,
                     "name": "W. W. White H-E-B",
                     "longitude": -98.40568,
                     "latitude": 29.41476,
@@ -7313,25 +8386,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 226,
-                            "openAppointmentSlots": 226,
+                            "openTimeslots": 53,
+                            "openAppointmentSlots": 53,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 141,
-                            "openAppointmentSlots": 141,
+                            "openTimeslots": 49,
+                            "openAppointmentSlots": 49,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 9,
-                            "openAppointmentSlots": 9,
+                            "openTimeslots": 55,
+                            "openAppointmentSlots": 55,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 376,
+                    "openTimeslots": 157,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 376,
+                    "openAppointmentSlots": 157,
                     "name": "281 and Evans Road H-E-B plus!",
                     "longitude": -98.45756,
                     "latitude": 29.63886,
@@ -7347,13 +8420,18 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 334,
-                            "openAppointmentSlots": 334,
+                            "openTimeslots": 120,
+                            "openAppointmentSlots": 120,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 331,
+                            "openAppointmentSlots": 331,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 335,
-                            "openAppointmentSlots": 335,
+                            "openTimeslots": 328,
+                            "openAppointmentSlots": 328,
                             "manufacturer": "Pfizer"
                         },
                         {
@@ -7362,10 +8440,10 @@
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 753,
+                    "openTimeslots": 863,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 753,
+                    "openAppointmentSlots": 863,
                     "name": "Fairfield Market H-E-B",
                     "longitude": -95.74599,
                     "latitude": 29.9925,
@@ -7381,13 +8459,13 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 4,
-                            "openAppointmentSlots": 4,
+                            "openTimeslots": 10,
+                            "openAppointmentSlots": 10,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 14,
-                            "openAppointmentSlots": 14,
+                            "openTimeslots": 12,
+                            "openAppointmentSlots": 12,
                             "manufacturer": "Pfizer"
                         },
                         {
@@ -7396,10 +8474,10 @@
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 34,
+                    "openTimeslots": 38,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 34,
+                    "openAppointmentSlots": 38,
                     "name": "Jones and West H-E-B",
                     "longitude": -95.5859,
                     "latitude": 29.91104,
@@ -7415,20 +8493,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 64,
-                            "openAppointmentSlots": 64,
+                            "openTimeslots": 57,
+                            "openAppointmentSlots": 57,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 72,
-                            "openAppointmentSlots": 72,
+                            "openTimeslots": 40,
+                            "openAppointmentSlots": 40,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 22,
+                            "openAppointmentSlots": 22,
+                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 136,
+                    "openTimeslots": 119,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 136,
+                    "openAppointmentSlots": 119,
                     "name": "The Market at Stone Oak",
                     "longitude": -98.50062,
                     "latitude": 29.662,
@@ -7446,18 +8529,13 @@
                         {
                             "openTimeslots": 16,
                             "openAppointmentSlots": 16,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 16,
-                            "openAppointmentSlots": 16,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 32,
+                    "openTimeslots": 16,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 32,
+                    "openAppointmentSlots": 16,
                     "name": "Lakeline H-E-B plus!",
                     "longitude": -97.8034,
                     "latitude": 30.47786,
@@ -7473,20 +8551,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 349,
-                            "openAppointmentSlots": 349,
+                            "openTimeslots": 347,
+                            "openAppointmentSlots": 347,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 392,
-                            "openAppointmentSlots": 392,
+                            "openTimeslots": 387,
+                            "openAppointmentSlots": 387,
                             "manufacturer": "Pfizer"
                         }
                     ],
-                    "openTimeslots": 741,
+                    "openTimeslots": 734,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 741,
+                    "openAppointmentSlots": 734,
                     "name": "Conroe Market H-E-B",
                     "longitude": -95.49817,
                     "latitude": 30.32647,
@@ -7502,20 +8580,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 5,
-                            "openAppointmentSlots": 5,
+                            "openTimeslots": 120,
+                            "openAppointmentSlots": 120,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 5,
-                            "openAppointmentSlots": 5,
+                            "openTimeslots": 95,
+                            "openAppointmentSlots": 95,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 10,
+                    "openTimeslots": 215,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 10,
+                    "openAppointmentSlots": 215,
                     "name": "Texas City H-E-B",
                     "longitude": -94.94893,
                     "latitude": 29.39535,
@@ -7549,30 +8627,30 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 22,
-                            "openAppointmentSlots": 22,
+                            "openTimeslots": 27,
+                            "openAppointmentSlots": 27,
                             "manufacturer": "Janssen"
                         },
                         {
-                            "openTimeslots": 89,
-                            "openAppointmentSlots": 89,
+                            "openTimeslots": 40,
+                            "openAppointmentSlots": 40,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 68,
-                            "openAppointmentSlots": 68,
+                            "openTimeslots": 28,
+                            "openAppointmentSlots": 28,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 89,
-                            "openAppointmentSlots": 89,
+                            "openTimeslots": 52,
+                            "openAppointmentSlots": 52,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 268,
+                    "openTimeslots": 147,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 268,
+                    "openAppointmentSlots": 147,
                     "name": "Broadway Central Market",
                     "longitude": -98.46408,
                     "latitude": 29.47069,
@@ -7606,25 +8684,20 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
+                            "openTimeslots": 9,
+                            "openAppointmentSlots": 9,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 29,
-                            "openAppointmentSlots": 29,
+                            "openTimeslots": 11,
+                            "openAppointmentSlots": 11,
                             "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 20,
-                            "openAppointmentSlots": 20,
-                            "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 59,
+                    "openTimeslots": 20,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 59,
+                    "openAppointmentSlots": 20,
                     "name": "Carrizo Springs H-E-B",
                     "longitude": -99.85102,
                     "latitude": 28.53642,
@@ -7640,25 +8713,40 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 19,
-                            "openAppointmentSlots": 19,
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
+                            "manufacturer": "Janssen"
+                        },
+                        {
+                            "openTimeslots": 88,
+                            "openAppointmentSlots": 88,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 14,
-                            "openAppointmentSlots": 14,
+                            "openTimeslots": 25,
+                            "openAppointmentSlots": 25,
+                            "manufacturer": "Pediatric_Moderna"
+                        },
+                        {
+                            "openTimeslots": 86,
+                            "openAppointmentSlots": 86,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 16,
-                            "openAppointmentSlots": 16,
+                            "openTimeslots": 56,
+                            "openAppointmentSlots": 56,
                             "manufacturer": "Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 45,
+                            "openAppointmentSlots": 45,
+                            "manufacturer": "Ultra_Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 49,
+                    "openTimeslots": 350,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 49,
+                    "openAppointmentSlots": 350,
                     "name": "Valley Mills H-E-B plus!",
                     "longitude": -97.13916,
                     "latitude": 31.52508,
@@ -7674,15 +8762,30 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 12,
-                            "openAppointmentSlots": 12,
+                            "openTimeslots": 8,
+                            "openAppointmentSlots": 8,
                             "manufacturer": "Moderna"
+                        },
+                        {
+                            "openTimeslots": 2,
+                            "openAppointmentSlots": 2,
+                            "manufacturer": "Pediatric_Moderna"
+                        },
+                        {
+                            "openTimeslots": 11,
+                            "openAppointmentSlots": 11,
+                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                        },
+                        {
+                            "openTimeslots": 66,
+                            "openAppointmentSlots": 66,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 12,
+                    "openTimeslots": 87,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 12,
+                    "openAppointmentSlots": 87,
                     "name": "University Blvd H-E-B",
                     "longitude": -97.68859,
                     "latitude": 30.56107,
@@ -7698,25 +8801,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 5,
-                            "openAppointmentSlots": 5,
+                            "openTimeslots": 14,
+                            "openAppointmentSlots": 14,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 49,
-                            "openAppointmentSlots": 49,
+                            "openTimeslots": 28,
+                            "openAppointmentSlots": 28,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 25,
-                            "openAppointmentSlots": 25,
+                            "openTimeslots": 13,
+                            "openAppointmentSlots": 13,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 79,
+                    "openTimeslots": 55,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 79,
+                    "openAppointmentSlots": 55,
                     "name": "Palmhurst H-E-B",
                     "longitude": -98.31816,
                     "latitude": 26.25684,
@@ -7732,25 +8835,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 85,
-                            "openAppointmentSlots": 85,
+                            "openTimeslots": 201,
+                            "openAppointmentSlots": 201,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 62,
-                            "openAppointmentSlots": 62,
+                            "openTimeslots": 169,
+                            "openAppointmentSlots": 169,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 9,
-                            "openAppointmentSlots": 9,
+                            "openTimeslots": 153,
+                            "openAppointmentSlots": 153,
                             "manufacturer": "Pediatric_Pfizer"
                         }
                     ],
-                    "openTimeslots": 156,
+                    "openTimeslots": 523,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 156,
+                    "openAppointmentSlots": 523,
                     "name": "Pearland Market H-E-B",
                     "longitude": -95.26499,
                     "latitude": 29.55812,
@@ -7799,15 +8902,15 @@
             "Content-Type",
             "binary/octet-stream",
             "Content-Length",
-            "156878",
+            "178173",
             "Connection",
             "close",
             "Date",
-            "Sun, 19 Jun 2022 16:52:27 GMT",
+            "Thu, 30 Jun 2022 02:27:47 GMT",
             "Last-Modified",
-            "Sun, 19 Jun 2022 16:51:55 GMT",
+            "Thu, 30 Jun 2022 02:26:08 GMT",
             "ETag",
-            "\"cd26b27ddcdab0af41463630dd244e97\"",
+            "\"b14524c3f8c52a9e5f2b5ec8e958d43f\"",
             "Cache-Control",
             "max-age:0",
             "Accept-Ranges",
@@ -7817,11 +8920,11 @@
             "X-Cache",
             "Miss from cloudfront",
             "Via",
-            "1.1 e59248dced0c86acee162cdb37ef8ba6.cloudfront.net (CloudFront)",
+            "1.1 42d3518040c55e24793897f7f5d5f342.cloudfront.net (CloudFront)",
             "X-Amz-Cf-Pop",
-            "SFO5-P1",
+            "EWR53-C1",
             "X-Amz-Cf-Id",
-            "F0S8Z8lmq7p6x8Wo7b2PH1CmpxaLZjU-mMGHRhmq4QJ-IDhogih-ZA=="
+            "M3mJVyrjZG6SXMaoB0I4NjpqaWogopf8aO_jH5RiPjczaiesaBeryw=="
         ],
         "responseIsBinary": false
     }


### PR DESCRIPTION
H-E-B now lists some appointment slots as having a vaccine type of "Multiple," instead of specifying a particular vaccine. There doesn't appear to be anything in the main listing file that includes details as to which vaccines are available, but we can usually get the list of products from the CDC in these cases instead, so for now we just skip this type.

While I was at it, I also added schema validation so we’re alerted in case they add some details later.

This whole thing seems unfriendly for end users, since it also shows up as “multiple” in their UI:

<img width="735" alt="Screen Shot 2022-06-29 at 10 01 21 PM" src="https://user-images.githubusercontent.com/74178/176579990-5be5f238-a4e1-431e-b59a-45a585d26e88.png">

Although sometimes there’s a more complete listing with other vaccines as well:

<img width="729" alt="Screen Shot 2022-06-29 at 10 01 41 PM" src="https://user-images.githubusercontent.com/74178/176580054-510170d1-0667-4bc9-aa01-83a5ddbce4c7.png">

¯\\\_(ツ)\_/¯