### PR TITLE
Support new Moderna `80777-275-*` NDC codes

### DIFF
--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -490,6 +490,10 @@ const ndcLookup = {
   [normalizeNdc("80777-0273-98")]: VaccineProduct.moderna, // sale
   [normalizeNdc("80777-0273-99")]: VaccineProduct.moderna, // sale
 
+  // 80777-275-* can be used as an adult booser or ages 6-11 primary dose.
+  [normalizeNdc("80777-0275-05")]: VaccineProduct.modernaAge6_11, // use
+  [normalizeNdc("80777-0275-99")]: VaccineProduct.modernaAge6_11, // sale
+
   [normalizeNdc("80777-0277-05")]: VaccineProduct.modernaAge6_11, // use
   [normalizeNdc("80777-0277-99")]: VaccineProduct.modernaAge6_11, // sale
 


### PR DESCRIPTION
These codes appear to be the first case where a product can be used for different age groups (albeit in different use cases for those groups), which poses a bit of a problem. I've classified this as `moderna_age_6_11` since it's the product for the primary series as opposed to the booster in that age group. The obvious alternative here is to modify the CDC loader so that an NDC code maps to an array of products rather than a single product. This seemed simpler for now, though.

Fixes https://sentry.io/organizations/usdr/issues/3342633674