### PR TITLE
Handle new Albertsons age range format

### DIFF
--- a/loader/src/sources/albertsons/index.js
+++ b/loader/src/sources/albertsons/index.js
@@ -462,7 +462,7 @@ function parseNameAndAddress(text) {
   // Most store names are in the form "<Brand Name> NNNN", e.g. "Safeway 3189".
   // Sometimes names repeat after the store number, e.g. "Safeway 3189 Safeway".
   const numberMatch = name.match(
-    /^(?<name>.*?)\s+#?(?<number>\d{2,6})(?:\s+\1)?/
+    /^(?<name>.*?)(?<!\d\sto)\s+#?(?<number>\d{2,6})(?:\s+\1)?/
   );
   let storeNumber;
   if (numberMatch) {
@@ -728,5 +728,6 @@ async function checkAvailability(handler, options) {
 module.exports = {
   checkAvailability,
   formatLocation,
+  parseNameAndAddress,
   API_URL,
 };

--- a/loader/test/albertsons.test.js
+++ b/loader/test/albertsons.test.js
@@ -3,6 +3,7 @@ const {
   API_URL,
   checkAvailability,
   formatLocation,
+  parseNameAndAddress,
 } = require("../src/sources/albertsons");
 const { corrections } = require("../src/sources/albertsons/corrections");
 const { Available } = require("../src/model");
@@ -644,5 +645,23 @@ describe("Albertsons", () => {
 
     expect(longerSectionFirst.name).toEqual("Happy Lands Church - Some info");
     expect(longerSectionSecond.name).toEqual("Happy Lands Church - Some info");
+  });
+
+  it("finds store number and brand when age ranges might look like store numbers", () => {
+    const result = parseNameAndAddress(
+      "Pfizer Age 5 to 11 Albertsons 3592  - 15970 Los Serranos City Club Dr, Chino Hills, CA, 91709"
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        storeBrand: expect.objectContaining({ key: "albertsons" }),
+        storeNumber: "3592",
+        address: {
+          lines: ["15970 Los Serranos City Club Dr"],
+          city: "Chino Hills",
+          state: "CA",
+          zip: "91709",
+        },
+      })
+    );
   });
 });


### PR DESCRIPTION
Albertsons has started using textual age ranges (e.g. "ages 5 to 11" instead of "ages 5-11"), which caused us to start seeing the "11" as a store number. This change makes our store-number-finding-regex a little more complex to not find numbers preceded by `" to "`, which solves the issue.

Fixes https://sentry.io/organizations/usdr/issues/3397100576.