### PR TITLE
Support age ranges using `through` instead of `-`

### DIFF
--- a/loader/src/utils.js
+++ b/loader/src/utils.js
@@ -514,7 +514,7 @@ module.exports = {
         return VaccineProduct.moderna;
       } else if (/ages?\s+6\s*(m|months)\b/i.test(text)) {
         return VaccineProduct.modernaAge0_5;
-      } else if (/ages? 6\s?-11/i.test(text)) {
+      } else if (/ages? 6\s?(-|through)\s?11/i.test(text)) {
         return VaccineProduct.modernaAge6_11;
       } else if (/ped|child|age/i.test(text)) {
         // Possibly a pediatric variation we haven't seen, so return nothing to
@@ -528,7 +528,7 @@ module.exports = {
     } else if (text.includes("pfizer")) {
       if (/ages?\s+12( and up|\s*\+)/i.test(text)) {
         return VaccineProduct.pfizer;
-      } else if (/ages?\s+5|\b5\s?-\s?11\b/i.test(text)) {
+      } else if (/ages?\s+5|\b5\s?(-|through)\s?11\b/i.test(text)) {
         return VaccineProduct.pfizerAge5_11;
       } else if (/ages?\s+6\s*(m|months)\b/i.test(text)) {
         return VaccineProduct.pfizerAge0_4;

--- a/loader/test/utils.test.js
+++ b/loader/test/utils.test.js
@@ -239,6 +239,7 @@ describe("matchVaccineProduct", () => {
     [v.moderna, "Moderna COVID-19 Vaccine/Booster (Ages 18+)"],
 
     [v.modernaAge6_11, "Moderna COVID-19 Vaccine (ages 6-11 Primary, 18+ Booster)"],
+    [v.modernaAge6_11, "Moderna Pediatric COVID-19 Vaccine (Ages 6 through 11)"],
 
     [v.modernaAge0_5, "Moderna Pediatric COVID-19 Vaccine (Ages 6 months - 5 years)"],
     [v.modernaAge0_5, "Moderna COVID-19 Vaccine (Ages 6m-5yrs)"],


### PR DESCRIPTION
Fixes https://sentry.io/organizations/usdr/issues/3382842420