### PR TITLE
Avoid interpreting dates as store numbers

### DIFF
--- a/loader/src/sources/albertsons/index.js
+++ b/loader/src/sources/albertsons/index.js
@@ -459,14 +459,41 @@ function parseNameAndAddress(text) {
     }
   }
 
-  // Most store names are in the form "<Brand Name> NNNN", e.g. "Safeway 3189".
-  // Sometimes names repeat after the store number, e.g. "Safeway 3189 Safeway".
-  const numberMatch = name.match(
-    /^(?<name>.*?)(?<!\d\sto)\s+#?(?<number>\d{2,6})(?:\s+\1)?/
+  // Identify the store number from the name string, avoiding things like
+  // dates, times, and age ranges.
+  const numberExpression = new RegExp(
+    String.raw`
+    ^
+    (?<name>.*?)
+    (?<!
+      \d\sto   |
+      \d\s?-   |
+      \sages?  |
+      \sjan\w+ |
+      \sfeb\w+ |
+      \smar\w+ |
+      \sapr\w+ |
+      \smay\w+ |
+      \sjun\w+ |
+      \sjul\w+ |
+      \saug\w+ |
+      \ssep\w+ |
+      \soct\w+ |
+      \snov\w+ |
+      \sdec\w+
+    )
+    \s+
+    #?(?<number>\d{2,6})
+    (\s|$)
+  `.replace(/\s+/g, ""),
+    "i"
   );
+  const numberMatch = name.match(numberExpression);
   let storeNumber;
   if (numberMatch) {
     storeNumber = unpadNumber(numberMatch.groups.number);
+    // Sometimes names repeat after the number, like "Safeway 3189 Safeway",
+    // so we rewrite the name here to clean that up.
     name = `${numberMatch.groups.name} ${storeNumber}`;
   }
 

--- a/loader/test/albertsons.test.js
+++ b/loader/test/albertsons.test.js
@@ -651,17 +651,27 @@ describe("Albertsons", () => {
     const result = parseNameAndAddress(
       "Pfizer Age 5 to 11 Albertsons 3592  - 15970 Los Serranos City Club Dr, Chino Hills, CA, 91709"
     );
-    expect(result).toEqual(
-      expect.objectContaining({
-        storeBrand: expect.objectContaining({ key: "albertsons" }),
-        storeNumber: "3592",
-        address: {
-          lines: ["15970 Los Serranos City Club Dr"],
-          city: "Chino Hills",
-          state: "CA",
-          zip: "91709",
-        },
-      })
+    expect(result).toHaveProperty("storeBrand.key", "albertsons");
+    expect(result).toHaveProperty("storeNumber", "3592");
+    expect(result).toHaveProperty("address", {
+      lines: ["15970 Los Serranos City Club Dr"],
+      city: "Chino Hills",
+      state: "CA",
+      zip: "91709",
+    });
+  });
+
+  it("finds store number and brand when dates might look like store numbers", () => {
+    const result = parseNameAndAddress(
+      "Albertsons July 10 Albertsons 3592 - 15970 Los Serranos City Club Dr, Chino Hills, CA, 91709"
     );
+    expect(result).toHaveProperty("storeBrand.key", "albertsons");
+    expect(result).toHaveProperty("storeNumber", "3592");
+    expect(result).toHaveProperty("address", {
+      lines: ["15970 Los Serranos City Club Dr"],
+      city: "Chino Hills",
+      state: "CA",
+      zip: "91709",
+    });
   });
 });


### PR DESCRIPTION
We were sometimes interpreting dates as store numbers for Albertsons, like the "10" in "July 10" from the entry named "Olympic Hills School Pfizer Clinic for ages 3+ July 10 9:30am-12:30pm". This updates our store number regex to avoid this situation.

This is a little ugly, and a better long-term fix is probably to include store numbers in the regex used to match brands (we don’t really need the part of this that cleans up the name, since we have the scraped store data now). That’s a big change I don’t want to land without a lot more testing, though.

Fixes https://sentry.io/organizations/usdr/issues/3397100576