### PR TITLE
Add an S3 bucket for testing the Render deployment

### DIFF
--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -1,16 +1,26 @@
 # s3.tf
 
+locals {
+  data_snapshot_bucket_names = toset([
+    "univaf-data-snapshots",
+    "univaf-render-test-data-snapshots",
+  ])
+}
+
 resource "aws_s3_bucket" "data_snapshots" {
-  bucket = "univaf-data-snapshots"
+  for_each = local.data_snapshot_bucket_names
+  bucket = each.key
 }
 
 resource "aws_s3_bucket_acl" "data_snapshots_acl" {
-  bucket = aws_s3_bucket.data_snapshots.id
+  for_each = aws_s3_bucket.data_snapshots
+  bucket = each.value.id
   acl    = "public-read"
 }
 
 resource "aws_s3_bucket_policy" "data_snapshots" {
-  bucket = aws_s3_bucket.data_snapshots.id
+  for_each = aws_s3_bucket.data_snapshots
+  bucket = each.value.id
   policy = jsonencode({
     Version = "2008-10-17"
     Id      = "Policy8542383977173"


### PR DESCRIPTION
This is a pre-requisite for #755. Since the Render deployment is a test, it needs its own S3 bucket to dump historical data into so it doesn't overwrite the actual production data from our stuff running on ECS.