### PR TITLE
Downsize loaders to 0.5 vCPU, 1 GB RAM

### DIFF
--- a/terraform/modules/loader/main.tf
+++ b/terraform/modules/loader/main.tf
@@ -4,8 +4,8 @@ module "loader_task" {
   name    = var.name
   image   = var.loader_image
   role    = var.role
-  cpu     = 1024
-  memory  = 2048
+  cpu     = 512
+  memory  = 1024
   port    = 3000
   command = concat(var.command, [var.loader_source])
 


### PR DESCRIPTION
We've long known that the loaders are probably overprovisioned. This downsizes them by 50%. Partially covers #303.

See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size for valid cpu/memory values and combinations.