### PR TITLE
542 compress those logfiles

### DIFF
--- a/server/scripts/availability_dump.js
+++ b/server/scripts/availability_dump.js
@@ -23,6 +23,8 @@ const knexConfig = require("../knexfile");
 const luxon = require("luxon");
 const JSONStream = require("JSONStream");
 const stream = require("stream");
+const { Buffer } = require("buffer");
+const zlib = require("zlib");
 
 Sentry.init();
 
@@ -57,6 +59,80 @@ function removeNullPropertiesStream() {
       callback(null, record);
     },
   });
+}
+
+/**
+ * A stream that emits buffers of a given size (in bytes). Useful when an input
+ * stream might emit data in small chunks, while the next stream in a pipeline
+ * works more efficiently with larger chunks, or chunks of a given size.
+ *
+ * In practice, we use this for gzipping, since gzip stream work most
+ * efficiently if data comes in chunks of at least 32 kB (this actually makes
+ * a pretty big difference).
+ *
+ * We couldn't find a good version of this on NPM (which seems surprising,
+ * we're probably missing it). The `stream-chunker` package, which is popular,
+ * performs *terribly* and is often worse than no chunking at all.
+ */
+class BufferedStream extends stream.Transform {
+  constructor({ size = 256 * 1024, ...options } = {}) {
+    super(options);
+    this.size = size;
+    this.resetBuffer();
+  }
+
+  resetBuffer() {
+    this.buffer = Buffer.allocUnsafe(this.size);
+    this.offset = 0;
+  }
+
+  _transform(input, encoding, callback) {
+    if (typeof input === "string") {
+      input = Buffer.from(input, encoding);
+    } else if (!(input instanceof Buffer)) {
+      callback(
+        new TypeError(
+          `BufferedStream input must be strings or buffers, not ${input.constructor.name}`
+        )
+      );
+      return;
+    }
+
+    let inputPosition = 0;
+    while (inputPosition < input.length) {
+      const written = input.copy(this.buffer, this.offset, inputPosition);
+      inputPosition += written;
+      this.offset += written;
+
+      if (this.offset === this.size) {
+        this.push(this.buffer);
+        this.resetBuffer();
+      }
+    }
+    callback();
+  }
+
+  _flush(callback) {
+    if (this.offset > 0) {
+      this.push(this.buffer.slice(0, this.offset));
+    }
+    callback();
+  }
+
+  _destroy(error, callback) {
+    this.buffer = null;
+    callback(error);
+  }
+}
+
+function bufferedGzipStream(size = 64 * 1024) {
+  return stream.compose(
+    new BufferedStream({ size }),
+    zlib.createGzip({
+      level: zlib.constants.Z_BEST_COMPRESSION,
+      chunkSize: size,
+    })
+  );
 }
 
 function getQueryStream(queryBuilder) {
@@ -157,7 +233,7 @@ function formatDate(date) {
 }
 
 function pathFor(type, date) {
-  return `${type}/${type}-${formatDate(date)}.ndjson`;
+  return `${type}/${type}-${formatDate(date)}.ndjson.gz`;
 }
 
 function eachDayOfInterval({ start, end }) {
@@ -184,12 +260,15 @@ async function main() {
 
   for (const table of ["external_ids", "availability"]) {
     writeLog(`writing ${pathFor(table, runDate)}`);
-    await writeStream(getTableStream(table), pathFor(table, runDate));
+    await writeStream(
+      getTableStream(table).pipe(bufferedGzipStream()),
+      pathFor(table, runDate)
+    );
   }
 
   writeLog(`writing ${pathFor("provider_locations", runDate)}`);
   await writeStream(
-    getProviderLocationsStream(),
+    getProviderLocationsStream().pipe(bufferedGzipStream()),
     pathFor("provider_locations", runDate)
   );
 
@@ -197,7 +276,7 @@ async function main() {
   for (const logRunDate of logRunDates) {
     writeLog(`writing ${pathFor("availability_log", logRunDate)}`);
     await writeStream(
-      getAvailabilityLogStream(logRunDate),
+      getAvailabilityLogStream(logRunDate).pipe(bufferedGzipStream()),
       pathFor("availability_log", logRunDate)
     );
   }


### PR DESCRIPTION
This gzips our nightly log files before writing them, resulting in drastically smaller and easier to manage data files. At the moment, our data is big enough that the bottleneck is pretty much always bandwidth to load the file (even when loading from disk and not the network!). Gzipping them makes sending, loading, and processing historical data *much* faster. Fixes #542.

The implementation here is based on experimentation and refinement done a while back in https://gist.github.com/Mr0grog/1f5e14ac360e64304c0031282e0cae3f. See that gist and #542 for more details about the approach and other alternatives.

I made this always gzip streams, but we could also change it up so that’s an option.

I also updated a bunch of things here to use the new `compose()` and `pipeline()` builtins here, which forward errors along so we actually handle them correctly in ways that `pipe` does not (luckily we haven’t encountered any weird errors, so this is more just imposing some better practices). However, it’s worth noting that `compose` is still classified as experimental (because it also does fancy stuff like convert generators to streams — very nice). I also didn’t do this in all cases because `compose` can’t take `JSONStream.stringify()` as the last argument (I think it’s just a very old-school first-generation stream, and compose doesn’t support those). Anyway. This is fine, but I think we could also replace the third-party library with:

```js
const ndjsonStream = stream.compose(async function * stringify(source) {
  for await (const object of source) {
    yield JSON.stringify(object);
  }
});
```

🤷