### PR TITLE
Actually deploy updates to daily-data-snapshot

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -120,7 +120,7 @@ module "daily_data_snapshot_task" {
   source = "./modules/task"
 
   name    = "daily-data-snapshot"
-  image   = aws_ecr_repository.server_repository.repository_url
+  image   = "${aws_ecr_repository.server_repository.repository_url}:${var.api_release_version}"
   command = ["node", "scripts/availability_dump.js", "--write-to-s3", "--clear-log"]
   role    = aws_iam_role.ecs_task_execution_role.arn
 


### PR DESCRIPTION
This is a follow-on to #542. Apparently we weren't telling ECS what image tag to use for the daily-data-snapshot task, so we've never actually deployed new code to it. 😱

(I noticed this only because the run today did not write a `.gz` file!)