### PR TITLE
Use same DB connection pool for data and logs

### DIFF
--- a/server/src/availability-log.ts
+++ b/server/src/availability-log.ts
@@ -1,12 +1,13 @@
-import Knex from "knex";
-import { loadDbConfig } from "./config";
+import dbConnection from "./db-connection";
 import { AvailabilityInput } from "./interfaces";
 
 interface AvailabilityLog extends AvailabilityInput {
   changed_at: Date | string;
 }
 
-export const availabilityDb = Knex(loadDbConfig()); // for now, store with the rest of our data
+// Re-use the main DB connection for logs, but use a new constant, so this can
+// change to point to a separate data warehouse if needed.
+export const availabilityDb = dbConnection;
 
 export async function write(
   locationId: string,

--- a/server/src/db-connection.ts
+++ b/server/src/db-connection.ts
@@ -1,0 +1,4 @@
+import Knex from "knex";
+import { loadDbConfig } from "./config";
+
+export default Knex(loadDbConfig());

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -9,9 +9,8 @@ import {
   LocationAvailability,
 } from "./interfaces";
 import { NotFoundError, OutOfDateError, ValueError } from "./exceptions";
-import Knex from "knex";
 import { validateAvailabilityInput, validateLocationInput } from "./validation";
-import { loadDbConfig } from "./config";
+import dbConnection from "./db-connection";
 import { UUID_PATTERN } from "./utils";
 import { logger, logStackTrace } from "./logger";
 
@@ -31,7 +30,7 @@ const DEFAULT_BATCH_SIZE = 2000;
 // within this many milliseconds of each other.
 const AVAILABILITY_MERGE_TIMEFRAME = 7 * 24 * 60 * 60 * 1000;
 
-export const db = Knex(loadDbConfig());
+export const db = dbConnection;
 
 const providerLocationFields = [
   "id",


### PR DESCRIPTION
We used to create two connection pools to the database (one for data and one for writing availability update logs). This leads to a *lot* of connections, and on the new Render deployment we are sometimes running out of connections and dropping logs. This re-uses the same pool for both, which should be safe (we still keep separate references, so the availability log can be changed to point somewhere else) and solves the issue by using half as many connections.

Another option here is to add an environment variable for the maximum number of DB connections in the pool(s). That might still be a good idea, and could be useful in addition to the change I made here, but skipping it seemed simpler for now.

Fixes https://sentry.io/organizations/usdr/issues/3155794613.

@astonm do you mind giving me a gut-check on whether this seems reasonable? The biggest concern I can think of here is that this might reduce throughput slightly, but I *think* it should be low impact overall.