### PR TITLE
Log changes to database connection pool size

### DIFF
--- a/server/src/availability-log.ts
+++ b/server/src/availability-log.ts
@@ -1,12 +1,12 @@
-import Knex from "knex";
-import { loadDbConfig } from "./config";
+import { createDbClient } from "./db-client";
 import { AvailabilityInput } from "./interfaces";
 
 interface AvailabilityLog extends AvailabilityInput {
   changed_at: Date | string;
 }
 
-export const availabilityDb = Knex(loadDbConfig()); // for now, store with the rest of our data
+// For now, we store these logs alongside with the rest of our data.
+export const availabilityDb = createDbClient("Availability");
 
 export async function write(
   locationId: string,

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -1,3 +1,4 @@
+import os from "node:os";
 import type { Knex } from "knex";
 
 export const LOG_LEVEL = process.env.LOG_LEVEL || "info";
@@ -31,6 +32,18 @@ export function getPrimaryHost(): string {
     );
   }
   return host || null;
+}
+
+/**
+ * Get a string identifier for host machine instance the app is running on.
+ * @returns {string}
+ */
+export function getHostInstance(): string {
+  if (process.env.RENDER) {
+    return `${process.env.RENDER_SERVICE_NAME}-${process.env.RENDER_INSTANCE_ID}`;
+  } else {
+    return os.hostname();
+  }
 }
 
 export function loadDbConfig(): Knex.Config {

--- a/server/src/db-client.ts
+++ b/server/src/db-client.ts
@@ -1,0 +1,20 @@
+import Knex from "knex";
+import type { Knex as KnexType } from "knex";
+import { logger } from "./logger";
+import { getHostInstance, loadDbConfig } from "./config";
+
+export function createDbClient(label: string): KnexType<any, unknown[]> {
+  const client = Knex(loadDbConfig());
+
+  // Add debug-related logging.
+  const pool = client.client.pool;
+  const instanceName = getHostInstance();
+  function logPoolSize() {
+    const poolSize = pool.numUsed() + pool.numFree();
+    logger.info(`${instanceName} ${label} DB pool size: ${poolSize}`);
+  }
+  pool.on("createSuccess", logPoolSize);
+  pool.on("destroySuccess", logPoolSize);
+
+  return client;
+}

--- a/server/src/db-client.ts
+++ b/server/src/db-client.ts
@@ -7,7 +7,7 @@ export function createDbClient(label: string): KnexType<any, unknown[]> {
   const client = Knex(loadDbConfig());
 
   // Add debug-related logging.
-  const pool = client.client.pool;
+  const pool = (client.client as KnexType.Client).pool;
   const instanceName = getHostInstance();
   function logPoolSize() {
     const poolSize = pool.numUsed() + pool.numFree();

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -9,9 +9,8 @@ import {
   LocationAvailability,
 } from "./interfaces";
 import { NotFoundError, OutOfDateError, ValueError } from "./exceptions";
-import Knex from "knex";
 import { validateAvailabilityInput, validateLocationInput } from "./validation";
-import { loadDbConfig } from "./config";
+import { createDbClient } from "./db-client";
 import { UUID_PATTERN } from "./utils";
 import { logger, logStackTrace } from "./logger";
 
@@ -31,7 +30,7 @@ const DEFAULT_BATCH_SIZE = 2000;
 // within this many milliseconds of each other.
 const AVAILABILITY_MERGE_TIMEFRAME = 7 * 24 * 60 * 60 * 1000;
 
-export const db = Knex(loadDbConfig());
+export const db = createDbClient("Data");
 
 const providerLocationFields = [
   "id",

--- a/server/src/logger.ts
+++ b/server/src/logger.ts
@@ -2,17 +2,27 @@ import { createLogger, Logger, transports, format } from "winston";
 const { combine, timestamp, splat, printf, label } = format;
 import { LOG_LEVEL } from "./config";
 
-const timestampPrefixLogFormat = printf(
-  ({ level, message, label, timestamp }) => {
-    return `${timestamp} [${label}] ${level}: ${message}`;
-  }
+// Some platforms include the timestamp for each log line, so adding our own
+// timestamp makes them harder to read.
+const shouldLogTimestamp = !(
+  process.env.RENDER ||
+  process.env.ECS_CONTAINER_METADATA_URI ||
+  process.env.ECS_CONTAINER_METADATA_URI_V4
 );
+
+const univafLogFormat = printf(({ level, message, label, timestamp }) => {
+  let formatted = `[${label}] ${level}: ${message}`;
+  if (shouldLogTimestamp) {
+    formatted = `${timestamp} ${formatted}`;
+  }
+  return formatted;
+});
 
 const customFormatWithTimestamp = combine(
   label({ label: "univaf" }),
   timestamp(),
   splat(),
-  timestampPrefixLogFormat
+  univafLogFormat
 );
 
 export const logger: Logger = createLogger({


### PR DESCRIPTION
While addressing https://sentry.io/organizations/usdr/issues/3155794613, we realized we don't really have a handle on exactly how the database connection pools are behaving (see discussion in #778). This change logs every time the pool grows or shrinks, which should give us a better idea how the two pools are behaving. It'll log lines like:

```
2022-07-28T19:37:00.711Z [univaf] info: squarpix.lan Data DB pool size: 1
2022-07-28T19:37:00.714Z [univaf] info: squarpix.lan Data DB pool size: 2
2022-07-28T19:37:00.715Z [univaf] info: squarpix.lan Data DB pool size: 3
2022-07-28T19:37:31.763Z [univaf] info: squarpix.lan Data DB pool size: 2
```

Note: the hostname is included here (`squarpix.lan` in the example above) because we are usually running multiple instances of the server, and we need to know which instance we are logging pool info for to actually understand things.

Another interesting lesson learned here: Knex's pool will reclaim and destroy connection objects from the pool if not used for a while, so that probably has a lot to do with how unpredictable hitting the connection limits seems to be.