### PR TITLE
Handle Moderna ages 12-17 listings from HyVee

### DIFF
--- a/loader/src/sources/hyvee/index.js
+++ b/loader/src/sources/hyvee/index.js
@@ -24,6 +24,9 @@ const SOURCE_NAME = "univaf-hyvee";
 const PROVIDER_NAME = "hyvee";
 const VACCINE_NAMES = {
   Moderna: VaccineProduct.moderna,
+  // Moderna 12-17 is the same product as 12+ or 18+. This is a little messy,
+  // since technically these might be separate appointment slots for teens.
+  "Moderna (12-17)": VaccineProduct.moderna,
   "Pediatric-Moderna (3-5)": VaccineProduct.modernaAge0_5,
   "Pfizer-BioNTech": VaccineProduct.pfizer,
   "Pediatric-Pfizer (5-11)": VaccineProduct.pfizerAge5_11,


### PR DESCRIPTION
HyVee started listing "Moderna (12-17)" as a vaccine type, but it's not actually a different product from what's used for ages 12+ or 18+. The location in question also lists some younger pediatric vaccines, so presumably this doesn't have anything to do with the minimum age the pharmacist is qualified for, and presumably there are just some appointment slots that are age limited this way.

I've classified these as normal `moderna` here, and that is probably a close enough approximation to make sense, rather than creating a new vaccine type for this weirdness (but if we want to there is the [someone-is-always-doing-something-weird](https://github.com/usdigitalresponse/univaf/compare/0605690...someone-is-always-doing-something-weird) branch). HyVee doesn’t have any locations in NJ or AK, so this is probably less of a big deal anyway.

Fixes https://sentry.io/organizations/usdr/issues/3464812423/