### PR TITLE
Add more DB pool metrics, improve metric tagging

### DIFF
--- a/server/knexfile.js
+++ b/server/knexfile.js
@@ -12,6 +12,8 @@ const base = {
     tableName: "migrations",
   },
   pool: {
+    min: 0,
+    max: 10,
     afterCreate(conn, done) {
       // Ensure Postgres formats times in UTC.
       conn.query('SET timezone="UTC";', done);

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -34,6 +34,19 @@ export function getPrimaryHost(): string {
   return host || null;
 }
 
+export function getPlatform(): string {
+  if (process.env.RENDER) {
+    return "render";
+  } else if (
+    process.env.ECS_CONTAINER_METADATA_URI ||
+    process.env.ECS_CONTAINER_METADATA_URI_V4
+  ) {
+    return "ecs";
+  } else {
+    return "";
+  }
+}
+
 /**
  * Get a string identifier for host machine instance the app is running on.
  * @returns {string}

--- a/server/src/datadog.ts
+++ b/server/src/datadog.ts
@@ -1,8 +1,15 @@
 import { Response, Request, NextFunction } from "express";
 import StatsD from "hot-shots";
+import { getHostInstance, getPlatform } from "./config";
+
+const globalTags = [`instance:${getHostInstance()}`];
+if (getPlatform()) {
+  globalTags.push(`platform:${getPlatform()}`);
+}
 
 export const dogstatsd = new StatsD({
   mock: process.env.NODE_ENV == "test",
+  globalTags,
 });
 const stat = "node.express.router";
 const DELIMITER = "-";

--- a/server/src/db-client.ts
+++ b/server/src/db-client.ts
@@ -1,5 +1,6 @@
 import Knex from "knex";
 import type { Knex as KnexType } from "knex";
+import Sentry from "@sentry/node";
 import { logger } from "./logger";
 import { getHostInstance, loadDbConfig } from "./config";
 import { dogstatsd } from "./datadog";
@@ -10,15 +11,52 @@ export function createDbClient(label: string): KnexType<any, unknown[]> {
   // Add debug-related logging.
   const pool = (client.client as KnexType.Client).pool;
   const instanceName = getHostInstance();
+  const poolStatName = `db.${label.toLowerCase()}.pool`;
+  const poolStatTags = [`instance:${instanceName}`];
+
   function logPoolSize() {
     const poolSize = pool.numUsed() + pool.numFree();
     logger.debug(`${instanceName} ${label} DB pool size: ${poolSize}`);
-    dogstatsd.gauge(`db.${label.toLowerCase()}.pool.size`, poolSize, [
-      `instance:${instanceName}`,
-    ]);
+    dogstatsd.gauge(`${poolStatName}.size`, poolSize, poolStatTags);
   }
   pool.on("createSuccess", logPoolSize);
   pool.on("destroySuccess", logPoolSize);
+
+  // Keep track of pending acquires (i.e. how backed up are we).
+  function logPendingAcquires() {
+    dogstatsd.gauge(
+      `${poolStatName}.pending_acquires`,
+      pool.numPendingAcquires(),
+      poolStatTags
+    );
+  }
+  pool.on("acquireRequest", logPendingAcquires);
+  pool.on("acquireSuccess", logPendingAcquires);
+  pool.on("acquireFail", logPendingAcquires);
+
+  // Keep track of how long acquiring a connection takes.
+  const acquireTimes = new Map<number, number>();
+  function logAcquireTime(eventId: number) {
+    const startTime = acquireTimes.get(eventId);
+    if (startTime) {
+      acquireTimes.delete(eventId);
+      dogstatsd.histogram(
+        `${poolStatName}.acquire_time`,
+        Date.now() - startTime,
+        poolStatTags
+      );
+    } else {
+      logger.warn(
+        `${instanceName} ${label} DB: no timing data for acquire ${eventId}`
+      );
+      Sentry.captureMessage(`No timing data for ${label} DB acquire`, {
+        level: "warning",
+      });
+    }
+  }
+  pool.on("acquireRequest", (eventId) => acquireTimes.set(eventId, Date.now()));
+  pool.on("acquireSuccess", logAcquireTime);
+  pool.on("acquireFail", logAcquireTime);
 
   return client;
 }

--- a/server/src/db-client.ts
+++ b/server/src/db-client.ts
@@ -12,12 +12,11 @@ export function createDbClient(label: string): KnexType<any, unknown[]> {
   const pool = (client.client as KnexType.Client).pool;
   const instanceName = getHostInstance();
   const poolStatName = `db.${label.toLowerCase()}.pool`;
-  const poolStatTags = [`instance:${instanceName}`];
 
   function logPoolSize() {
     const poolSize = pool.numUsed() + pool.numFree();
     logger.debug(`${instanceName} ${label} DB pool size: ${poolSize}`);
-    dogstatsd.gauge(`${poolStatName}.size`, poolSize, poolStatTags);
+    dogstatsd.gauge(`${poolStatName}.size`, poolSize);
   }
   pool.on("createSuccess", logPoolSize);
   pool.on("destroySuccess", logPoolSize);
@@ -26,8 +25,7 @@ export function createDbClient(label: string): KnexType<any, unknown[]> {
   function logPendingAcquires() {
     dogstatsd.gauge(
       `${poolStatName}.pending_acquires`,
-      pool.numPendingAcquires(),
-      poolStatTags
+      pool.numPendingAcquires()
     );
   }
   pool.on("acquireRequest", logPendingAcquires);
@@ -42,8 +40,7 @@ export function createDbClient(label: string): KnexType<any, unknown[]> {
       acquireTimes.delete(eventId);
       dogstatsd.histogram(
         `${poolStatName}.acquire_time`,
-        Date.now() - startTime,
-        poolStatTags
+        Date.now() - startTime
       );
     } else {
       logger.warn(

--- a/server/src/db-client.ts
+++ b/server/src/db-client.ts
@@ -1,6 +1,6 @@
 import Knex from "knex";
 import type { Knex as KnexType } from "knex";
-import Sentry from "@sentry/node";
+import * as Sentry from "@sentry/node";
 import { logger } from "./logger";
 import { getHostInstance, loadDbConfig } from "./config";
 import { dogstatsd } from "./datadog";

--- a/server/src/logger.ts
+++ b/server/src/logger.ts
@@ -1,14 +1,11 @@
 import { createLogger, Logger, transports, format } from "winston";
 const { combine, timestamp, splat, printf, label } = format;
-import { LOG_LEVEL } from "./config";
+import { getPlatform, LOG_LEVEL } from "./config";
 
 // Some platforms include the timestamp for each log line, so adding our own
 // timestamp makes them harder to read.
-const shouldLogTimestamp = !(
-  process.env.RENDER ||
-  process.env.ECS_CONTAINER_METADATA_URI ||
-  process.env.ECS_CONTAINER_METADATA_URI_V4
-);
+const platform = getPlatform();
+const shouldLogTimestamp = !(platform === "render" || platform === "ecs");
 
 const univafLogFormat = printf(({ level, message, label, timestamp }) => {
   let formatted = `[${label}] ${level}: ${message}`;

--- a/server/src/logger.ts
+++ b/server/src/logger.ts
@@ -4,8 +4,7 @@ import { getPlatform, LOG_LEVEL } from "./config";
 
 // Some platforms include the timestamp for each log line, so adding our own
 // timestamp makes them harder to read.
-const platform = getPlatform();
-const shouldLogTimestamp = !(platform === "render" || platform === "ecs");
+const shouldLogTimestamp = !["render", "ecs"].includes(getPlatform());
 
 const univafLogFormat = printf(({ level, message, label, timestamp }) => {
   let formatted = `[${label}] ${level}: ${message}`;

--- a/server/test/datadog.test.ts
+++ b/server/test/datadog.test.ts
@@ -35,8 +35,8 @@ describe("datadog middleware", () => {
     const res = await context.client.get<any>("api/edge/locations");
     expect(res.statusCode).toBe(200);
 
-    const middlewareMetrics = dogstatsd.mockBuffer.filter((x) =>
-      x.startsWith("node.express.router.")
+    const middlewareMetrics = dogstatsd.mockBuffer.filter((s) =>
+      s.startsWith("node.express.router.")
     );
     expect(middlewareMetrics).toHaveLength(2);
 

--- a/server/test/datadog.test.ts
+++ b/server/test/datadog.test.ts
@@ -35,7 +35,10 @@ describe("datadog middleware", () => {
     const res = await context.client.get<any>("api/edge/locations");
     expect(res.statusCode).toBe(200);
 
-    expect(dogstatsd.mockBuffer).toHaveLength(2);
+    const middlewareMetrics = dogstatsd.mockBuffer.filter((x) =>
+      x.startsWith("node.express.router.")
+    );
+    expect(middlewareMetrics).toHaveLength(2);
 
     expect(dogstatsd.mockBuffer).toContain(
       "node.express.router.response_total:1|c|#route:/api/edge/locations,method:get,response_code:200"

--- a/server/test/datadog.test.ts
+++ b/server/test/datadog.test.ts
@@ -40,8 +40,10 @@ describe("datadog middleware", () => {
     );
     expect(middlewareMetrics).toHaveLength(2);
 
-    expect(dogstatsd.mockBuffer).toContain(
-      "node.express.router.response_total:1|c|#route:/api/edge/locations,method:get,response_code:200"
+    expect(dogstatsd.mockBuffer).toContainEqual(
+      expect.stringMatching(
+        /^node\.express\.router\.response_total:1\|c\|#.*response_code:200.*/
+      )
     );
     expect(dogstatsd.mockBuffer).toContainEqual(
       expect.stringMatching(/^node\.express\.router\.response_time:/)
@@ -58,10 +60,10 @@ describe("datadog middleware", () => {
     expect(res.statusCode).toBe(404);
 
     expect(
-      dogstatsd.mockBuffer.filter(
-        (s) =>
-          s ===
-          "node.express.router.response_total:1|c|#route:/api/edge/locations/:id,method:get,response_code:404"
+      dogstatsd.mockBuffer.filter((s) =>
+        /^node\.express\.router\.response_total:1\|c\|#.*route:\/api\/edge\/locations\/:id.*response_code:404.*/.test(
+          s
+        )
       )
     ).toHaveLength(2);
   });


### PR DESCRIPTION
These are some minor monitoring improvements:
- Use global tags to make sure every metric gets platform and instance name info.
- Use metrics to track how backlogged the pool is by watching pending acquires and connection acquire time (in milliseconds).

This also updates the minimum pool size to be zero, per an earlier discussion with @astonm about [Knex’s defaults vs. recommended settings](https://knexjs.org/guide/#pool).