### PR TITLE
Implement Sentry tracing for API server

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -256,6 +256,8 @@ envVarGroups:
         sync: false
       - key: SENTRY_DSN
         sync: false
+      - key: SENTRY_TRACES_SAMPLE_RATE
+        value: "0.2"
       - key: SENTRY_ENVIRONMENT
         # FIXME: should be 'production' if/when we turn off AWS
         value: render
@@ -272,6 +274,8 @@ envVarGroups:
         sync: false
       - key: SENTRY_DSN
         sync: false
+      - key: SENTRY_TRACES_SAMPLE_RATE
+        value: "0.2"
       - key: SENTRY_ENVIRONMENT
         # FIXME: should be 'production' if/when we turn off AWS
         value: render

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -3,6 +3,9 @@ import type { Knex } from "knex";
 
 export const LOG_LEVEL = process.env.LOG_LEVEL || "info";
 
+export const RELEASE =
+  process.env.RELEASE || process.env.RENDER_GIT_COMMIT || undefined;
+
 export function getApiKeys(): Array<string> {
   let keyList = process.env.API_KEYS;
   if (!keyList) {

--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -102,15 +102,16 @@ module "api_task" {
   datadog_api_key = var.datadog_api_key
 
   env_vars = {
-    RELEASE      = var.api_release_version
-    DB_HOST      = module.db.host
-    DB_NAME      = module.db.db_name
-    DB_USERNAME  = var.db_user
-    DB_PASSWORD  = var.db_password
-    API_KEYS     = var.api_key
-    SENTRY_DSN   = var.api_sentry_dsn
-    PRIMARY_HOST = var.domain_name
-    ENV          = "production"
+    RELEASE                   = var.api_release_version
+    DB_HOST                   = module.db.host
+    DB_NAME                   = module.db.db_name
+    DB_USERNAME               = var.db_user
+    DB_PASSWORD               = var.db_password
+    API_KEYS                  = var.api_key
+    SENTRY_DSN                = var.api_sentry_dsn
+    SENTRY_TRACES_SAMPLE_RATE = var.api_sentry_traces_sample_rate
+    PRIMARY_HOST              = var.domain_name
+    ENV                       = "production"
   }
 
   depends_on = [aws_alb_listener.front_end, aws_iam_role_policy_attachment.ecs_task_execution_role]

--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -109,7 +109,7 @@ module "api_task" {
     DB_PASSWORD               = var.db_password
     API_KEYS                  = var.api_key
     SENTRY_DSN                = var.api_sentry_dsn
-    SENTRY_TRACES_SAMPLE_RATE = var.api_sentry_traces_sample_rate
+    SENTRY_TRACES_SAMPLE_RATE = format("%.2f", var.api_sentry_traces_sample_rate)
     PRIMARY_HOST              = var.domain_name
     ENV                       = "production"
   }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -111,7 +111,7 @@ variable "api_sentry_traces_sample_rate" {
 
   validation {
     condition     = var.api_sentry_traces_sample_rate >= 0.0 && var.api_sentry_traces_sample_rate <= 1.0
-    error_message = "api_sentry_traces_sample_rate must be between 0 and 1."
+    error_message = "The api_sentry_traces_sample_rate variable must be between 0 and 1."
   }
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -106,7 +106,13 @@ variable "api_sentry_dsn" {
 
 variable "api_sentry_traces_sample_rate" {
   description = "The sample rate for Sentry performance monitoring"
+  type        = number
   default     = 0.2
+
+  validation {
+    condition     = var.api_sentry_traces_sample_rate >= 0.0 && var.api_sentry_traces_sample_rate <= 1.0
+    error_message = "api_sentry_traces_sample_rate must be between 0 and 1."
+  }
 }
 
 variable "loader_sentry_dsn" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -104,6 +104,11 @@ variable "api_sentry_dsn" {
   sensitive   = true
 }
 
+variable "api_sentry_traces_sample_rate" {
+  description = "The sample rate for Sentry performance monitoring"
+  default     = 0.2
+}
+
 variable "loader_sentry_dsn" {
   description = "The Sentry.io DSN to use for the loaders"
   default     = ""


### PR DESCRIPTION
We've had Sentry's tracing tools in our dependencies for a while, but never gotten around to setting them up properly. This sets things up for the server (it doesn't address the loader since there's no built-in stuff and there needs to be a lot of work putting spans in all the appropriate places). There are probably a lot of places where we could put in spans for more detail, but this is a start.