### PR TITLE
Manually correct another Albertsons address

### DIFF
--- a/loader/src/sources/albertsons/corrections.js
+++ b/loader/src/sources/albertsons/corrections.js
@@ -223,6 +223,9 @@ module.exports.corrections = {
     lat: "41.6121506",
     long: "-87.718918",
   },
+  1660088122107: {
+    address: "Safeway 1094 - 1891 Pioneer pkwy, Springfield, OR, 97477",
+  },
 
   // These two are the adult and pediatric versions of a single location, but
   // one is labeled in the raw data as "Albertsons Pharmacy 4706" and the


### PR DESCRIPTION
This locations was coming in with the address field `1094  - 1891 Pioneer pkwy, Springfield, OR, 97477`, which leaves the `1094` at the start pretty ambiguous. It turns out to be the store number for the Safeway in Springfield.

Fixes https://sentry.io/organizations/usdr/issues/3490953352.