### PR TITLE
Support "Comirnaty" as a vaccine name

### DIFF
--- a/loader/src/utils.js
+++ b/loader/src/utils.js
@@ -525,7 +525,7 @@ module.exports = {
       }
     } else if (/nova\s*vax/.test(text)) {
       return VaccineProduct.novavax;
-    } else if (text.includes("pfizer")) {
+    } else if (text.includes("comirnaty") || text.includes("pfizer")) {
       if (/ages?\s+12( and up|\s*\+)/i.test(text)) {
         return VaccineProduct.pfizer;
       } else if (/ages?\s+5|\b5\s?(-|through)\s?11\b/i.test(text)) {

--- a/loader/test/utils.test.js
+++ b/loader/test/utils.test.js
@@ -247,6 +247,7 @@ describe("matchVaccineProduct", () => {
     [v.pfizer, "Pfizer-BioNTech"],
     [v.pfizer, "Pfizer-BioNTech COVID-19 Vaccine (Ages 12+)"],
     [v.pfizer, "Pfizer-BioNTech COVID-19 Vaccine/Booster (Ages 12+)"],
+    [v.pfizer, "Comirnaty COVID-19 Vaccine/Booster (Ages 12+)"],
 
     [v.pfizerAge5_11, "Pediatric-Pfizer (5-11)"],
     [v.pfizerAge5_11, "Pfizer COVID-19 Vaccine (Ages 5-11)"],


### PR DESCRIPTION
Listings in Alaska's PrepMod instance are starting to show up as "Comirnaty" instead of "Pfizer" or "Pfizer (Comirnaty)", so we need to make sure it works for fuzzy matching of names. Fixes https://sentry.io/organizations/usdr/issues/3382842420