### PR TITLE
Reduce default Sentry sample rate

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -257,7 +257,7 @@ envVarGroups:
       - key: SENTRY_DSN
         sync: false
       - key: SENTRY_TRACES_SAMPLE_RATE
-        value: "0.2"
+        value: "0.01"
       - key: SENTRY_ENVIRONMENT
         # FIXME: should be 'production' if/when we turn off AWS
         value: render
@@ -275,7 +275,7 @@ envVarGroups:
       - key: SENTRY_DSN
         sync: false
       - key: SENTRY_TRACES_SAMPLE_RATE
-        value: "0.2"
+        value: "0.01"
       - key: SENTRY_ENVIRONMENT
         # FIXME: should be 'production' if/when we turn off AWS
         value: render

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -107,7 +107,7 @@ variable "api_sentry_dsn" {
 variable "api_sentry_traces_sample_rate" {
   description = "The sample rate for Sentry performance monitoring"
   type        = number
-  default     = 0.2
+  default     = 0.01
 
   validation {
     condition     = var.api_sentry_traces_sample_rate >= 0.0 && var.api_sentry_traces_sample_rate <= 1.0


### PR DESCRIPTION
We hit the transaction limit in Sentry less than a week after I turned on performance monitoring (#794). This drops us down to a much more minimal sample rate (we can adjust back up later as appropriate or if/when we turn off either the ECS or Render deployments.