### PR TITLE
Ignore Monkeypox vaccines in Alaska

### DIFF
--- a/loader/src/sources/prepmod/index.js
+++ b/loader/src/sources/prepmod/index.js
@@ -177,6 +177,7 @@ function formatLocationBookingUrl(host, location) {
 // - Adenovirus vaccines (This one has a narrower definition to make sure we
 //   are only matching vaccines against adenovirus, not ones that might be using
 //   modified adenovirus as a vaccine against COVID or other things.)
+// - Monkeypox vaccine (Jynneos)
 const raw = String.raw;
 const nonCovidProductName = new RegExp(
   [
@@ -185,6 +186,8 @@ const nonCovidProductName = new RegExp(
     raw`zoster`,
     raw`^\s*adenovirus\s*$`,
     raw`^child and adolescent immunization`,
+    raw`monkeypox`,
+    raw`jynneos`,
   ].join("|"),
   "i"
 );

--- a/loader/test/prepmod.test.js
+++ b/loader/test/prepmod.test.js
@@ -768,6 +768,32 @@ describe("PrepMod API", () => {
     expect(result).toBeNull();
   });
 
+  it("does not include monkeypox vaccines", async () => {
+    const testLocation = createSmartLocation({
+      schedules: [
+        {
+          extension: [
+            {
+              url: EXTENSIONS.PRODUCT,
+              valueCoding: {
+                system: "http://hl7.org/fhir/sid/cvx",
+                code: null,
+                display: "Monkeypox Vaccine (JYNNEOS™) (Ages 18+)",
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = formatLocation(
+      "https://myhealth.alaska.gov",
+      new Date(),
+      testLocation
+    );
+    expect(result).toBeNull();
+  });
+
   it("hides locations not in the API response when --hide-missing-locations is set", async () => {
     const testLocation = createSmartLocation({ id: "abc123" });
     // A UNIVAF-formatted location that matches the above SMART SL data.


### PR DESCRIPTION
Alaska's PrepMod instance is now surfacing Jynneos (Monkeypox vaccine). This ignores it like we do other non-COVID vaccines.

Fixes https://sentry.io/organizations/usdr/issues/3382842420.