### PR TITLE
Make DB pool sizes adjustable by connection type

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -261,6 +261,8 @@ envVarGroups:
       - key: SENTRY_ENVIRONMENT
         # FIXME: should be 'production' if/when we turn off AWS
         value: render
+      - key: DB_POOL_SIZE_AVAILABILIITY
+        value: "5"
 
   - name: "Loader Environment"
     envVars:

--- a/server/.env.example
+++ b/server/.env.example
@@ -5,6 +5,10 @@
 # export DB_PASSWORD='password'
 export DB_NAME='univaf'
 
+# Customize the DB connection pool for each type of DB connection (optional)
+# export DB_POOL_SIZE_DATA=10
+# export DB_POOL_SIZE_AVAILABILIITY=5
+
 # Comma-separated list of API keys to use for authorization
 # export API_KEYS='x,y'
 

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -62,8 +62,29 @@ export function getHostInstance(): string {
   }
 }
 
-export function loadDbConfig(): Knex.Config {
+function getPoolSize(connectionName?: string): number {
+  if (!connectionName) return 0;
+
+  const sizeName = `DB_POOL_SIZE_${connectionName.toUpperCase()}`;
+  const rawSize = process.env[sizeName];
+  if (!rawSize) return 0;
+
+  const size = parseInt(rawSize, 10);
+  if (isNaN(size) || size < 1) {
+    throw new TypeError(`${sizeName} must be > 0 (not "${rawSize}")`);
+  }
+  return size;
+}
+
+export function loadDbConfig(connectionName?: string): Knex.Config {
   const knexfile = require("../knexfile");
   const nodeEnv = process.env.NODE_ENV || "development";
-  return knexfile[nodeEnv];
+  const poolSize = getPoolSize(connectionName);
+  return {
+    ...knexfile[nodeEnv],
+    pool: {
+      ...knexfile[nodeEnv].pool,
+      max: poolSize || knexfile[nodeEnv].pool.max,
+    },
+  };
 }

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -70,8 +70,8 @@ function getPoolSize(connectionName?: string): number {
   if (!rawSize) return 0;
 
   const size = parseInt(rawSize, 10);
-  if (isNaN(size) || size < 1) {
-    throw new TypeError(`${sizeName} must be > 0 (not "${rawSize}")`);
+  if (isNaN(size) || size < 0) {
+    throw new TypeError(`${sizeName} must be >= 0 (not "${rawSize}")`);
   }
   return size;
 }

--- a/server/src/db-client.ts
+++ b/server/src/db-client.ts
@@ -6,7 +6,7 @@ import { getHostInstance, loadDbConfig } from "./config";
 import { dogstatsd } from "./datadog";
 
 export function createDbClient(label: string): KnexType<any, unknown[]> {
-  const client = Knex(loadDbConfig());
+  const client = Knex(loadDbConfig(label));
 
   // Add debug-related logging.
   const pool = (client.client as KnexType.Client).pool;


### PR DESCRIPTION
We need to manage our database connections on Render more carefully (the limits are *much* lower), and this gives us the ability to configure the connection pool size for regular DB connections vs availability log connections separately. It also configures the availability log connections to have a smaller pool size (5, rather than 10) since there is usually much lower contention for them.

Fixes https://sentry.io/organizations/usdr/issues/3155794613 and is an alternative to #778, based on @astonm’s advice.