### PR TITLE
Check for and handle errors in HyVee responses

### DIFF
--- a/loader/src/exceptions.js
+++ b/loader/src/exceptions.js
@@ -28,6 +28,9 @@ class HttpApiError extends Error {
   }
 }
 
+/**
+ * Represents errors received from a GraphQL query result.
+ */
 class GraphQlError extends HttpApiError {
   parse(response) {
     if (typeof response.body === "object") {
@@ -39,10 +42,22 @@ class GraphQlError extends HttpApiError {
   }
 }
 
+/**
+ * If the HTTP response represents a GraphQL error, throws an instance of
+ * `GraphQlError` with relevant information.
+ * @param {http.IncomingMessage} response
+ */
+function assertValidGraphQl(response) {
+  if (response.statusCode >= 400 || response.body?.errors) {
+    throw new GraphQlError(response);
+  }
+}
+
 class ParseError extends Error {}
 
 module.exports = {
   GraphQlError,
   HttpApiError,
   ParseError,
+  assertValidGraphQl,
 };

--- a/loader/src/exceptions.js
+++ b/loader/src/exceptions.js
@@ -28,9 +28,21 @@ class HttpApiError extends Error {
   }
 }
 
+class GraphQlError extends HttpApiError {
+  parse(response) {
+    if (typeof response.body === "object") {
+      this.details = response.body;
+    } else {
+      this.details = JSON.parse(response.body);
+    }
+    this.message = this.details.errors.map((item) => item.message).join(", ");
+  }
+}
+
 class ParseError extends Error {}
 
 module.exports = {
+  GraphQlError,
   HttpApiError,
   ParseError,
 };

--- a/loader/src/sources/hyvee/index.js
+++ b/loader/src/sources/hyvee/index.js
@@ -14,9 +14,11 @@
  * not worthwhile at the moment.
  */
 
+const assert = require("node:assert/strict");
 const Sentry = require("@sentry/node");
 const { httpClient, createWarningLogger } = require("../../utils");
 const { LocationType, Available, VaccineProduct } = require("../../model");
+const { GraphQlError } = require("../../exceptions");
 
 const API_URL = "https://www.hy-vee.com/my-pharmacy/api/graphql";
 const BOOKING_URL = "https://www.hy-vee.com/my-pharmacy/covid-vaccine-consent";
@@ -99,7 +101,16 @@ async function fetchRawData() {
     },
   });
 
-  return response.body.data.searchPharmaciesNearPoint;
+  if (response.statusCode >= 400 || response.body.errors) {
+    throw new GraphQlError(response);
+  }
+
+  const result = response.body.data.searchPharmaciesNearPoint;
+  assert.ok(
+    Array.isArray(result),
+    `Response did not match expected format: ${JSON.stringify(response.body)}`
+  );
+  return result;
 }
 
 function formatLocation(data, checkedAt) {

--- a/loader/src/sources/hyvee/index.js
+++ b/loader/src/sources/hyvee/index.js
@@ -18,7 +18,7 @@ const assert = require("node:assert/strict");
 const Sentry = require("@sentry/node");
 const { httpClient, createWarningLogger } = require("../../utils");
 const { LocationType, Available, VaccineProduct } = require("../../model");
-const { GraphQlError } = require("../../exceptions");
+const { assertValidGraphQl } = require("../../exceptions");
 
 const API_URL = "https://www.hy-vee.com/my-pharmacy/api/graphql";
 const BOOKING_URL = "https://www.hy-vee.com/my-pharmacy/covid-vaccine-consent";
@@ -101,11 +101,9 @@ async function fetchRawData() {
     },
   });
 
-  if (response.statusCode >= 400 || response.body.errors) {
-    throw new GraphQlError(response);
-  }
+  assertValidGraphQl(response);
 
-  const result = response.body.data.searchPharmaciesNearPoint;
+  const result = response.body?.data?.searchPharmaciesNearPoint;
   assert.ok(
     Array.isArray(result),
     `Response did not match expected format: ${JSON.stringify(response.body)}`

--- a/loader/src/sources/wa-doh.js
+++ b/loader/src/sources/wa-doh.js
@@ -7,7 +7,7 @@ const {
   matchVaccineProduct,
   createWarningLogger,
 } = require("../utils");
-const { HttpApiError } = require("../exceptions");
+const { GraphQlError } = require("../exceptions");
 const allStates = require("../states.json");
 
 const warn = createWarningLogger("waDoh");
@@ -79,17 +79,6 @@ const INVALID_LOCATIONS = [
   "prep-mod-3696ec0d-3869-4ff4-88ce-1030db1639ef",
 ];
 
-class WaDohApiError extends HttpApiError {
-  parse(response) {
-    if (typeof response.body === "object") {
-      this.details = response.body;
-    } else {
-      this.details = JSON.parse(response.body);
-    }
-    this.message = this.details.errors.map((item) => item.message).join(", ");
-  }
-}
-
 /**
  *
  * @param {string} state 2-letter state abbreviation or state name to query
@@ -116,7 +105,7 @@ async function* queryState(state) {
       },
     });
     if (response.statusCode >= 400 || response.body.errors) {
-      throw new WaDohApiError(response);
+      throw new GraphQlError(response);
     }
 
     const data = response.body.data;
@@ -343,5 +332,4 @@ module.exports = {
   API_URL,
   checkAvailability,
   formatLocation,
-  WaDohApiError,
 };

--- a/loader/src/sources/wa-doh.js
+++ b/loader/src/sources/wa-doh.js
@@ -1,13 +1,14 @@
 // Washington State DoH hosts data for multiple states for some providers where
 // they have API access. (In practice, this is pretty much only Costco.)
 
+const assert = require("node:assert/strict");
 const { Available, LocationType } = require("../model");
 const {
   httpClient,
   matchVaccineProduct,
   createWarningLogger,
 } = require("../utils");
-const { GraphQlError } = require("../exceptions");
+const { assertValidGraphQl } = require("../exceptions");
 const allStates = require("../states.json");
 
 const warn = createWarningLogger("waDoh");
@@ -104,14 +105,16 @@ async function* queryState(state) {
         },
       },
     });
-    if (response.statusCode >= 400 || response.body.errors) {
-      throw new GraphQlError(response);
-    }
+    assertValidGraphQl(response);
 
-    const data = response.body.data;
-    yield data.searchLocations.locations;
+    const data = response.body?.data?.searchLocations;
+    assert.ok(
+      Array.isArray(data?.locations) && data?.paging?.total,
+      `Response did not match expected format: ${JSON.stringify(response.body)}`
+    );
+    yield data.locations;
 
-    if (data.searchLocations.paging.total <= pageNum * pageSize) break;
+    if (data.paging.total <= pageNum * pageSize) break;
 
     pageNum++;
   }

--- a/loader/test/wa-doh.test.js
+++ b/loader/test/wa-doh.test.js
@@ -1,9 +1,9 @@
 const nock = require("nock");
+const { GraphQlError } = require("../src/exceptions");
 const { VaccineProduct } = require("../src/model");
 const {
   API_URL,
   checkAvailability,
-  WaDohApiError,
   formatLocation,
 } = require("../src/sources/wa-doh");
 const { expectDatetimeString, splitHostAndPath } = require("./support");
@@ -90,7 +90,7 @@ describe("Washington DoH API", () => {
     expect(result).toContainItemsMatchingSchema(locationSchema);
   });
 
-  it("should throw WaDohApiError with detailed error info", async () => {
+  it("should throw GraphQlError with detailed error info", async () => {
     nock(API_URL_BASE)
       .post(API_URL_PATH)
       .reply(500, {
@@ -109,7 +109,7 @@ describe("Washington DoH API", () => {
       () => null,
       (error) => error
     );
-    expect(error).toBeInstanceOf(WaDohApiError);
+    expect(error).toBeInstanceOf(GraphQlError);
     expect(error.message).toContain("Expected type Int!");
   });
 


### PR DESCRIPTION
It turns out we weren't checking for and surfacing error messages from HyVee's GraphQL responses, which led to this confusing error early this morning: https://sentry.io/organizations/usdr/issues/3505575050. We didn't capture much detail because we didn't even realize the response was an error. Now we surface a better error at a more appropriate point.

This is a standard format for errors in GraphQL, so I've just genericized the handling we already had in the Washington Dept. of Health source.