### PR TITLE
Ignore Tdap vaccines in Prepmod

### DIFF
--- a/loader/src/sources/prepmod/index.js
+++ b/loader/src/sources/prepmod/index.js
@@ -188,6 +188,7 @@ const nonCovidProductName = new RegExp(
     raw`^child and adolescent immunization`,
     raw`monkeypox`,
     raw`jynneos`,
+    raw`\btdap\b`,
   ].join("|"),
   "i"
 );


### PR DESCRIPTION
Alaska is now surfacing Tdap vaccinations in Prepmod, which we should not be including. Fixes https://sentry.io/organizations/usdr/issues/3382842420.