### PR TITLE
Clean up CLI parsing boilerplate, allow default `--states`

### DIFF
--- a/loader/src/cli.js
+++ b/loader/src/cli.js
@@ -151,14 +151,12 @@ function main() {
               Comma-separated list of states to query for multi-state sources
               (e.g. vaccinespotter)
             `,
-          })
-          .option("vaccinespotter-states", {
-            type: "string",
-            describe: "Overrides the `--states` option for vaccinespotter",
-          })
-          .option("rite-aid-states", {
-            type: "string",
-            describe: "Overrides the `--states` option for riteAidApi",
+            coerce(value) {
+              return value
+                .split(",")
+                .map((state) => state.trim().toUpperCase())
+                .filter(Boolean);
+            },
           })
           .option("hide-missing-locations", {
             type: "boolean",
@@ -178,6 +176,11 @@ function main() {
               Only make this many HTTP requests per second. (Only applies to
               the Rite Aid sources for now.)
             `,
+            coerce(value) {
+              if (isNaN(value) || value < 0) {
+                throw new Error(`--rate-limit must be a positive number.`);
+              }
+            },
           }),
       handler: run,
     })

--- a/loader/src/cli.js
+++ b/loader/src/cli.js
@@ -150,7 +150,8 @@ function main() {
             type: "string",
             describe: oneLine`
               Comma-separated list of states to query for multi-state sources
-              (e.g. cvsSmart)
+              (e.g. cvsSmart). If not specified all relevant states for the
+              requested sources will be checked.
             `,
             coerce(value) {
               const invalid = [];

--- a/loader/src/sources/albertsons/index.js
+++ b/loader/src/sources/albertsons/index.js
@@ -27,6 +27,7 @@ const {
   parseUsAddress,
   getUniqueExternalIds,
   unpadNumber,
+  DEFAULT_STATES,
 } = require("../../utils");
 const {
   Available,
@@ -733,13 +734,8 @@ function formatLocation(data, validAt, checkedAt) {
   };
 }
 
-async function checkAvailability(handler, options) {
-  if (!options.states?.length) {
-    console.warn("No states specified for Albertsons");
-    return [];
-  }
-
-  const stores = await getData(options.states);
+async function checkAvailability(handler, { states = DEFAULT_STATES }) {
+  const stores = await getData(states);
   stores.forEach((store) => handler(store, { update_location: true }));
   if (config.debug) {
     console.error("Matches to known locations:", knownLocationMatches);

--- a/loader/src/sources/albertsons/index.js
+++ b/loader/src/sources/albertsons/index.js
@@ -734,17 +734,12 @@ function formatLocation(data, validAt, checkedAt) {
 }
 
 async function checkAvailability(handler, options) {
-  let states = [];
-  if (options.states) {
-    states = options.states.split(",").map((state) => state.trim());
-  }
-
-  if (!states.length) {
+  if (!options.states?.length) {
     console.warn("No states specified for Albertsons");
     return [];
   }
 
-  const stores = await getData(states);
+  const stores = await getData(options.states);
   stores.forEach((store) => handler(store, { update_location: true }));
   if (config.debug) {
     console.error("Matches to known locations:", knownLocationMatches);

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -35,6 +35,7 @@ const {
   unpadNumber,
   cleanUrl,
   createWarningLogger,
+  DEFAULT_STATES,
 } = require("../../utils");
 
 const API_HOST = "https://data.cdc.gov";
@@ -545,15 +546,10 @@ function formatProductTypes(products) {
   return result.length ? result : undefined;
 }
 
-async function checkAvailability(handler, options) {
-  if (!options.states?.length) {
-    warn("No states specified for cdcApi");
-    return [];
-  }
-
+async function checkAvailability(handler, { states = DEFAULT_STATES }) {
   const checkedAt = new Date().toISOString();
   let results = [];
-  for (const state of options.states) {
+  for (const state of states) {
     const entriesByStoreId = {};
     for await (const entry of queryState(state)) {
       if (!(entry.provider_location_guid in entriesByStoreId)) {

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -546,16 +546,14 @@ function formatProductTypes(products) {
 }
 
 async function checkAvailability(handler, options) {
-  const states = options.states?.split(",").map((state) => state.trim());
-
-  if (!states || !states.length) {
+  if (!options.states?.length) {
     warn("No states specified for cdcApi");
     return [];
   }
 
   const checkedAt = new Date().toISOString();
   let results = [];
-  for (const state of states) {
+  for (const state of options.states) {
     const entriesByStoreId = {};
     for await (const entry of queryState(state)) {
       if (!(entry.provider_location_guid in entriesByStoreId)) {

--- a/loader/src/sources/cvs/smart.js
+++ b/loader/src/sources/cvs/smart.js
@@ -11,7 +11,7 @@ const {
   formatExternalIds,
   valuesAsObject,
 } = require("../../smart-scheduling-links");
-const { createWarningLogger } = require("../../utils");
+const { createWarningLogger, DEFAULT_STATES } = require("../../utils");
 const { CVS_BOOKING_URL } = require("./shared");
 
 const CVS_SMART_API_URL =
@@ -141,13 +141,8 @@ function formatCapacity(slots) {
     .map((key) => byDate[key]);
 }
 
-async function checkAvailability(handler, options) {
-  if (!options.states?.length) {
-    console.warn("No states specified for CVS");
-    return [];
-  }
-
-  const stores = await getData(options.states);
+async function checkAvailability(handler, { states = DEFAULT_STATES }) {
+  const stores = await getData(states);
   stores.forEach((store) => handler(store));
   return stores;
 }

--- a/loader/src/sources/cvs/smart.js
+++ b/loader/src/sources/cvs/smart.js
@@ -142,19 +142,12 @@ function formatCapacity(slots) {
 }
 
 async function checkAvailability(handler, options) {
-  let states = [];
-  if (options.cvsStates) {
-    states = options.cvsStates.split(",").map((state) => state.trim());
-  } else if (options.states) {
-    states = options.states.split(",").map((state) => state.trim());
-  }
-
-  if (!states.length) {
+  if (!options.states?.length) {
     console.warn("No states specified for CVS");
     return [];
   }
 
-  const stores = await getData(states);
+  const stores = await getData(options.states);
   stores.forEach((store) => handler(store));
   return stores;
 }

--- a/loader/src/sources/heb/index.js
+++ b/loader/src/sources/heb/index.js
@@ -12,7 +12,11 @@
 
 const Sentry = require("@sentry/node");
 const { DateTime } = require("luxon");
-const { httpClient, createWarningLogger } = require("../../utils");
+const {
+  httpClient,
+  createWarningLogger,
+  DEFAULT_STATES,
+} = require("../../utils");
 const { LocationType, VaccineProduct, Available } = require("../../model");
 const { assertSchema } = require("../../schema-validation");
 
@@ -204,13 +208,8 @@ function formatUrl(url) {
   return url ? url : "https://vaccine.heb.com/scheduler";
 }
 
-async function checkAvailability(handler, options) {
-  if (!options.states?.length) {
-    console.warn("No states specified for H-E-B");
-    return [];
-  }
-
-  const stores = await getData(options.states);
+async function checkAvailability(handler, { states = DEFAULT_STATES }) {
+  const stores = await getData(states);
   stores.forEach((store) => handler(store));
   return stores;
 }

--- a/loader/src/sources/heb/index.js
+++ b/loader/src/sources/heb/index.js
@@ -205,17 +205,12 @@ function formatUrl(url) {
 }
 
 async function checkAvailability(handler, options) {
-  let states = [];
-  if (options.states) {
-    states = options.states.split(",").map((state) => state.trim());
-  }
-
-  if (!states.length) {
+  if (!options.states?.length) {
     console.warn("No states specified for H-E-B");
     return [];
   }
 
-  const stores = await getData(states);
+  const stores = await getData(options.states);
   stores.forEach((store) => handler(store));
   return stores;
 }

--- a/loader/src/sources/hyvee/index.js
+++ b/loader/src/sources/hyvee/index.js
@@ -203,17 +203,12 @@ async function getData(states) {
 }
 
 async function checkAvailability(handler, options) {
-  let states = [];
-  if (options.states) {
-    states = options.states.split(",").map((state) => state.trim());
-  }
-
-  if (!states.length) {
+  if (!options.states?.length) {
     console.warn("No states specified for HyVee");
     return [];
   }
 
-  const locations = await getData(states);
+  const locations = await getData(options.states);
   locations.forEach((location) => handler(location));
   return locations;
 }

--- a/loader/src/sources/hyvee/index.js
+++ b/loader/src/sources/hyvee/index.js
@@ -16,7 +16,11 @@
 
 const assert = require("node:assert/strict");
 const Sentry = require("@sentry/node");
-const { httpClient, createWarningLogger } = require("../../utils");
+const {
+  httpClient,
+  createWarningLogger,
+  DEFAULT_STATES,
+} = require("../../utils");
 const { LocationType, Available, VaccineProduct } = require("../../model");
 const { assertValidGraphQl } = require("../../exceptions");
 
@@ -202,13 +206,8 @@ async function getData(states) {
     .filter((location) => states.includes(location.state));
 }
 
-async function checkAvailability(handler, options) {
-  if (!options.states?.length) {
-    console.warn("No states specified for HyVee");
-    return [];
-  }
-
-  const locations = await getData(options.states);
+async function checkAvailability(handler, { states = DEFAULT_STATES }) {
+  const locations = await getData(states);
   locations.forEach((location) => handler(location));
   return locations;
 }

--- a/loader/src/sources/kroger.js
+++ b/loader/src/sources/kroger.js
@@ -26,6 +26,7 @@ const {
   unpadNumber,
   getUniqueExternalIds,
   createWarningLogger,
+  DEFAULT_STATES,
 } = require("../utils");
 const {
   EXTENSIONS,
@@ -305,13 +306,8 @@ function formatCapacity(slots) {
     .map((key) => byDate[key]);
 }
 
-async function checkAvailability(handler, options) {
-  if (!options.states?.length) {
-    console.warn("No states specified for Kroger");
-    return [];
-  }
-
-  const stores = await getData(options.states);
+async function checkAvailability(handler, { states = DEFAULT_STATES }) {
+  const stores = await getData(states);
   stores.forEach((store) => handler(store));
   return stores;
 }

--- a/loader/src/sources/kroger.js
+++ b/loader/src/sources/kroger.js
@@ -306,19 +306,12 @@ function formatCapacity(slots) {
 }
 
 async function checkAvailability(handler, options) {
-  let states = [];
-  if (options.krogerStates) {
-    states = options.krogerStates.split(",").map((state) => state.trim());
-  } else if (options.states) {
-    states = options.states.split(",").map((state) => state.trim());
-  }
-
-  if (!states.length) {
+  if (!options.states?.length) {
     console.warn("No states specified for Kroger");
     return [];
   }
 
-  const stores = await getData(states);
+  const stores = await getData(options.states);
   stores.forEach((store) => handler(store));
   return stores;
 }

--- a/loader/src/sources/prepmod/index.js
+++ b/loader/src/sources/prepmod/index.js
@@ -19,7 +19,11 @@ const {
 const { Available, LocationType } = require("../../model");
 const { prepmodHostsByState } = require("./hosts");
 const { HTTPError } = require("got");
-const { matchVaccineProduct, createWarningLogger } = require("../../utils");
+const {
+  matchVaccineProduct,
+  createWarningLogger,
+  DEFAULT_STATES,
+} = require("../../utils");
 
 const API_PATH = "/api/smart-scheduling-links/$bulk-publish";
 
@@ -337,19 +341,17 @@ function formatSlots(smartSlots) {
   return { available, slots };
 }
 
-async function checkAvailability(handler, options) {
-  if (!options.states?.length) {
-    console.warn("No states specified for PrepMod");
-    return [];
-  }
-
+async function checkAvailability(
+  handler,
+  { states = DEFAULT_STATES, hideMissingLocations = false }
+) {
   let results = [];
   for (const [state, namedHosts] of Object.entries(prepmodHostsByState)) {
-    if (options.states.includes(state)) {
+    if (states.includes(state)) {
       // Load known locations in the state so we can mark any that are missing
       // from PrepMod as private. (It's not unusual for locations to be public
       // and later become private, at which point we should hide them, too.)
-      const knownLocations = options.hideMissingLocations
+      const knownLocations = hideMissingLocations
         ? await getKnownLocations(state)
         : Object.create(null);
 

--- a/loader/src/sources/prepmod/index.js
+++ b/loader/src/sources/prepmod/index.js
@@ -338,21 +338,14 @@ function formatSlots(smartSlots) {
 }
 
 async function checkAvailability(handler, options) {
-  let states = [];
-  if (options.prepmodStates) {
-    states = options.prepmodStates.split(",").map((state) => state.trim());
-  } else if (options.states) {
-    states = options.states.split(",").map((state) => state.trim());
-  }
-
-  if (!states.length) {
+  if (!options.states?.length) {
     console.warn("No states specified for PrepMod");
     return [];
   }
 
   let results = [];
   for (const [state, namedHosts] of Object.entries(prepmodHostsByState)) {
-    if (states.includes(state)) {
+    if (options.states.includes(state)) {
       // Load known locations in the state so we can mark any that are missing
       // from PrepMod as private. (It's not unusual for locations to be public
       // and later become private, at which point we should hide them, too.)

--- a/loader/src/sources/riteaid/api.js
+++ b/loader/src/sources/riteaid/api.js
@@ -283,22 +283,12 @@ function formatAddress(location) {
 }
 
 async function checkAvailability(handler, options) {
-  let states = [];
-  if (options.riteAidStates) {
-    states = options.riteAidStates.split(",").map((state) => state.trim());
-  } else if (options.states) {
-    states = options.states.split(",").map((state) => state.trim());
-  }
   // Rite Aid only has stores in a few states, so filter down to those.
-  states = states.filter((state) => riteAidStates.has(state));
-
-  if (!states.length) {
+  const states = options.states?.filter((state) => riteAidStates.has(state));
+  if (!states?.length) {
     const statesText = Array.from(riteAidStates).join(", ");
     warn(`No states set for riteAidApi (supported: ${statesText})`);
-  }
-
-  if (options.rateLimit != null && isNaN(options.rateLimit)) {
-    throw new Error("Invalid --rate-limit set.");
+    return [];
   }
 
   const rateLimit = new RateLimit(options.rateLimit || 1);

--- a/loader/src/sources/riteaid/common.js
+++ b/loader/src/sources/riteaid/common.js
@@ -2,7 +2,7 @@ const assert = require("assert").strict;
 const { HttpApiError } = require("../../exceptions");
 
 // States in which Rite Aid has stores.
-const RITE_AID_STATES = new Set([
+const RITE_AID_STATES = [
   "CA",
   "CO",
   "CT",
@@ -21,7 +21,7 @@ const RITE_AID_STATES = new Set([
   "VA",
   "VT",
   "WA",
-]);
+];
 
 class RiteAidApiError extends HttpApiError {
   parse(response) {

--- a/loader/src/sources/riteaid/common.js
+++ b/loader/src/sources/riteaid/common.js
@@ -1,6 +1,28 @@
 const assert = require("assert").strict;
 const { HttpApiError } = require("../../exceptions");
 
+// States in which Rite Aid has stores.
+const RITE_AID_STATES = new Set([
+  "CA",
+  "CO",
+  "CT",
+  "DE",
+  "ID",
+  "MA",
+  "MD",
+  "MI",
+  "NH",
+  "NJ",
+  "NV",
+  "NY",
+  "OH",
+  "OR",
+  "PA",
+  "VA",
+  "VT",
+  "WA",
+]);
+
 class RiteAidApiError extends HttpApiError {
   parse(response) {
     assert.equal(typeof response.body, "object");
@@ -55,4 +77,9 @@ function getLocationName(externalIds) {
   return nonBrandName;
 }
 
-module.exports = { RiteAidApiError, getExternalIds, getLocationName };
+module.exports = {
+  RITE_AID_STATES,
+  RiteAidApiError,
+  getExternalIds,
+  getLocationName,
+};

--- a/loader/src/sources/riteaid/scraper.js
+++ b/loader/src/sources/riteaid/scraper.js
@@ -347,25 +347,15 @@ function formatSlots(location) {
 }
 
 async function checkAvailability(handler, options) {
-  let states = [];
-  if (options.riteAidStates) {
-    states = options.riteAidStates.split(",").map((state) => state.trim());
-  } else if (options.states) {
-    states = options.states.split(",").map((state) => state.trim());
-  }
-
-  if (!states.length) {
+  if (!options.states?.length) {
     warn(`No states set for riteAidApi`);
-  }
-
-  if (options.rateLimit != null && isNaN(options.rateLimit)) {
-    throw new Error("Invalid --rate-limit set.");
+    return [];
   }
 
   const rateLimit = new RateLimit(options.rateLimit || 1);
 
   const results = [];
-  for (const state of states) {
+  for (const state of options.states) {
     for await (const apiLocation of queryState(state, rateLimit)) {
       let location;
       Sentry.withScope((scope) => {

--- a/loader/src/sources/riteaid/scraper.js
+++ b/loader/src/sources/riteaid/scraper.js
@@ -24,6 +24,7 @@ const {
   RiteAidApiError,
   getExternalIds,
   getLocationName,
+  RITE_AID_STATES,
 } = require("./common");
 const { zipCodesCovering100Miles } = require("./zip-codes");
 
@@ -346,17 +347,15 @@ function formatSlots(location) {
   return allSlots;
 }
 
-async function checkAvailability(handler, options) {
-  if (!options.states?.length) {
-    warn(`No states set for riteAidApi`);
-    return [];
-  }
-
-  const rateLimit = new RateLimit(options.rateLimit || 1);
+async function checkAvailability(
+  handler,
+  { states = RITE_AID_STATES, rateLimit }
+) {
+  const rateLimiter = new RateLimit(rateLimit || 1);
 
   const results = [];
-  for (const state of options.states) {
-    for await (const apiLocation of queryState(state, rateLimit)) {
+  for (const state of states) {
+    for await (const apiLocation of queryState(state, rateLimiter)) {
       let location;
       Sentry.withScope((scope) => {
         scope.setContext("location", {

--- a/loader/src/sources/vaccinespotter/index.js
+++ b/loader/src/sources/vaccinespotter/index.js
@@ -18,6 +18,7 @@ const {
   unpadNumber,
   getUniqueExternalIds,
   createWarningLogger,
+  DEFAULT_STATES,
 } = require("../../utils");
 const walgreens_store_list = require("./walgreens_base");
 
@@ -435,15 +436,11 @@ function formatStore(store) {
   return result;
 }
 
-async function checkAvailability(handler, options) {
+async function checkAvailability(handler, { states = DEFAULT_STATES }) {
   warn("WARNING: vaccinespotter is deprecated and no longer maintained.");
 
-  if (!options.states?.length) {
-    console.warn("No states specified for vaccinespotter");
-  }
-
   let results = [];
-  for (const state of options.states) {
+  for (const state of states) {
     const stores = await queryState(state);
     const formatted = stores.features
       .filter(hasUsefulData)

--- a/loader/src/sources/vaccinespotter/index.js
+++ b/loader/src/sources/vaccinespotter/index.js
@@ -438,19 +438,12 @@ function formatStore(store) {
 async function checkAvailability(handler, options) {
   warn("WARNING: vaccinespotter is deprecated and no longer maintained.");
 
-  let states = ["NJ"];
-  if (options.vaccinespotterStates) {
-    states = options.vaccinespotterStates
-      .split(",")
-      .map((state) => state.trim());
-  } else if (options.states) {
-    states = options.states.split(",").map((state) => state.trim());
+  if (!options.states?.length) {
+    console.warn("No states specified for vaccinespotter");
   }
 
-  if (!states.length) console.warn("No states specified for vaccinespotter");
-
   let results = [];
-  for (const state of states) {
+  for (const state of options.states) {
     const stores = await queryState(state);
     const formatted = stores.features
       .filter(hasUsefulData)

--- a/loader/src/sources/vts/geo.js
+++ b/loader/src/sources/vts/geo.js
@@ -150,14 +150,13 @@ async function updateGeo(handler, options) {
     Please fix https://github.com/usdigitalresponse/univaf/issues/433 first.
   `);
   /* eslint-disable no-unreachable */
-  const states = options.states?.split(",").map((state) => state.trim());
 
-  if (!states || !states.length) {
+  if (!options.states?.length) {
     warn("No states specified for vts.geo");
     return [];
   }
 
-  const statesFilter = new Set(states);
+  const statesFilter = new Set(options.states);
 
   const stores = await getStores();
   const results = stores.features

--- a/loader/src/sources/vts/geo.js
+++ b/loader/src/sources/vts/geo.js
@@ -46,11 +46,6 @@ const dataProviders = {
   },
 };
 
-function warn(message, context) {
-  console.warn(`VTS Geo: ${message}`, context);
-  Sentry.captureMessage(message, "info");
-}
-
 function error(message, context) {
   console.error(`VTS Geo: ${message}`, context);
   Sentry.captureMessage(message, "error");

--- a/loader/src/sources/vts/geo.js
+++ b/loader/src/sources/vts/geo.js
@@ -15,7 +15,12 @@
  */
 
 const Sentry = require("@sentry/node");
-const { httpClient, splitOnce, oneLine } = require("../../utils");
+const {
+  httpClient,
+  splitOnce,
+  oneLine,
+  DEFAULT_STATES,
+} = require("../../utils");
 
 const dataProviders = {
   "Rite-Aid": {
@@ -144,19 +149,14 @@ function formatStore(store) {
   return result;
 }
 
-async function updateGeo(handler, options) {
+async function updateGeo(handler, { states = DEFAULT_STATES }) {
   throw new Error(oneLine`
     The vtsGeo source is unsafe!
     Please fix https://github.com/usdigitalresponse/univaf/issues/433 first.
   `);
   /* eslint-disable no-unreachable */
 
-  if (!options.states?.length) {
-    warn("No states specified for vts.geo");
-    return [];
-  }
-
-  const statesFilter = new Set(options.states);
+  const statesFilter = new Set(states);
 
   const stores = await getStores();
   const results = stores.features

--- a/loader/src/sources/wa-doh.js
+++ b/loader/src/sources/wa-doh.js
@@ -282,15 +282,9 @@ function formatLocation(data) {
  * Get availability data from the WA Department of Health API.
  */
 async function checkAvailability(handler, options) {
-  let states = [];
-  if (options.waDohStates) {
-    states = options.waDohStates.split(",").map((state) => state.trim());
-  } else if (options.states) {
-    states = options.states.split(",").map((state) => state.trim());
-  }
   // WA doesn't support some US territories.
   const unsupported = new Set(["AA", "AP", "AE"]);
-  states = states.filter((state) => !unsupported.has(state));
+  const states = options?.states?.filter((state) => !unsupported.has(state));
 
   if (!states.length) console.error("No states specified for WA DoH");
 

--- a/loader/src/sources/wa-doh.js
+++ b/loader/src/sources/wa-doh.js
@@ -7,6 +7,7 @@ const {
   httpClient,
   matchVaccineProduct,
   createWarningLogger,
+  DEFAULT_STATES,
 } = require("../utils");
 const { assertValidGraphQl } = require("../exceptions");
 const allStates = require("../states.json");
@@ -281,12 +282,16 @@ function formatLocation(data) {
 /**
  * Get availability data from the WA Department of Health API.
  */
-async function checkAvailability(handler, options) {
+async function checkAvailability(handler, { states = DEFAULT_STATES }) {
   // WA doesn't support some US territories.
   const unsupported = new Set(["AA", "AP", "AE"]);
-  const states = options?.states?.filter((state) => !unsupported.has(state));
-
-  if (!states.length) console.error("No states specified for WA DoH");
+  states = states.filter((state) => {
+    if (unsupported.has(state)) {
+      console.warn(`"${state}" is not supported for WA DoH.`);
+      return false;
+    }
+    return true;
+  });
 
   const results = [];
   for (const state of states) {

--- a/loader/src/sources/walgreens.js
+++ b/loader/src/sources/walgreens.js
@@ -7,7 +7,12 @@
 
 const Sentry = require("@sentry/node");
 const { Available, LocationType } = require("../model");
-const { titleCase, unpadNumber, createWarningLogger } = require("../utils");
+const {
+  titleCase,
+  unpadNumber,
+  createWarningLogger,
+  DEFAULT_STATES,
+} = require("../utils");
 const {
   EXTENSIONS,
   SmartSchedulingLinksApi,
@@ -186,13 +191,8 @@ function formatCapacity(slots) {
     .map((key) => byDate[key]);
 }
 
-async function checkAvailability(handler, options) {
-  if (!options.states?.length) {
-    console.warn("No states specified for Walgreens");
-    return [];
-  }
-
-  const stores = await getData(options.states);
+async function checkAvailability(handler, { states = DEFAULT_STATES }) {
+  const stores = await getData(states);
   stores.forEach((store) => handler(store));
   return stores;
 }

--- a/loader/src/sources/walgreens.js
+++ b/loader/src/sources/walgreens.js
@@ -187,19 +187,12 @@ function formatCapacity(slots) {
 }
 
 async function checkAvailability(handler, options) {
-  let states = [];
-  if (options.walgreensStates) {
-    states = options.walgreensStates.split(",").map((state) => state.trim());
-  } else if (options.states) {
-    states = options.states.split(",").map((state) => state.trim());
-  }
-
-  if (!states.length) {
+  if (!options.states?.length) {
     console.warn("No states specified for Walgreens");
     return [];
   }
 
-  const stores = await getData(states);
+  const stores = await getData(options.states);
   stores.forEach((store) => handler(store));
   return stores;
 }

--- a/loader/src/utils.js
+++ b/loader/src/utils.js
@@ -147,6 +147,63 @@ const PHONE_NUMBER_PATTERN = new RegExp(
   r`$`
 );
 
+const DEFAULT_STATES = [
+  "AL",
+  "AK",
+  "AZ",
+  "AR",
+  "CA",
+  "CO",
+  "CT",
+  "DE",
+  "DC",
+  "FL",
+  "GA",
+  "HI",
+  "ID",
+  "IL",
+  "IN",
+  "IA",
+  "KS",
+  "KY",
+  "LA",
+  "ME",
+  "MD",
+  "MA",
+  "MI",
+  "MN",
+  "MS",
+  "MO",
+  "MT",
+  "NE",
+  "NV",
+  "NH",
+  "NJ",
+  "NM",
+  "NY",
+  "NC",
+  "ND",
+  "OH",
+  "OK",
+  "OR",
+  "PA",
+  "RI",
+  "SC",
+  "SD",
+  "TN",
+  "TX",
+  "UT",
+  "VT",
+  "VA",
+  "WA",
+  "WV",
+  "WI",
+  "WY",
+  "MH",
+  "PR",
+  "VI",
+];
+
 /**
  * Enforce rate limits on operations by awaiting the `ready()` method on
  * instances of this class.
@@ -198,6 +255,8 @@ class RateLimit {
 }
 
 module.exports = {
+  DEFAULT_STATES,
+
   USER_AGENTS,
 
   TIME_ZONE_OFFSET_STRINGS,

--- a/loader/test/albertsons.test.js
+++ b/loader/test/albertsons.test.js
@@ -41,7 +41,7 @@ describe("Albertsons", () => {
   });
 
   it.nock("should output valid data", { ignoreQuery: ["v"] }, async () => {
-    const result = await checkAvailability(() => {}, { states: "AK" });
+    const result = await checkAvailability(() => {}, { states: ["AK"] });
     expect(result).toContainItemsMatchingSchema(locationSchema);
   });
 
@@ -76,7 +76,7 @@ describe("Albertsons", () => {
         { "Last-Modified": "Thu, 28 Oct 2021 07:06:13 GMT" }
       );
 
-    const result = await checkAvailability(() => {}, { states: "AK" });
+    const result = await checkAvailability(() => {}, { states: ["AK"] });
     expect(result).toContainItemsMatchingSchema(locationSchema);
     expect(result).toEqual([
       {
@@ -188,7 +188,7 @@ describe("Albertsons", () => {
         },
       ]);
 
-    const result = await checkAvailability(() => {}, { states: "AK" });
+    const result = await checkAvailability(() => {}, { states: ["AK"] });
     expect(result[0]).toHaveProperty("name", "Safeway Pharmacy #3410");
     expect(result[0]).toHaveProperty("address_lines", ["30 College Rd"]);
     expect(result).toContainItemsMatchingSchema(locationSchema);
@@ -205,7 +205,7 @@ describe("Albertsons", () => {
         },
       ]);
 
-    const result = await checkAvailability(() => {}, { states: "MD" });
+    const result = await checkAvailability(() => {}, { states: ["MD"] });
     expect(result).toContainItemsMatchingSchema(locationSchema);
     expect(result[0]).toHaveProperty(
       "availability.available",
@@ -229,7 +229,7 @@ describe("Albertsons", () => {
         },
       ]);
 
-    const result = await checkAvailability(() => {}, { states: "AK" });
+    const result = await checkAvailability(() => {}, { states: ["AK"] });
     expect(result).toContainItemsMatchingSchema(locationSchema);
     expect(result[0].availability.products).toBe(undefined);
   });
@@ -245,7 +245,7 @@ describe("Albertsons", () => {
         },
       ]);
 
-    const result = await checkAvailability(() => {}, { states: "MD" });
+    const result = await checkAvailability(() => {}, { states: ["MD"] });
     expect(result).toContainItemsMatchingSchema(locationSchema);
     expect(result[0]).toHaveProperty("availability.products", ["pfizer"]);
   });
@@ -261,7 +261,7 @@ describe("Albertsons", () => {
         },
       ]);
 
-    const result = await checkAvailability(() => {}, { states: "AK" });
+    const result = await checkAvailability(() => {}, { states: ["AK"] });
     expect(result).toHaveLength(0);
   });
 
@@ -309,7 +309,7 @@ describe("Albertsons", () => {
         { "Last-Modified": "Thu, 28 Oct 2021 07:06:13 GMT" }
       );
 
-    const result = await checkAvailability(() => {}, { states: "VA" });
+    const result = await checkAvailability(() => {}, { states: ["VA"] });
     expect(result).toContainItemsMatchingSchema(locationSchema);
     expect(result).toEqual([
       {
@@ -418,7 +418,7 @@ describe("Albertsons", () => {
         ],
         { "Last-Modified": "Thu, 28 Oct 2021 07:06:13 GMT" }
       );
-    const result = await checkAvailability(() => {}, { states: "CA" });
+    const result = await checkAvailability(() => {}, { states: ["CA"] });
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchSchema(locationSchema);
     expect(result).toHaveProperty("0.meta", {
@@ -475,7 +475,7 @@ describe("Albertsons", () => {
         ],
         { "Last-Modified": "Thu, 28 Oct 2021 07:06:13 GMT" }
       );
-    const result = await checkAvailability(() => {}, { states: "CA" });
+    const result = await checkAvailability(() => {}, { states: ["CA"] });
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchSchema(locationSchema);
     expect(result).toHaveProperty("0.meta", {
@@ -518,7 +518,7 @@ describe("Albertsons", () => {
         { "Last-Modified": "Thu, 28 Oct 2021 07:06:13 GMT" }
       );
 
-    const result = await checkAvailability(() => {}, { states: "MD" });
+    const result = await checkAvailability(() => {}, { states: ["MD"] });
     expect(result[0]).toMatchSchema(locationSchema);
     expect(result[0]).toHaveProperty("name", "Takoma Park Recreation Center");
     expect(result[0]).toHaveProperty("location_type", "CLINIC");
@@ -544,7 +544,7 @@ describe("Albertsons", () => {
         { "Last-Modified": "Thu, 28 Oct 2021 07:06:13 GMT" }
       );
 
-    const result = await checkAvailability(() => {}, { states: "MD" });
+    const result = await checkAvailability(() => {}, { states: ["MD"] });
     expect(result).toHaveLength(0);
   });
 
@@ -553,7 +553,7 @@ describe("Albertsons", () => {
       errors: "Oh no!",
     });
 
-    const error = await checkAvailability(() => null, { states: "AK" }).then(
+    const error = await checkAvailability(() => null, { states: ["AK"] }).then(
       () => null,
       (error) => error
     );

--- a/loader/test/cdc.api.test.js
+++ b/loader/test/cdc.api.test.js
@@ -21,7 +21,7 @@ describe("CDC Open Data API", () => {
   const fixturePath = path.join(__dirname, "fixtures/cdc.api.01929.json");
 
   it.nock("should output valid data", async () => {
-    const result = await checkAvailability(() => {}, { states: "AK" });
+    const result = await checkAvailability(() => {}, { states: ["AK"] });
     expect(result).toContainItemsMatchingSchema(locationSchema);
   });
 
@@ -32,7 +32,7 @@ describe("CDC Open Data API", () => {
       "Content-Type": "application/json",
     });
 
-    const locations = await checkAvailability(() => null, { states: "NJ" });
+    const locations = await checkAvailability(() => null, { states: ["NJ"] });
     expect(locations).toHaveLength(1);
     expect(locations[0]).toHaveProperty("availability.products", ["pfizer"]);
   });
@@ -63,7 +63,7 @@ describe("CDC Open Data API", () => {
         },
       ]);
 
-    const locations = await checkAvailability(() => null, { states: "NJ" });
+    const locations = await checkAvailability(() => null, { states: ["NJ"] });
     expect(locations).toHaveProperty("0.availability.available", Available.yes);
     expect(locations).toHaveProperty("1.availability.available", Available.no);
     expect(locations).toHaveProperty(
@@ -93,7 +93,7 @@ describe("CDC Open Data API", () => {
         },
       ]);
 
-    const locations = await checkAvailability(() => null, { states: "NJ" });
+    const locations = await checkAvailability(() => null, { states: ["NJ"] });
     expect(locations).toHaveProperty(
       "0.availability.available",
       Available.unknown

--- a/loader/test/cvs.smart.test.js
+++ b/loader/test/cvs.smart.test.js
@@ -30,7 +30,7 @@ describe("CVS SMART Scheduling Links API", () => {
       .get("/immunizations/inventory/data/slot.ndjson")
       .reply(200, toNdJson(fixtures.TestSlots));
 
-    const result = await checkAvailability(() => null, { states: "VA" });
+    const result = await checkAvailability(() => null, { states: ["VA"] });
     expect(result).toEqual([
       {
         external_ids: [
@@ -92,7 +92,7 @@ describe("CVS SMART Scheduling Links API", () => {
         )
       );
 
-    const result = await checkAvailability(() => null, { states: "VA" });
+    const result = await checkAvailability(() => null, { states: ["VA"] });
     expect(result).toHaveProperty("0.availability.available", Available.no);
     expect(result).toContainItemsMatchingSchema(locationSchema);
   });
@@ -109,7 +109,7 @@ describe("CVS SMART Scheduling Links API", () => {
       .get("/immunizations/inventory/data/slot.ndjson")
       .reply(200, toNdJson(fixtures.TestSlots));
 
-    const result = await checkAvailability(() => null, { states: "NJ" });
+    const result = await checkAvailability(() => null, { states: ["NJ"] });
     expect(result).toHaveLength(0);
   });
 });

--- a/loader/test/heb.test.js
+++ b/loader/test/heb.test.js
@@ -8,7 +8,7 @@ jest.mock("../src/utils");
 
 describe("H-E-B", () => {
   it.nock("should output valid data", { ignoreQuery: ["v"] }, async () => {
-    const result = await checkAvailability(() => {}, { states: "TX" });
+    const result = await checkAvailability(() => {}, { states: ["TX"] });
     expect(result).toContainItemsMatchingSchema(locationSchema);
   });
 

--- a/loader/test/hyvee.test.js
+++ b/loader/test/hyvee.test.js
@@ -134,7 +134,7 @@ describe("HyVee", () => {
   });
 
   it.nock("should output valid data", async () => {
-    const states = stateData.map((x) => x.usps).join(",");
+    const states = stateData.map((x) => x.usps);
     const result = await checkAvailability(() => {}, { states });
     expect(result).toContainItemsMatchingSchema(locationSchema);
   });

--- a/loader/test/kroger.smart.test.js
+++ b/loader/test/kroger.smart.test.js
@@ -27,7 +27,7 @@ describe("Kroger SMART Scheduling Links API", () => {
       .get("/v1/health-wellness/schedules/vaccines/slot_AK.ndjson")
       .reply(200, toNdJson(fixtures.TestSlots));
 
-    const result = await checkAvailability(() => null, { states: "AK" });
+    const result = await checkAvailability(() => null, { states: ["AK"] });
     expect(result).toEqual([
       {
         external_ids: [
@@ -99,7 +99,7 @@ describe("Kroger SMART Scheduling Links API", () => {
         )
       );
 
-    const result = await checkAvailability(() => null, { states: "AK" });
+    const result = await checkAvailability(() => null, { states: ["AK"] });
     expect(result).toHaveProperty("0.availability.available", Available.no);
     expect(result).toContainItemsMatchingSchema(locationSchema);
   });
@@ -116,7 +116,7 @@ describe("Kroger SMART Scheduling Links API", () => {
       .get("/v1/health-wellness/schedules/vaccines/slot_NJ.ndjson")
       .reply(200, toNdJson(fixtures.TestSlots));
 
-    const result = await checkAvailability(() => null, { states: "NJ" });
+    const result = await checkAvailability(() => null, { states: ["NJ"] });
     expect(result).toHaveLength(0);
   });
 
@@ -150,7 +150,7 @@ describe("Kroger SMART Scheduling Links API", () => {
         return toNdJson(items);
       });
 
-    const result = await checkAvailability(() => null, { states: "AK" });
+    const result = await checkAvailability(() => null, { states: ["AK"] });
     expect(result).toHaveLength(0);
   });
 });

--- a/loader/test/prepmod.test.js
+++ b/loader/test/prepmod.test.js
@@ -35,7 +35,7 @@ describe("PrepMod API", () => {
   // have tests with simpler, more contrived API responses to verify values.
   // This is too complicated to set up again if the API changes.
   it.nock("should successfully format results", async () => {
-    const result = await checkAvailability(() => {}, { states: "WA" });
+    const result = await checkAvailability(() => {}, { states: ["WA"] });
     expect(result).toEqual([
       {
         address_lines: ["500 Tausick Way"],
@@ -834,7 +834,7 @@ describe("PrepMod API", () => {
       .reply(200, toNdJson(testLocation.slots));
 
     const results = await checkAvailability(() => {}, {
-      states: "AK",
+      states: ["AK"],
       hideMissingLocations: true,
     });
     expect(results).toHaveLength(2);

--- a/loader/test/riteaid.api.test.js
+++ b/loader/test/riteaid.api.test.js
@@ -56,7 +56,7 @@ describe("Rite Aid Source", () => {
 
     nock(API_URL).get("?stateCode=NJ").reply(200, responseFixture);
 
-    const locations = await checkAvailability(() => {}, { states: "NJ" });
+    const locations = await checkAvailability(() => {}, { states: ["NJ"] });
     expect(locations.length).toBe(108);
 
     expect(locations[0]).toStrictEqual({
@@ -202,7 +202,7 @@ describe("Rite Aid Source", () => {
 
   it("does not attempt to load states without Rite Aid stores", async () => {
     nock(API_URL).get("?stateCode=AK").reply(403, "uhoh");
-    const results = await checkAvailability(() => {}, { states: "AK" });
+    const results = await checkAvailability(() => {}, { states: ["AK"] });
     expect(results).toHaveLength(0);
   });
 

--- a/loader/test/riteaid.scraper.test.js
+++ b/loader/test/riteaid.scraper.test.js
@@ -44,7 +44,7 @@ describe("Rite Aid Scraper", () => {
 
   it.nock("should output valid data", async () => {
     const result = await checkAvailability(() => {}, {
-      states: "NJ",
+      states: ["NJ"],
       rateLimit: 0,
     });
     expect(result).toContainItemsMatchingSchema(locationSchema);
@@ -145,7 +145,7 @@ describe("Rite Aid Scraper", () => {
         },
       });
 
-    const result = await checkAvailability(() => {}, { states: "NJ" });
+    const result = await checkAvailability(() => {}, { states: ["NJ"] });
     expect(result).toContainItemsMatchingSchema(locationSchema);
     expect(result).toEqual([
       {
@@ -287,7 +287,7 @@ describe("Rite Aid Scraper", () => {
         },
       });
 
-    const result = await checkAvailability(() => {}, { states: "NJ" });
+    const result = await checkAvailability(() => {}, { states: ["NJ"] });
     expect(result).toContainItemsMatchingSchema(locationSchema);
     expect(result[0].availability.slots).toEqual([
       {
@@ -339,7 +339,7 @@ describe("Rite Aid Scraper", () => {
         },
       });
 
-    const result = await checkAvailability(() => {}, { states: "NJ" });
+    const result = await checkAvailability(() => {}, { states: ["NJ"] });
     expect(result).toContainItemsMatchingSchema(locationSchema);
     expect(result).toHaveProperty("0.availability.available", Available.no);
   });
@@ -353,9 +353,9 @@ describe("Rite Aid Scraper", () => {
       ErrMsgDtl: null,
     });
 
-    await expect(checkAvailability(() => {}, { states: "NJ" })).rejects.toThrow(
-      "Something went wrong"
-    );
+    await expect(
+      checkAvailability(() => {}, { states: ["NJ"] })
+    ).rejects.toThrow("Something went wrong");
   });
 
   it("includes sub-brand IDs when appropriate", async () => {
@@ -392,7 +392,7 @@ describe("Rite Aid Scraper", () => {
         },
       });
 
-    const result = await checkAvailability(() => {}, { states: "NJ" });
+    const result = await checkAvailability(() => {}, { states: ["NJ"] });
     expect(result).toHaveProperty("0.external_ids", [
       ["rite_aid", "6958"],
       ["bartell", "58"],

--- a/loader/test/vts.geo.test.js
+++ b/loader/test/vts.geo.test.js
@@ -25,22 +25,22 @@ describe.skip("VtS Geo", () => {
 
   it("filters by state", async () => {
     let locations;
-    locations = await checkAvailability(noopHandler, { states: "NJ" });
+    locations = await checkAvailability(noopHandler, { states: ["NJ"] });
     expect(locations.length).toBe(0);
 
-    locations = await checkAvailability(noopHandler, { states: "CA" });
+    locations = await checkAvailability(noopHandler, { states: ["CA"] });
     expect(locations.length).not.toBe(0);
   });
 
   it("skips stores we don't care about", async () => {
     expect(apiResponse.features.length).toBe(3);
 
-    const locations = await checkAvailability(noopHandler, { states: "CA" });
+    const locations = await checkAvailability(noopHandler, { states: ["CA"] });
     expect(locations.length).toBe(2);
   });
 
   it("formats stores as expected", async () => {
-    const locations = await checkAvailability(noopHandler, { states: "CA" });
+    const locations = await checkAvailability(noopHandler, { states: ["CA"] });
     expect(locations[0]).toStrictEqual({
       external_ids: [
         ["vaccines_gov", "d91cd449-36c2-4cf5-9c1a-f4136d9a2bf7"],

--- a/loader/test/wa-doh.test.js
+++ b/loader/test/wa-doh.test.js
@@ -20,7 +20,7 @@ describe("Washington DoH API", () => {
   });
 
   it.nock("should successfully format results", async () => {
-    const result = await checkAvailability(() => {}, { states: "PR" });
+    const result = await checkAvailability(() => {}, { states: ["PR"] });
     expect(result).toEqual([
       {
         address_lines: ["PR #30 INTERSECCION AVENDIA", "RAFAEL CORDERO BARIO"],
@@ -105,7 +105,7 @@ describe("Washington DoH API", () => {
         ],
       });
 
-    const error = await checkAvailability(() => null, { states: "PR" }).then(
+    const error = await checkAvailability(() => null, { states: ["PR"] }).then(
       () => null,
       (error) => error
     );

--- a/loader/test/walgreens.test.js
+++ b/loader/test/walgreens.test.js
@@ -27,7 +27,7 @@ describe("Walgreens SMART Scheduling Links API", () => {
       .get("/fhir/Slot-abc.ndjson")
       .reply(200, toNdJson(fixtures.TestSlots));
 
-    const result = await checkAvailability(() => null, { states: "AK" });
+    const result = await checkAvailability(() => null, { states: ["AK"] });
     expect(result).toEqual([
       {
         external_ids: [
@@ -90,7 +90,7 @@ describe("Walgreens SMART Scheduling Links API", () => {
         )
       );
 
-    const result = await checkAvailability(() => null, { states: "AK" });
+    const result = await checkAvailability(() => null, { states: ["AK"] });
     expect(result).toHaveProperty("0.availability.available", Available.no);
     expect(result).toContainItemsMatchingSchema(locationSchema);
   });
@@ -105,7 +105,7 @@ describe("Walgreens SMART Scheduling Links API", () => {
       .reply(200, toNdJson(fixtures.TestSchedules));
     nock(API_BASE).get("/fhir/Slot-abc.ndjson").reply(200, "");
 
-    const result = await checkAvailability(() => null, { states: "AK" });
+    const result = await checkAvailability(() => null, { states: ["AK"] });
     expect(result).toHaveProperty("0.availability.available", Available.no);
     expect(result).toContainItemsMatchingSchema(locationSchema);
   });
@@ -122,7 +122,7 @@ describe("Walgreens SMART Scheduling Links API", () => {
       .get("/fhir/Slot-abc.ndjson")
       .reply(200, toNdJson(fixtures.TestSlots));
 
-    const result = await checkAvailability(() => null, { states: "VA" });
+    const result = await checkAvailability(() => null, { states: ["VA"] });
     expect(result).toHaveLength(0);
   });
 });


### PR DESCRIPTION
This fixes some long-standing bad decisions around parsing CLI options and default values in the loader (all my own fault):
- We had lots of repetitive parsing and error-checking code for converting `--states` to an array and validating other options. These always should have been handled up-front in the CLI parsing code, and they now are.

- Now that the parsing and validation is done in one place, I made it a little more detailed and strict.

- Removed the source-specific state options (e.g. `--rite-aid-states`). I originally made these because I expected we’d call the loader with multiple sources and often need to specify different sets of states for each source. We’ve never used it that way in production, though, so there’s really no value in supporting those options.

- Add/allow default values for `--states`. Not having this has always made ad-hoc usage and testing a pain. Sources now each have their own reasonable default for `--states` that loads all the states that are relevant. (This also means we don’t need to list states in most of the loader configurations in `loaders.tf` and `render.yaml`, but I’ve left them in for maximum clarify/specificity.)