### PR TITLE
Ignore Pneumococcal vaccines in PrepMod

### DIFF
--- a/loader/src/sources/prepmod/index.js
+++ b/loader/src/sources/prepmod/index.js
@@ -182,6 +182,7 @@ function formatLocationBookingUrl(host, location) {
 //   are only matching vaccines against adenovirus, not ones that might be using
 //   modified adenovirus as a vaccine against COVID or other things.)
 // - Monkeypox vaccine (Jynneos)
+// - Pneumococcal vaccines (PCV, PCV7, PCV13, PPSV, PPSV23, etc.)
 const raw = String.raw;
 const nonCovidProductName = new RegExp(
   [
@@ -193,6 +194,8 @@ const nonCovidProductName = new RegExp(
     raw`monkeypox`,
     raw`jynneos`,
     raw`\btdap\b`,
+    raw`\bPCV(\d+)?\b`,
+    raw`\bPPSV(\d+)?\b`,
   ].join("|"),
   "i"
 );


### PR DESCRIPTION
PCSV13 and PPSV (types of Pneumococcal vaccines) recently started showing up in PrepMod. This ignores them like we do other non-COVID vaccines.

Fixes https://sentry.io/organizations/usdr/issues/3382842420.