### PR TITLE
Allow tests to have transactions

### DIFF
--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
   transform: {
     "^.+\\.(ts|tsx)$": "ts-jest",
   },
-  testMatch: ["**/test/**/*.test.(ts|js)"],
+  testMatch: ["**/test/**/*.test.(ts|js)", "!**/dist/test/**/*"],
   testEnvironment: "node",
   reporters: ["default", "github-actions"],
   coverageReporters: ["text", "html"],

--- a/server/test/db.test.ts
+++ b/server/test/db.test.ts
@@ -678,7 +678,7 @@ describe("db.addExternalIds", () => {
   };
 
   describe("creating locations", () => {
-    it.skip("does not allow a colon in the externalId", async () => {
+    it("does not allow a colon in the externalId", async () => {
       const TestLocationInvalidExternalId = {
         ...TestLocation,
         ...updatedData,
@@ -690,7 +690,7 @@ describe("db.addExternalIds", () => {
       const newLocation = await getLocationById(
         TestLocationInvalidExternalId.id
       );
-      expect(newLocation).toBe(undefined);
+      expect(newLocation).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
Instead of wrapping tests in transactions (and making transactions *inside* the test do nothing), truncate the relevant tables and sequences before each test (not after, so if something goes wrong, that leaves stuff in the DB so you can inspect it).

This also fixes a long-standing issue where Jest would try and run tests in the `dist` directory, which would sometimes lead to incorrect failures (if you hadn’t run a build since changing a test file, the test in `dist` would have the old code and fail).

Fixes #463.