### PR TITLE
Ensure all HTTP requests eventually time out

### DIFF
--- a/loader/src/utils.js
+++ b/loader/src/utils.js
@@ -498,6 +498,7 @@ module.exports = {
    */
   httpClient: got.extend({
     headers: { "User-Agent": config.userAgent },
+    timeout: 2.5 * 60 * 1000, // 2.5 minutes
   }),
 
   /**


### PR DESCRIPTION
Got doesn't have a built-in timeout, so it's possible for an HTTP request the loader makes to hang forever. This sets a default timeout of 2.5 minutes on every request. That's long, but at least makes sure things eventually fail. I think this might help with #669 (the loader occasionally hangs and never stops), although it's possible the root cause is something else.