### PR TITLE
Add `MOBILE_CLINIC` location type

### DIFF
--- a/loader/src/model.js
+++ b/loader/src/model.js
@@ -21,6 +21,7 @@ const LocationType = {
   pharmacy: "PHARMACY",
   massVax: "MASS_VAX",
   clinic: "CLINIC",
+  mobileClinic: "MOBILE_CLINIC",
 };
 
 /**

--- a/server/src/interfaces.ts
+++ b/server/src/interfaces.ts
@@ -8,6 +8,7 @@ export enum LocationType {
   PHARMACY = "PHARMACY",
   MASS_VAX = "MASS_VAX",
   CLINIC = "CLINIC",
+  MOBILE_CLINIC = "MOBILE_CLINIC",
 }
 
 export interface Position {


### PR DESCRIPTION
When I was reviewing #122 earlier this week, I noticed some locations had a `MOBILE_CLINIC` location type in the database, even though we don't have constants here for them (they were probably manually set, or came from earlier code, or something to do with Vaccinate the States). This adds a constant for it so we can use it, and so it's clear that it's a valid value, even though we don't actually have any code using it right now.