### PR TITLE
A little light JSDoc types cleanup

### DIFF
--- a/loader/src/exceptions.js
+++ b/loader/src/exceptions.js
@@ -1,7 +1,17 @@
+/**
+ * @typedef {object} HttpResponse
+ * @property {number} statusCode
+ * @property {string} [statusMessage]
+ * @property {any} body
+ */
+
+/**
+ * An error from an HTTP response.
+ */
 class HttpApiError extends Error {
   /**
    * Create an error object for a bad response from an API.
-   * @param {http.IncomingMessage} response
+   * @param {HttpResponse} response
    */
   constructor(response, { cause = null } = {}) {
     super(`${response.statusCode} ${response.statusMessage}`, { cause });
@@ -20,7 +30,7 @@ class HttpApiError extends Error {
    * It's safe for this to raise an exception (it will be handled and a more
    * generic error message will be set).
    *
-   * @param {http.IncomingMessage} response An HTTP response with error info.
+   * @param {HttpResponse} response An HTTP response with error info.
    */
   parse(response) {
     this.details = JSON.parse(response.body);
@@ -45,7 +55,7 @@ class GraphQlError extends HttpApiError {
 /**
  * If the HTTP response represents a GraphQL error, throws an instance of
  * `GraphQlError` with relevant information.
- * @param {http.IncomingMessage} response
+ * @param {HttpResponse} response
  */
 function assertValidGraphQl(response) {
   if (response.statusCode >= 400 || response.body?.errors) {

--- a/loader/src/smart-scheduling-links.js
+++ b/loader/src/smart-scheduling-links.js
@@ -172,7 +172,7 @@ function isCovidSchedule(schedule) {
  * @param {SmartSchedulingLinksApi} api
  * @param {Array<string>} [states] List of state abbreviations. If set, only
  *        return data for locations possibly in the given states.
- * @returns {Array<{location: any, schedules: Array<any>, slots: Array<any>}>}
+ * @returns {Promise<{location: any, schedules: Array<any>, slots: Array<any>}[]>}
  */
 async function getLocations(api, states) {
   const locations = Object.create(null);

--- a/loader/src/smart-scheduling-links.js
+++ b/loader/src/smart-scheduling-links.js
@@ -313,17 +313,18 @@ function isValidIdentifier(value) {
 
 /**
  * Create UNIVAF-style external IDs for a SMART SL location object.
- * @param {Object} location
- * @param {Object} [options]
- * @param {string} options.smartIdName If set, include the location object's ID
+ * @param {any} location
+ * @param {Object} options
+ * @param {string} [options.smartIdName] If set, include the location object's ID
  *        in the list of external IDs, using the string as the system name.
- * @param {(identifier: {system: string, value: string}) => [string, string]} options.formatUnknownId
+ * @param {(identifier: {system: string, value: string}) => [string, string]} [options.formatUnknownId]
  *        Customize handling of unknown ID systems. Normally, unknown system
  *        names are simply passed through, but you can provide custom mappings
  *        using this function. Return `["", ""]` to drop the identifier.
- * @returns {Array<[string,string]>}
+ * @returns {[string,string][]}
  */
 function formatExternalIds(location, { smartIdName, formatUnknownId } = {}) {
+  /** @type {[string,string][]} */
   const externalIds = [];
 
   if (smartIdName) externalIds.push([smartIdName, location.id]);

--- a/loader/src/sources/cvs/api.js
+++ b/loader/src/sources/cvs/api.js
@@ -125,9 +125,11 @@ function parseApiLocation(location, lastUpdated) {
 
 /**
  * Get availability data from the CVS API.
- * @param {string} [apiKey] CVS API key. Can also be provided via the
- *        CVS_API_KEY environment variable.
- * @param {string} [apiUrl] Base URL for the CVS API.
+ * Make sure to set these environment variables:
+ * - CVS_API_KEY
+ * - CVS_API_URL (optional, the base URL for the CVS API)
+ * @param {(any) => void} handler
+ * @param {any} [_options]
  */
 async function checkAvailability(handler, _options) {
   warn("WARNING: cvsApi is deprecated and no longer maintained.");

--- a/loader/src/sources/cvs/api.js
+++ b/loader/src/sources/cvs/api.js
@@ -68,7 +68,7 @@ class CvsApiError extends HttpApiError {
 /**
  * Convert availability value from the API to our availability model.
  * @param {string} apiValue Availability field from the CVS API
- * @returns {availability}
+ * @returns {Available}
  */
 function toAvailable(apiValue) {
   const text = apiValue.toLowerCase();

--- a/loader/src/sources/cvs/scraper.js
+++ b/loader/src/sources/cvs/scraper.js
@@ -359,7 +359,7 @@ function createCannedUnavailableStore() {
 /**
  * Kick off the scraper to crawl the getIMZStores endpoint.
  *
- * @return {array} Array of results conforming to the scraper standard.
+ * @return {Promise<Array>} Array of results conforming to the scraper standard.
  */
 async function checkAvailability(handler, _options) {
   warn("WARNING: cvsScraper is deprecated and no longer maintained.");

--- a/loader/src/sources/cvs/scraper.js
+++ b/loader/src/sources/cvs/scraper.js
@@ -378,7 +378,7 @@ async function checkAvailability(handler, _options) {
     await timers.setTimeout(randomInt(3, 7) * 1000);
   }
 
-  const finalResult = { ...createCannedUnavailableStore(clinicsZip) };
+  const finalResult = { ...createCannedUnavailableStore() };
   for (const storeNumber in standardResults) {
     finalResult[storeNumber] = standardResults[storeNumber];
   }

--- a/loader/src/sources/cvs/smart.js
+++ b/loader/src/sources/cvs/smart.js
@@ -23,7 +23,7 @@ const logError = createWarningLogger("cvsSmart", "error");
 /**
  * Get an array of UNIVAF-formatted locations & availabilities from the
  * SMART SL API.
- * @returns {Array<any>}
+ * @returns {Promise<Array<any>>}
  */
 async function getData(states) {
   const api = new SmartSchedulingLinksApi(CVS_SMART_API_URL);

--- a/loader/src/sources/kroger.js
+++ b/loader/src/sources/kroger.js
@@ -45,7 +45,7 @@ const warn = createWarningLogger("krogerSmart");
 /**
  * Get an array of UNIVAF-formatted locations & availabilities from the
  * SMART SL API.
- * @returns {Array<any>}
+ * @returns {Promise<Array<any>>}
  */
 async function getData(states) {
   const api = new SmartSchedulingLinksApi(API_URL);

--- a/loader/src/sources/njvss/index.js
+++ b/loader/src/sources/njvss/index.js
@@ -38,18 +38,20 @@ const logDebug = console.warn;
 
 /**
  * @typedef {Object} NjvssRecord
+ * @property {string} res_id
+ * @property {number} provider_id
  * @property {string} name
  * @property {string} statuscodename
  * @property {string} vras_provideraddress
- * @property {string} vras_typename Type of service, usually 'COVID Vaccination'
- * @property {float} vras_latitude
- * @property {float} vras_longitude
+ * @property {string} vras_typetext Type of service, usually 'COVID Vaccination'
+ * @property {number} vras_latitude
+ * @property {number} vras_longitude
  * @property {string} vras_typetext Additional details as an HTML string.
  * @property {boolean?} vras_allowschedulingforcountyresidentsonly Whether
  *           scheduling is allowed only for county residents. May be `null` if
  *           unknown.
  * @property {string} county
- * @property {int} available Number of available appointment slots
+ * @property {number} available Number of available appointment slots
  */
 
 /**

--- a/loader/src/sources/njvss/index.js
+++ b/loader/src/sources/njvss/index.js
@@ -238,7 +238,7 @@ function filterActualNjvssLocations(locations) {
  * Returns the list of passed in locations, but with each modified to add an
  * `id` property.
  * @param {Array<object>} locations List of found NJVSS locations.
- * @returns {Array<object>}
+ * @returns {Promise<Array<object>>}
  */
 async function findLocationIds(locations) {
   // FIXME: a lot has changed about how we manage locations and IDs since this

--- a/loader/src/sources/prepmod/index.js
+++ b/loader/src/sources/prepmod/index.js
@@ -42,7 +42,7 @@ function getApiForHost(host) {
 /**
  * Get an array of UNIVAF-formatted locations & availabilities from the
  * SMART SL API.
- * @returns {Array<any>}
+ * @returns {Promise<any[]>}
  */
 async function getDataForHost(host) {
   const api = getApiForHost(host);

--- a/loader/src/sources/wa-doh.js
+++ b/loader/src/sources/wa-doh.js
@@ -12,6 +12,8 @@ const {
 const { assertValidGraphQl } = require("../exceptions");
 const allStates = require("../states.json");
 
+/** @typedef {import("../model").VaccineProduct} VaccineProduct */
+
 const warn = createWarningLogger("waDoh");
 
 // You can also navigate to this URL in a browser and get an interactive

--- a/loader/src/sources/walgreens.js
+++ b/loader/src/sources/walgreens.js
@@ -34,7 +34,7 @@ const warn = createWarningLogger("walgreensSmart");
 /**
  * Get an array of UNIVAF-formatted locations & availabilities from the
  * SMART SL API.
- * @returns {Array<any>}
+ * @returns {Promise<Array<any>>}
  */
 async function getData(states) {
   const api = new SmartSchedulingLinksApi(API_URL);

--- a/loader/src/utils.js
+++ b/loader/src/utils.js
@@ -389,7 +389,7 @@ module.exports = {
   /**
    * Remove an item matching a predicate function from an array and return it.
    * @param {Array} list Array to remove the item from.
-   * @param {(any) => bool} predicate Function to identify an item to remove
+   * @param {(any) => boolean} predicate Function to identify an item to remove
    */
   popItem(list, predicate) {
     const index = list.findIndex(predicate);
@@ -526,7 +526,7 @@ module.exports = {
   /**
    * Remove duplicate entries from a list of external IDs.
    * @param {Array<[string,string]>} idList
-   * @returns {Array<[string,string]}
+   * @returns {Array<[string,string]>}
    */
   getUniqueExternalIds(idList) {
     const seen = new Set();

--- a/loader/src/utils.js
+++ b/loader/src/utils.js
@@ -361,7 +361,7 @@ module.exports = {
   /**
    * Template string tag that transforms a template string into a single line.
    * Line breaks and indentations are reduced to a single space character.
-   * @param {Array<string>} strings String components of the template literal.
+   * @param {TemplateStringsArray} strings String components of the template literal.
    * @param  {...any} replacements Interpolated replacements in the template.
    * @returns {string}
    *


### PR DESCRIPTION
In my experiments on code sharing in #882, I noticed our JSDoc types aren’t always correct or up to date, owing to the fact that they aren’t strictly checked. This fixes up some of the more obvious issues, although it isn’t enough to make the TypeScript compiler happy.