### PR TITLE
Simplify DB connection config on Render

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -63,31 +63,11 @@ services:
           name: DataDog Agent
           type: pserv
           property: host
-      - &DB_HOST
-        key: DB_HOST
+      - &DB_URL
+        key: DB_URL
         fromDatabase:
           name: univaf-db-production
-          property: host
-      - &DB_PORT
-        key: DB_PORT
-        fromDatabase:
-          name: univaf-db-production
-          property: port
-      - &DB_USERNAME
-        key: DB_USERNAME
-        fromDatabase:
-          name: univaf-db-production
-          property: user
-      - &DB_PASSWORD
-        key: DB_PASSWORD
-        fromDatabase:
-          name: univaf-db-production
-          property: password
-      - &DB_NAME
-        key: DB_NAME
-        fromDatabase:
-          name: univaf-db-production
-          property: database
+          property: connectionString
 
   # Dump database and historical log files in S3
   - name: "Daily Data Snapshot"
@@ -112,11 +92,7 @@ services:
     envVars:
       - fromGroup: "Server Environment"
       - *DD_AGENT_HOST
-      - *DB_HOST
-      - *DB_PORT
-      - *DB_USERNAME
-      - *DB_PASSWORD
-      - *DB_NAME
+      - *DB_URL
       - key: DATA_SNAPSHOT_S3_BUCKET
         value: "univaf-render-test-data-snapshots"
       - key: AWS_ACCESS_KEY_ID

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,9 +1,17 @@
-# Postgres DB Configuration
+# Database connection configuration. Can be either:
+#
+# 1. A postgres connection string in the form:
+#    `postgres://<user>:<password>@<host>:<port>/<db_name>'
+export DB_URL='postgres://localhost:5432/univaf'
+#
+# 2. Individual variables for each component:
 # export DB_HOST='127.0.0.1'
 # export DB_PORT=''
 # export DB_USERNAME='postgres'
 # export DB_PASSWORD='password'
-export DB_NAME='univaf'
+# export DB_NAME='univaf'
+#
+# If set, DB_URL will take precedence over individual variables.
 
 # Customize the DB connection pool for each type of DB connection (optional)
 # export DB_POOL_SIZE_DATA=10

--- a/server/knexfile.js
+++ b/server/knexfile.js
@@ -1,7 +1,7 @@
 /** @type {import("knex").Knex.Config} */
 const base = {
   client: "postgresql",
-  connection: {
+  connection: process.env.DB_URL || {
     host: process.env.DB_HOST,
     port: process.env.DB_PORT,
     database: process.env.DB_NAME,


### PR DESCRIPTION
One discovery from initially deploying to render in #755 was that database connection configuration is a lot of boilerplate, since we don't support a connection URI as a single variable. This fixes that problem. I've updated the Render configuration here, but not bothered with Terraform/AWS since we will be tearing that down shortly.