### PR TITLE
Exit with error code when availability_dump fails

### DIFF
--- a/server/scripts/availability_dump.js
+++ b/server/scripts/availability_dump.js
@@ -252,6 +252,7 @@ async function main() {
 
   if (!process.env.DATA_SNAPSHOT_S3_BUCKET) {
     writeLog("DATA_SNAPSHOT_S3_BUCKET environment var required");
+    process.exitCode = 1;
     return;
   }
 


### PR DESCRIPTION
I noticed this whiles tuning the resources this job needs on Render — if the configuration is wrong and the command exits early, it still signals success. That's not good!