### PR TITLE
Reduce resources for daily data dump job

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -74,7 +74,9 @@ services:
     region: oregon
     type: cron
     schedule: "0 5 * * *"
-    plan: standard
+    # The main bottleneck on this job is actually uploading to S3; even minimal
+    # CPU/memory don't impact overall run time.
+    plan: starter
     env: node
     repo: "https://github.com/usdigitalresponse/univaf.git"
     branch: main


### PR DESCRIPTION
I did some quick experiments on Render with a temporary cron job and discovered the bottleneck for the Daily Data Snaphsot is really uploading to S3. There might be some optimization we can do there, but in the mean time, there's no reason to use 2GB of RAM and 1 CPU when less will make no difference in performance.