### PR TITLE
Try downsizing the database by one level in Render

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -8,7 +8,7 @@
 databases:
   - name: univaf-db-production
     region: oregon
-    plan: pro
+    plan: standard plus
     databaseName: univaf_db_production
     user: univaf
     # Not sepecifying IPs for now; we may want to set this to an empty array


### PR DESCRIPTION
While reviewing the Render deployment with @alexallain last week, he pointed out that the database, while smaller than what we have on AWS, may still be overprovisioned (we use a good deal of RAM, but Postgres allocates a huge chunk by default even when it may not actually be using it, so good stats are more complicated here). If we're going to see whether we can lower the database tier by one, we ought to do it now, before switching production to Render.

**This will probably fail!** On the web console, you can’t downsize a database. If this fails, I’ll try creating a second one that is at `standard plus` tier and then switching things to it.