### PR TITLE
Ensure Sentry releases are set on Render Loader

### DIFF
--- a/loader/src/cli.js
+++ b/loader/src/cli.js
@@ -53,6 +53,8 @@ function createDatabaseSender() {
  * @returns {Promise<void>}
  */
 async function run(options) {
+  Sentry.setContext("CLI Arguments", { ...options });
+
   let handler;
   if (options.send) {
     handler = createDatabaseSender();

--- a/loader/src/cli.js
+++ b/loader/src/cli.js
@@ -3,11 +3,12 @@
 const Sentry = require("@sentry/node");
 const yargs = require("yargs");
 const { ApiClient } = require("./api-client");
+const config = require("./config");
 const { sources } = require("./index");
 const { oneLine } = require("./utils");
 const allStates = require("./states.json");
 
-Sentry.init();
+Sentry.init({ release: config.version });
 
 async function runSources(targets, handler, options) {
   targets =

--- a/loader/src/config.js
+++ b/loader/src/config.js
@@ -1,10 +1,13 @@
 const packageInfo = require("../package.json");
 
+// TODO: share the logic for getting the release/version with the server.
 const version =
   process.env.RELEASE ||
   process.env.COMMIT_REF ||
   process.env.COMMIT_SHA ||
   process.env.COMMIT_HASH ||
+  // Render
+  process.env.RENDER_GIT_COMMIT ||
   // GitHub Actions
   process.env.GITHUB_SHA ||
   // We don't necessarily bump this whenever we update, so it's only a fallback.

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -3,6 +3,7 @@ import type { Knex } from "knex";
 
 export const LOG_LEVEL = process.env.LOG_LEVEL || "info";
 
+// TODO: share the logic for getting the release/version with the loader.
 export const RELEASE =
   process.env.RELEASE || process.env.RENDER_GIT_COMMIT || undefined;
 


### PR DESCRIPTION
Use `RENDER_GIT_COMMIT` to set the release tag for Sentry, just like we do in the server. Ideally I’ll improve this in #882, but for now, this just needs to be added to the loader.