### PR TITLE
Disallow public connections to the DB on Render

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -11,11 +11,11 @@ databases:
     plan: standard plus
     databaseName: univaf_db
     user: univaf
-    # Not sepecifying IPs for now; we may want to set this to an empty array
-    # to disallow public connections, though. i.e. `ipAllowList: []`
-    # ipAllowList:
-    #   - source: 203.0.113.4/30
-    #     description: office
+    # Don't allow connections from the public internet.
+    # If you need to run scripts or log into the database directly, you should
+    # start a shell or SSH session for one of our internal services from the
+    # Render dashboard, and log in through that.
+    ipAllowList: []
 
 services:
   - name: DataDog Agent


### PR DESCRIPTION
In preparation for switching production to Render (#779) we are turning off public internet access to the database. This mainly means you can no longer run `psql -d xyz` from your local machine, and will instead need to start a temporary shell or ssh session on one of our Render services to access it.