### PR TITLE
Add more metrics to API & DB operations

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -5,13 +5,16 @@ import errorHandler from "errorhandler";
 import * as Sentry from "@sentry/node";
 import * as Tracing from "@sentry/tracing";
 import { RELEASE } from "./config";
-import { authorizeRequest, versionedMiddleware } from "./middleware";
+import {
+  authorizeRequest,
+  parseJsonBody,
+  versionedMiddleware,
+} from "./middleware";
 import { datadogMiddleware } from "./datadog";
 import { logger, logStackTrace } from "./logger";
 import * as apiEdge from "./api/edge";
 import * as apiLegacy from "./api/legacy";
 import { asyncHandler, urlDecodeSpecialPathChars } from "./utils";
-import bodyParser from "body-parser";
 
 // TODO: we should use a proper logging library (e.g. Winston) which has
 // plugins and extensions for this, and will gather better data.
@@ -57,7 +60,7 @@ app.use(Sentry.Handlers.tracingHandler());
 app.use(logRequest);
 app.use(datadogMiddleware);
 app.use(compression());
-app.use(bodyParser.json({ limit: "2.5mb" }));
+app.use(parseJsonBody({ limit: "2.5mb" }));
 app.use(cors());
 app.use(authorizeRequest);
 app.use(urlDecodeSpecialPathChars);

--- a/server/src/datadog.ts
+++ b/server/src/datadog.ts
@@ -59,6 +59,9 @@ export function datadogMiddleware(
     statTags.push(`method:${req.method.toLowerCase()}`);
     statTags.push(`response_code:${res.statusCode}`);
 
+    const isInternal = (req.headers["user-agent"] || "").startsWith("univaf");
+    statTags.push(`internal:${isInternal}`);
+
     const now = new Date();
     const responseTime = now.valueOf() - req.startTime.valueOf();
 

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -18,6 +18,7 @@ import * as Sentry from "@sentry/node";
 import * as availabilityLog from "./availability-log";
 import { isDeepStrictEqual } from "util";
 import { minimumAgeForProducts } from "./vaccines";
+import { dogstatsd } from "./datadog";
 
 // When locations are queried in batches (e.g. when iterating over extremely
 // large result sets), query this many records at a time.
@@ -81,7 +82,10 @@ function selectSqlPoint(column: string): string {
  * Create a provider location.
  * @param data ProviderLocation-like object with data to insert
  */
-export async function createLocation(data: any): Promise<ProviderLocation> {
+export async function createLocation(
+  data: any,
+  { source = "" } = {}
+): Promise<ProviderLocation> {
   data = validateLocationInput(data, true);
 
   const now = new Date();
@@ -113,6 +117,7 @@ export async function createLocation(data: any): Promise<ProviderLocation> {
 
     const locationId = inserted.rows[0].id;
     await addExternalIds(locationId, data.external_ids, tx);
+    dogstatsd.increment("db.locations.created.count", [`source:${source}`]);
     return locationId;
   });
   return await getLocationById(locationId, { includePrivate: true });
@@ -158,7 +163,7 @@ export async function addExternalIds(
 export async function updateLocation(
   location: ProviderLocation,
   data: any,
-  { mergeSubfields = true } = {}
+  { mergeSubfields = true, source = "" } = {}
 ): Promise<void> {
   data = validateLocationInput(data);
   const sqlData: any = { updated_at: new Date() };
@@ -184,6 +189,8 @@ export async function updateLocation(
       await addExternalIds(location.id, data.external_ids, tx);
     }
   });
+
+  dogstatsd.increment("db.locations.updated.count", [`source:${source}`]);
 }
 
 /**
@@ -673,6 +680,7 @@ export async function updateAvailability(
     }
 
     result = { locationId: id, action: "update" };
+    dogstatsd.increment("db.availability.updated.count", [`source:${source}`]);
   } else {
     try {
       await db("availability").insert({
@@ -691,6 +699,9 @@ export async function updateAvailability(
         changed_at: valid_at,
       });
       result = { locationId: id, action: "create" };
+      dogstatsd.increment("db.availability.created.count", [
+        `source:${source}`,
+      ]);
     } catch (error) {
       if (error.message.includes("availability_location_id_fkey")) {
         throw new NotFoundError(`Could not find location ${id}`);

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -84,7 +84,7 @@ function selectSqlPoint(column: string): string {
  */
 export async function createLocation(
   data: any,
-  { source = "" } = {}
+  { source = "unknown" } = {}
 ): Promise<ProviderLocation> {
   data = validateLocationInput(data, true);
 
@@ -163,7 +163,7 @@ export async function addExternalIds(
 export async function updateLocation(
   location: ProviderLocation,
   data: any,
-  { mergeSubfields = true, source = "" } = {}
+  { mergeSubfields = true, source = "unknown" } = {}
 ): Promise<void> {
   data = validateLocationInput(data);
   const sqlData: any = { updated_at: new Date() };

--- a/server/src/middleware.ts
+++ b/server/src/middleware.ts
@@ -49,10 +49,12 @@ export function versionedMiddleware(
 export function parseJsonBody(
   options: bodyParser.OptionsJson
 ): ReturnType<typeof bodyParser.json> {
-  const { verify, ...otherOptions } = options;
-
   return bodyParser.json({
-    ...otherOptions,
+    ...options,
+
+    // `verify` is a convenient callback to get the decoded/decompressed body
+    // before parsing, so this wraps whatever `verify` function may have been
+    // passed in and uses it to count bytes.
     verify(
       request: AppRequest,
       response: Response,
@@ -60,8 +62,8 @@ export function parseJsonBody(
       encoding: string
     ) {
       request.bodyByteLength = buffer.byteLength || buffer.length;
-      if (verify) {
-        verify(request, response, buffer, encoding);
+      if (options.verify) {
+        options.verify(request, response, buffer, encoding);
       }
     },
   });


### PR DESCRIPTION
This adds a few metrics (and tags for metrics) to track:
- `api.received.updates.count` are the number of calls to the `update` endpoint, tagged by source.
- `api.received.updates.bytes` (histogram) is the uncompressed body size of each update, tagged by source.
- `db.locations.created.count` is the number of locations created in the DB
- `db.locations.updated.count` is the number of locations updated in the DB
- `db.availability.created.count` is the number of availability records created in the DB
- `db.availability.updated.count` is the number of availability records updated in the DB

All the above have a `source:<source_name>` tag, and request metrics now also have a `internal:<true|false>` tag for whether the request came from part of UNIVAF, or from someone else (e.g. state of NJ).

I prototyped some code to track request and response size to every request, but wasn’t sure it was worthwhile, and left it out for now. (We currently get some basic metrics on this from our load balancer in AWS, but don’t have access to that data from Render.)