### PR TITLE
Point `render.getmyvax.org` to Render

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
     paths-ignore:
       - "docs/**"
       - "terraform/**"
+      - "render.yaml"
   push:
     branches:
       - main

--- a/render.yaml
+++ b/render.yaml
@@ -51,6 +51,7 @@ services:
     healthCheckPath: "/health"
     domains:
       - univaf.usdigitalresponse.org
+      - render.getmyvax.org
     envVars:
       - fromGroup: "Server Environment"
       - &DD_AGENT_HOST

--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -265,11 +265,11 @@ resource "aws_cloudfront_distribution" "univaf_api" {
 # First we have to point DNS directly at Render so it can validate that it's ok
 # for it to respond to this hostname.
 resource "aws_route53_record" "api_render_domain_record" {
-  count   = var.domain_name != "" ? 1 : 0
+  count   = var.api_remote_domain_name_test != "" ? 1 : 0
   zone_id = data.aws_route53_zone.domain_zone[0].zone_id
   name    = "render"
   type    = "CNAME"
-  records = [var.domain_name]
+  records = [var.api_remote_domain_name_test]
   ttl     = 300
 }
 

--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -258,3 +258,81 @@ resource "aws_cloudfront_distribution" "univaf_api" {
     }
   }
 }
+
+# -----------------------------------------------------------------------------
+# NOT USED FOR PRODUCTION -- TESTING CLOUDFRONT IN FRONT OF RENDER
+
+# First we have to point DNS directly at Render so it can validate that it's ok
+# for it to respond to this hostname.
+resource "aws_route53_record" "api_render_domain_record" {
+  count   = var.domain_name != "" ? 1 : 0
+  zone_id = data.aws_route53_zone.domain_zone[0].zone_id
+  name    = "render"
+  type    = "CNAME"
+  records = [var.domain_name]
+  ttl     = 300
+}
+
+# # ...then we turn off the above record and replace it with this one that
+# # at CloudFront.
+# resource "aws_route53_record" "api_render_domain_record" {
+#   count = var.domain_name != "" ? 1 : 0
+
+#   zone_id = data.aws_route53_zone.domain_zone[0].zone_id
+#   name    = "render.${var.domain_name}"
+#   type    = "A"
+
+#   alias {
+#     name                   = aws_cloudfront_distribution.univaf_api_render[0].domain_name
+#     zone_id                = aws_cloudfront_distribution.univaf_api_render[0].hosted_zone_id
+#     evaluate_target_health = false
+#   }
+# }
+
+resource "aws_cloudfront_distribution" "univaf_api_render" {
+  count       = var.ssl_certificate_arn_render_test != "" ? 1 : 0
+  enabled     = true
+  price_class = "PriceClass_100" # North America
+  aliases     = ["render.${var.domain_name}"]
+
+  origin {
+    origin_id   = "render-test-origin"
+    domain_name = "api-server-phc8.onrender.com"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_ssl_protocols   = ["SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2"]
+      origin_protocol_policy = "https-only"
+    }
+  }
+
+  default_cache_behavior {
+    allowed_methods        = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "render-test-origin"
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    max_ttl                = 3600
+
+    forwarded_values {
+      headers      = ["Host", "Origin"]
+      query_string = true
+
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn = var.ssl_certificate_arn_render_test
+    ssl_support_method  = "sni-only"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -93,6 +93,11 @@ variable "ssl_certificate_arn" {
   default     = ""
 }
 
+variable "ssl_certificate_arn_render_test" {
+  description = "To enable HTTPS, the ARN of an SSL certificate created with ACM in us-east-1"
+  default     = ""
+}
+
 variable "domain_name" {
   description = "The domain name to use for HTTPS traffic"
   default     = ""

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -93,13 +93,18 @@ variable "ssl_certificate_arn" {
   default     = ""
 }
 
-variable "ssl_certificate_arn_render_test" {
-  description = "To enable HTTPS, the ARN of an SSL certificate created with ACM in us-east-1"
+variable "domain_name" {
+  description = "The domain name to use for HTTPS traffic"
   default     = ""
 }
 
-variable "domain_name" {
-  description = "The domain name to use for HTTPS traffic"
+variable "api_remote_domain_name" {
+  description = "The domain name for a service outside AWS to send traffic to"
+  default     = ""
+}
+
+variable "ssl_certificate_arn_render_test" {
+  description = "To enable HTTPS, the ARN of an SSL certificate created with ACM in us-east-1"
   default     = ""
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -98,7 +98,7 @@ variable "domain_name" {
   default     = ""
 }
 
-variable "api_remote_domain_name" {
+variable "api_remote_domain_name_test" {
   description = "The domain name for a service outside AWS to send traffic to"
   default     = ""
 }


### PR DESCRIPTION
Since my previous attempt (#930, #932) at making CloudFront point getmyvax.org at Render failed spectacularly, I'm trying this again on a separate test domain (render.getmyvax.org) so we don't have downtime. I think the main issue is just that Render needs DNS pointed directly at it first so it can validate that it's ok to respond to the hostname we're sending it.

Once Render validates, this will need to be followed up my a change to the Route53 record so it points to CloudFront instead.