### PR TITLE
Fuzzy match new bivalent vaccines properly

### DIFF
--- a/loader/src/utils.js
+++ b/loader/src/utils.js
@@ -549,40 +549,44 @@ module.exports = {
    */
   matchVaccineProduct(name) {
     const text = name.toLowerCase();
+    const isBa4Ba5 = /bivalent|omicron|ba\.\s?4|ba\.\s?5/i.test(text);
+
     if (/astra\s*zeneca/.test(text)) {
-      return VaccineProduct.astraZeneca;
+      return isBa4Ba5 ? undefined : VaccineProduct.astraZeneca;
     } else if (text.includes("moderna")) {
       if (/ages?\s+18( and up|\s*\+)/i.test(text)) {
-        return VaccineProduct.moderna;
+        return isBa4Ba5 ? VaccineProduct.modernaBa4Ba5 : VaccineProduct.moderna;
       } else if (/ages?\s+6\s*(m|months)\b/i.test(text)) {
-        return VaccineProduct.modernaAge0_5;
+        return isBa4Ba5 ? undefined : VaccineProduct.modernaAge0_5;
       } else if (/ages? 6\s?(-|through)\s?11/i.test(text)) {
-        return VaccineProduct.modernaAge6_11;
+        return isBa4Ba5 ? undefined : VaccineProduct.modernaAge6_11;
       } else if (/ped|child|age/i.test(text)) {
         // Possibly a pediatric variation we haven't seen, so return nothing to
         // trigger warnings so we can address it.
         return undefined;
       } else {
-        return VaccineProduct.moderna;
+        return isBa4Ba5 ? VaccineProduct.modernaBa4Ba5 : VaccineProduct.moderna;
       }
     } else if (/nova\s*vax/.test(text)) {
-      return VaccineProduct.novavax;
+      return isBa4Ba5 ? undefined : VaccineProduct.novavax;
     } else if (text.includes("comirnaty") || text.includes("pfizer")) {
       if (/ages?\s+12( and up|\s*\+)/i.test(text)) {
-        return VaccineProduct.pfizer;
+        return isBa4Ba5 ? VaccineProduct.pfizerBa4Ba5 : VaccineProduct.pfizer;
       } else if (/ages?\s+5|\b5\s?(-|through)\s?11\b/i.test(text)) {
-        return VaccineProduct.pfizerAge5_11;
+        return isBa4Ba5
+          ? VaccineProduct.pfizerBa4Ba5Age5_11
+          : VaccineProduct.pfizerAge5_11;
       } else if (/ages?\s+6\s*(m|months)\b/i.test(text)) {
-        return VaccineProduct.pfizerAge0_4;
+        return isBa4Ba5 ? undefined : VaccineProduct.pfizerAge0_4;
       } else if (/ped|child|age/i.test(text)) {
         // Possibly a pediatric variation we haven't seen, so return nothing to
         // trigger warnings so we can address it.
         return undefined;
       } else {
-        return VaccineProduct.pfizer;
+        return isBa4Ba5 ? VaccineProduct.pfizerBa4Ba5 : VaccineProduct.pfizer;
       }
     } else if (/janssen|johnson/.test(text)) {
-      return VaccineProduct.janssen;
+      return isBa4Ba5 ? undefined : VaccineProduct.janssen;
     }
 
     return undefined;

--- a/loader/test/utils.test.js
+++ b/loader/test/utils.test.js
@@ -238,10 +238,14 @@ describe("matchVaccineProduct", () => {
     [v.moderna, "Moderna Booster COVID-19 Vaccine"],
     [v.moderna, "Moderna COVID-19 Vaccine/Booster (Ages 18+)"],
 
+    [v.modernaBa4Ba5, "Moderna COVID-19 Vaccine (Ages 12+)/Bivalent Booster (Ages 18+)"],
+    [v.modernaBa4Ba5, "Moderna COVID-19, Bivalent Booster (Ages 18+)"],
+
     [v.modernaAge6_11, "Moderna COVID-19 Vaccine (ages 6-11 Primary, 18+ Booster)"],
     [v.modernaAge6_11, "Moderna Pediatric COVID-19 Vaccine (Ages 6 through 11)"],
 
     [v.modernaAge0_5, "Moderna Pediatric COVID-19 Vaccine (Ages 6 months - 5 years)"],
+    [v.modernaAge0_5, "Moderna Pediatric COVID-19 Vaccine (Ages 6 months through 5 years)"],
     [v.modernaAge0_5, "Moderna COVID-19 Vaccine (Ages 6m-5yrs)"],
 
     [v.pfizer, "Pfizer-BioNTech"],
@@ -249,11 +253,20 @@ describe("matchVaccineProduct", () => {
     [v.pfizer, "Pfizer-BioNTech COVID-19 Vaccine/Booster (Ages 12+)"],
     [v.pfizer, "Comirnaty COVID-19 Vaccine/Booster (Ages 12+)"],
 
+    [v.pfizerBa4Ba5, "Pfizer-BioNTech COVID-19 Vaccine/Bivalent Booster (Ages 12+)"],
+    [v.pfizerBa4Ba5, "Pfizer COVID-19, Bivalent Booster (Ages 12+)"],
+
     [v.pfizerAge5_11, "Pediatric-Pfizer (5-11)"],
     [v.pfizerAge5_11, "Pfizer COVID-19 Vaccine (Ages 5-11)"],
     [v.pfizerAge5_11, "Pfizer-BioNTech Pediatric COVID-19 Vaccine/Booster (Ages 5 - 11)"],
+    [v.pfizerAge5_11, "Pfizer-BioNTech Pediatric COVID-19 Vaccine/Booster (Ages 5 through 11)"],
 
     [v.pfizerAge0_4, "Pfizer-BioNTech Pediatric COVID-19 Vaccine (Ages 6 months - 4 years)"],
+    [v.pfizerAge0_4, "Pfizer-BioNTech Pediatric COVID-19 Vaccine (Ages 6 months through 4 years)"],
+    [v.pfizerAge0_4, "Pfizer-BioNTech COVID-19 Vaccine (Ages 6m-4yrs)"],
+
+    [v.novavax, "Novavax COVID-19 Vaccine (Ages 12+)"],
+    [v.novavax, "Novavax COVID-19 Vaccine 12+"],
 
     // Unpredicted pediatric types for Moderna/Pfizer
     [undefined, "Moderna Pediatric COVID Ages 3 - 9"],


### PR DESCRIPTION
This is kind of ugly, but attempts to handle new bivalent vaccines in a meaningful way when fuzzy matching (this mainly affects PrepMod, where we were conflating bivalent vaccines with normal ones).

Caught by the Anchorage i-Team.