### PR TITLE
Add more detailed tracing for Sentry

### DIFF
--- a/server/src/api/edge.ts
+++ b/server/src/api/edge.ts
@@ -243,11 +243,11 @@ export const update = async (req: AppRequest, res: Response): Promise<any> => {
   const result: any = { location: { action: null } };
   const source = data?.source || data?.availability?.source;
 
+  // FIXME: need to make this a single PG operation or add locks around it. It's
+  // possible for two concurrent updates to both try and create a location.
   const updateLocationSpan = startSpan({ op: "updateLocation" });
   let location: ProviderLocation;
   // await withSpan({ op: "updateLocation" }, async () => {
-  // FIXME: need to make this a single PG operation or add locks around it. It's
-  // possible for two concurrent updates to both try and create a location.
   if (data.id && UUID_PATTERN.test(data.id)) {
     location = await db.getLocationById(data.id, { includePrivate: true });
   }
@@ -302,12 +302,12 @@ export const update = async (req: AppRequest, res: Response): Promise<any> => {
       result.availability = operation;
     } catch (error) {
       if (error instanceof ApiError) {
-        sendError(res, error);
-        return false;
+        return sendError(res, error);
+        // return false;
       }
       if (error instanceof TypeError) {
-        sendError(res, error, 422);
-        return false;
+        return sendError(res, error, 422);
+        // return false;
       } else {
         throw error;
       }

--- a/server/src/api/edge.ts
+++ b/server/src/api/edge.ts
@@ -247,7 +247,6 @@ export const update = async (req: AppRequest, res: Response): Promise<any> => {
   // possible for two concurrent updates to both try and create a location.
   const updateLocationSpan = startSpan({ op: "updateLocation" });
   let location: ProviderLocation;
-  // await withSpan({ op: "updateLocation" }, async () => {
   if (data.id && UUID_PATTERN.test(data.id)) {
     location = await db.getLocationById(data.id, { includePrivate: true });
   }
@@ -275,12 +274,10 @@ export const update = async (req: AppRequest, res: Response): Promise<any> => {
     // relevant external ID we've seen for a location.
     await db.addExternalIds(location.id, data.external_ids);
   }
-  // });
   finishSpan(updateLocationSpan);
 
   if (data.availability) {
     const updateAvailabilitySpan = startSpan({ op: "updateAvailability " });
-    // const success = await withSpan({ op: "updateAvailability" }, async () => {
     // Accommodate old formats that sources might still be sending.
     // TODO: remove once loaders have all been migrated.
     if (data.availability.updated_at) {
@@ -303,18 +300,13 @@ export const update = async (req: AppRequest, res: Response): Promise<any> => {
     } catch (error) {
       if (error instanceof ApiError) {
         return sendError(res, error);
-        // return false;
       }
       if (error instanceof TypeError) {
         return sendError(res, error, 422);
-        // return false;
       } else {
         throw error;
       }
     }
-    // return true;
-    // });
-    // if (!success) return;
     finishSpan(updateAvailabilitySpan);
   }
 

--- a/server/src/api/edge.ts
+++ b/server/src/api/edge.ts
@@ -87,7 +87,7 @@ export async function listStream(
   // big result sets.
   let started = false;
   const startTime = Date.now();
-  const resultsIterator = await db.iterateLocationBatches({
+  const resultsIterator = db.iterateLocationBatches({
     includePrivate,
     where,
     values,

--- a/server/src/api/edge.ts
+++ b/server/src/api/edge.ts
@@ -2,7 +2,7 @@
 
 import { Request, Response } from "express";
 import { ProviderLocation } from "../interfaces";
-import { finishSpan, startSpan, withSpan } from "../tracing";
+import { finishSpan, startSpan } from "../tracing";
 import { dogstatsd } from "../datadog";
 import * as db from "../db";
 import { ApiError, AuthorizationError } from "../exceptions";

--- a/server/src/api/edge.ts
+++ b/server/src/api/edge.ts
@@ -1,6 +1,8 @@
 "use strict";
 
 import { Request, Response } from "express";
+import { ProviderLocation } from "../interfaces";
+import { withSpan } from "../tracing";
 import { dogstatsd } from "../datadog";
 import * as db from "../db";
 import { ApiError, AuthorizationError } from "../exceptions";
@@ -241,67 +243,75 @@ export const update = async (req: AppRequest, res: Response): Promise<any> => {
   const result: any = { location: { action: null } };
   const source = data?.source || data?.availability?.source;
 
-  // FIXME: need to make this a single PG operation or add locks around it. It's
-  // possible for two concurrent updates to both try and create a location.
-  let location;
-  if (data.id && UUID_PATTERN.test(data.id)) {
-    location = await db.getLocationById(data.id, { includePrivate: true });
-  }
-  if (!location && data.external_ids) {
-    location = await db.getLocationByExternalIds(data.external_ids, {
-      includePrivate: true,
-    });
-  }
-  if (!location) {
-    location = await db.createLocation(data, { source });
-    result.location.action = "created";
-  } else if (req.query.update_location) {
-    // Only update an existing location if explicitly requested to do so via
-    // querystring and if there is other data for it.
-    // (In most cases, we expect the DB will have manual updates that make it
-    // a better source of truth for locations than the source data, hence the
-    // need to opt in to updating here.)
-    const fields = Object.keys(data).filter((key) => key !== "availability");
-    if (fields.length > 1) {
-      await db.updateLocation(location, data, { source });
-      result.location.action = "updated";
+  let location: ProviderLocation;
+  await withSpan({ op: "updateLocation" }, async () => {
+    // FIXME: need to make this a single PG operation or add locks around it. It's
+    // possible for two concurrent updates to both try and create a location.
+    if (data.id && UUID_PATTERN.test(data.id)) {
+      location = await db.getLocationById(data.id, { includePrivate: true });
     }
-  } else if (data.external_ids?.length) {
-    // Otherwise just update the external IDs. This ensures we track every
-    // relevant external ID we've seen for a location.
-    await db.addExternalIds(location.id, data.external_ids);
-  }
+    if (!location && data.external_ids) {
+      location = await db.getLocationByExternalIds(data.external_ids, {
+        includePrivate: true,
+      });
+    }
+    if (!location) {
+      location = await db.createLocation(data, { source });
+      result.location.action = "created";
+    } else if (req.query.update_location) {
+      // Only update an existing location if explicitly requested to do so via
+      // querystring and if there is other data for it.
+      // (In most cases, we expect the DB will have manual updates that make it
+      // a better source of truth for locations than the source data, hence the
+      // need to opt in to updating here.)
+      const fields = Object.keys(data).filter((key) => key !== "availability");
+      if (fields.length > 1) {
+        await db.updateLocation(location, data, { source });
+        result.location.action = "updated";
+      }
+    } else if (data.external_ids?.length) {
+      // Otherwise just update the external IDs. This ensures we track every
+      // relevant external ID we've seen for a location.
+      await db.addExternalIds(location.id, data.external_ids);
+    }
+  });
 
   if (data.availability) {
-    // Accommodate old formats that sources might still be sending.
-    // TODO: remove once loaders have all been migrated.
-    if (data.availability.updated_at) {
-      data.availability.valid_at = data.availability.updated_at;
-      delete data.availability.updated_at;
-    }
-
-    promoteFromMeta(data.availability, "slots");
-    promoteFromMeta(data.availability, "capacity");
-    promoteFromMeta(data.availability, "available_count");
-    promoteFromMeta(data.availability, "products");
-    promoteFromMeta(data.availability, "doses");
-
-    try {
-      const operation = await db.updateAvailability(
-        location.id,
-        data.availability
-      );
-      result.availability = operation;
-    } catch (error) {
-      if (error instanceof ApiError) {
-        return sendError(res, error);
+    const success = await withSpan({ op: "updateAvailability" }, async () => {
+      // Accommodate old formats that sources might still be sending.
+      // TODO: remove once loaders have all been migrated.
+      if (data.availability.updated_at) {
+        data.availability.valid_at = data.availability.updated_at;
+        delete data.availability.updated_at;
       }
-      if (error instanceof TypeError) {
-        return sendError(res, error, 422);
-      } else {
-        throw error;
+
+      promoteFromMeta(data.availability, "slots");
+      promoteFromMeta(data.availability, "capacity");
+      promoteFromMeta(data.availability, "available_count");
+      promoteFromMeta(data.availability, "products");
+      promoteFromMeta(data.availability, "doses");
+
+      try {
+        const operation = await db.updateAvailability(
+          location.id,
+          data.availability
+        );
+        result.availability = operation;
+      } catch (error) {
+        if (error instanceof ApiError) {
+          sendError(res, error);
+          return false;
+        }
+        if (error instanceof TypeError) {
+          sendError(res, error, 422);
+          return false;
+        } else {
+          throw error;
+        }
       }
-    }
+      return true;
+    });
+    if (!success) return;
   }
 
   if (

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -19,7 +19,7 @@ import * as availabilityLog from "./availability-log";
 import { isDeepStrictEqual } from "util";
 import { minimumAgeForProducts } from "./vaccines";
 import { dogstatsd } from "./datadog";
-import { callWithSpan } from "./tracing";
+import { callWithSpan, finishSpan, startSpan } from "./tracing";
 
 // When locations are queried in batches (e.g. when iterating over extremely
 // large result sets), query this many records at a time.
@@ -87,7 +87,10 @@ export async function createLocation(
   data: any,
   { source = "unknown" } = {}
 ): Promise<ProviderLocation> {
-  data = callWithSpan(validateLocationInput, data, true);
+  const span = startSpan({ op: "validateLocationInput " });
+  data = validateLocationInput(data, true);
+  finishSpan(span);
+  // data = callWithSpan(validateLocationInput, data, true);
 
   const now = new Date();
   const sqlData: { [index: string]: string } = {
@@ -166,7 +169,10 @@ export async function updateLocation(
   data: any,
   { mergeSubfields = true, source = "unknown" } = {}
 ): Promise<void> {
-  data = callWithSpan(validateLocationInput, data);
+  const span = startSpan({ op: "validateLocationInput " });
+  data = validateLocationInput(data);
+  finishSpan(span);
+  // data = callWithSpan(validateLocationInput, data);
 
   const sqlData: any = { updated_at: new Date() };
 
@@ -585,7 +591,10 @@ export async function updateAvailability(
   id: string,
   data: AvailabilityInput
 ): Promise<{ action: string; locationId: string }> {
-  data = callWithSpan(validateAvailabilityInput, data);
+  const span = startSpan({ op: "validateAvailabilityInput " });
+  data = validateAvailabilityInput(data);
+  finishSpan(span);
+  // data = callWithSpan(validateAvailabilityInput, data);
   const {
     source,
     available = Availability.UNKNOWN,

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -19,6 +19,7 @@ import * as availabilityLog from "./availability-log";
 import { isDeepStrictEqual } from "util";
 import { minimumAgeForProducts } from "./vaccines";
 import { dogstatsd } from "./datadog";
+import { callWithSpan } from "./tracing";
 
 // When locations are queried in batches (e.g. when iterating over extremely
 // large result sets), query this many records at a time.
@@ -86,7 +87,7 @@ export async function createLocation(
   data: any,
   { source = "unknown" } = {}
 ): Promise<ProviderLocation> {
-  data = validateLocationInput(data, true);
+  data = callWithSpan(validateLocationInput, data, true);
 
   const now = new Date();
   const sqlData: { [index: string]: string } = {
@@ -165,7 +166,8 @@ export async function updateLocation(
   data: any,
   { mergeSubfields = true, source = "unknown" } = {}
 ): Promise<void> {
-  data = validateLocationInput(data);
+  data = callWithSpan(validateLocationInput, data);
+
   const sqlData: any = { updated_at: new Date() };
 
   for (let [key, value] of Object.entries(data)) {
@@ -583,7 +585,7 @@ export async function updateAvailability(
   id: string,
   data: AvailabilityInput
 ): Promise<{ action: string; locationId: string }> {
-  data = validateAvailabilityInput(data);
+  data = callWithSpan(validateAvailabilityInput, data);
   const {
     source,
     available = Availability.UNKNOWN,

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -240,12 +240,10 @@ export async function listLocations({
     }
 
     const locationIds = result.rows.map((r: any) => r.id);
-    const externalIds = await getExternalIdsByLocation(locationIds);
-    const availabilities = await getCurrentAvailabilityByLocation(
-      locationIds,
-      includePrivate,
-      sources
-    );
+    const [externalIds, availabilities] = await Promise.all([
+      getExternalIdsByLocation(locationIds),
+      getCurrentAvailabilityByLocation(locationIds, includePrivate, sources),
+    ]);
 
     return withSpan("joinRelatedRecords", () =>
       result.rows.map((row: any) => {

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -19,7 +19,7 @@ import * as availabilityLog from "./availability-log";
 import { isDeepStrictEqual } from "util";
 import { minimumAgeForProducts } from "./vaccines";
 import { dogstatsd } from "./datadog";
-import { callWithSpan, finishSpan, startSpan } from "./tracing";
+import { finishSpan, startSpan } from "./tracing";
 
 // When locations are queried in batches (e.g. when iterating over extremely
 // large result sets), query this many records at a time.

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -88,8 +88,11 @@ export async function createLocation(
   { source = "unknown" } = {}
 ): Promise<ProviderLocation> {
   const span = startSpan({ op: "validateLocationInput " });
-  data = validateLocationInput(data, true);
-  finishSpan(span);
+  try {
+    data = validateLocationInput(data, true);
+  } finally {
+    finishSpan(span);
+  }
   // data = callWithSpan(validateLocationInput, data, true);
 
   const now = new Date();
@@ -170,8 +173,11 @@ export async function updateLocation(
   { mergeSubfields = true, source = "unknown" } = {}
 ): Promise<void> {
   const span = startSpan({ op: "validateLocationInput " });
-  data = validateLocationInput(data);
-  finishSpan(span);
+  try {
+    data = validateLocationInput(data);
+  } finally {
+    finishSpan(span);
+  }
   // data = callWithSpan(validateLocationInput, data);
 
   const sqlData: any = { updated_at: new Date() };
@@ -592,8 +598,11 @@ export async function updateAvailability(
   data: AvailabilityInput
 ): Promise<{ action: string; locationId: string }> {
   const span = startSpan({ op: "validateAvailabilityInput " });
-  data = validateAvailabilityInput(data);
-  finishSpan(span);
+  try {
+    data = validateAvailabilityInput(data);
+  } finally {
+    finishSpan(span);
+  }
   // data = callWithSpan(validateAvailabilityInput, data);
   const {
     source,

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -19,7 +19,7 @@ import * as availabilityLog from "./availability-log";
 import { isDeepStrictEqual } from "util";
 import { minimumAgeForProducts } from "./vaccines";
 import { dogstatsd } from "./datadog";
-import { withSpan } from "./tracing";
+import { startSpan, finishSpan, withSpan } from "./tracing";
 
 // When locations are queried in batches (e.g. when iterating over extremely
 // large result sets), query this many records at a time.
@@ -206,65 +206,72 @@ export async function listLocations({
   values = [] as any[],
   sources = [] as string[],
 } = {}): Promise<ProviderLocation[]> {
-  let fields = providerLocationFields;
+  return withSpan("db.listLocations", async () => {
+    let fields = providerLocationFields;
 
-  if (includePrivate) {
-    fields = fields.concat(providerLocationPrivateFields);
-  } else {
-    where.push(`pl.is_public = true`);
-  }
+    if (includePrivate) {
+      fields = fields.concat(providerLocationPrivateFields);
+    } else {
+      where.push(`pl.is_public = true`);
+    }
 
-  // Reformat fields as select expressions to get the right data back.
-  fields = fields
-    .map((name) => `pl.${name}`)
-    .map((name) => (name === "pl.position" ? selectSqlPoint(name) : name));
+    // Reformat fields as select expressions to get the right data back.
+    fields = fields
+      .map((name) => `pl.${name}`)
+      .map((name) => (name === "pl.position" ? selectSqlPoint(name) : name));
 
-  let result;
-  try {
-    result = await db.raw(
-      `
+    let result: any;
+    try {
+      result = await db.raw<any>(
+        `
       SELECT ${fields.join(", ")}
       FROM provider_locations pl
       ${where.length ? `WHERE ${where.join(" AND ")}` : ""}
       ORDER BY pl.created_at ASC, pl.id ASC
       ${limit ? `LIMIT ${limit}` : ""}
       `,
-      values || []
-    );
-  } catch (error) {
-    // If it was just a malformed UUID, treat that like no results.
-    if (error.routine === "string_to_uuid") return [];
+        values || []
+      );
+    } catch (error) {
+      // If it was just a malformed UUID, treat that like no results.
+      if (error.routine === "string_to_uuid") return [];
 
-    throw error;
-  }
-
-  const locationIds = result.rows.map((r: any) => r.id);
-  const externalIds = await getExternalIdsByLocation(locationIds);
-  const availabilities = await getCurrentAvailabilityByLocation(
-    locationIds,
-    includePrivate,
-    sources
-  );
-
-  return result.rows.map((row: any) => {
-    row.external_ids = externalIds[row.id] || [];
-    row.availability = availabilities.get(row.id);
-
-    if (row.availability) {
-      delete row.availability.id;
-      delete row.availability.location_id;
-      delete row.availability.is_public;
-      delete row.availability.rank;
-
-      if (row.minimum_age_months != null && row.availability.products?.length) {
-        row.availability.minimum_eligible_age_months = Math.max(
-          row.minimum_age_months,
-          minimumAgeForProducts(row.availability.products)
-        );
-      }
+      throw error;
     }
 
-    return row;
+    const locationIds = result.rows.map((r: any) => r.id);
+    const externalIds = await getExternalIdsByLocation(locationIds);
+    const availabilities = await getCurrentAvailabilityByLocation(
+      locationIds,
+      includePrivate,
+      sources
+    );
+
+    return withSpan("joinRelatedRecords", () =>
+      result.rows.map((row: any) => {
+        row.external_ids = externalIds[row.id] || [];
+        row.availability = availabilities.get(row.id);
+
+        if (row.availability) {
+          delete row.availability.id;
+          delete row.availability.location_id;
+          delete row.availability.is_public;
+          delete row.availability.rank;
+
+          if (
+            row.minimum_age_months != null &&
+            row.availability.products?.length
+          ) {
+            row.availability.minimum_eligible_age_months = Math.max(
+              row.minimum_age_months,
+              minimumAgeForProducts(row.availability.products)
+            );
+          }
+        }
+
+        return row;
+      })
+    );
   });
 }
 
@@ -548,6 +555,7 @@ export async function getCurrentAvailabilityByLocation(
     })
     .orderBy(["location_id", { column: "valid_at", order: "desc" }]);
 
+  const mergeSpan = startSpan({ op: "mergeAvailabilities" });
   const result = new Map<string, LocationAvailability>();
   const groups = new Map<string, LocationAvailability[]>();
   for (const row of rows) {
@@ -559,6 +567,7 @@ export async function getCurrentAvailabilityByLocation(
   for (const [id, rows] of groups.entries()) {
     result.set(id, mergeAvailabilities(rows));
   }
+  finishSpan(mergeSpan);
 
   return result;
 }
@@ -608,6 +617,7 @@ export async function updateAvailability(
     .where({ location_id: id, source })
     .first();
 
+  const changeSpan = startSpan({ op: "determineChanges" });
   let result;
   let changed_at;
   if (existingAvailability) {
@@ -671,6 +681,7 @@ export async function updateAvailability(
         };
       }
     }
+    finishSpan(changeSpan);
 
     loggableUpdate = { source, ...updateData };
     const rowCount = await updateQuery.update(updateData);

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -19,7 +19,7 @@ import * as availabilityLog from "./availability-log";
 import { isDeepStrictEqual } from "util";
 import { minimumAgeForProducts } from "./vaccines";
 import { dogstatsd } from "./datadog";
-import { finishSpan, startSpan } from "./tracing";
+import { withSpan } from "./tracing";
 
 // When locations are queried in batches (e.g. when iterating over extremely
 // large result sets), query this many records at a time.
@@ -87,13 +87,7 @@ export async function createLocation(
   data: any,
   { source = "unknown" } = {}
 ): Promise<ProviderLocation> {
-  const span = startSpan({ op: "validateLocationInput " });
-  try {
-    data = validateLocationInput(data, true);
-  } finally {
-    finishSpan(span);
-  }
-  // data = callWithSpan(validateLocationInput, data, true);
+  data = withSpan("validate", () => validateLocationInput(data, true));
 
   const now = new Date();
   const sqlData: { [index: string]: string } = {
@@ -172,13 +166,7 @@ export async function updateLocation(
   data: any,
   { mergeSubfields = true, source = "unknown" } = {}
 ): Promise<void> {
-  const span = startSpan({ op: "validateLocationInput " });
-  try {
-    data = validateLocationInput(data);
-  } finally {
-    finishSpan(span);
-  }
-  // data = callWithSpan(validateLocationInput, data);
+  data = withSpan("validate", () => validateLocationInput(data));
 
   const sqlData: any = { updated_at: new Date() };
 
@@ -597,13 +585,7 @@ export async function updateAvailability(
   id: string,
   data: AvailabilityInput
 ): Promise<{ action: string; locationId: string }> {
-  const span = startSpan({ op: "validateAvailabilityInput " });
-  try {
-    data = validateAvailabilityInput(data);
-  } finally {
-    finishSpan(span);
-  }
-  // data = callWithSpan(validateAvailabilityInput, data);
+  data = withSpan("validate", () => validateAvailabilityInput(data));
   const {
     source,
     available = Availability.UNKNOWN,

--- a/server/src/tracing.ts
+++ b/server/src/tracing.ts
@@ -23,7 +23,7 @@ interface SpanOptions extends SpanContext {
 // on the hub's client, but there are a lot of guard clauses anywhere the client
 // gets used internally, and I'm not sure how reliable it is for this use case.
 // We want to wrap up before the transaction finishes, not when a client that
-// may-or-may-not exist depending on configuring is finishing a transaction.
+// may-or-may-not exist depending on configuration is finishing a transaction.
 // (Also, the transaction's `_hub` is a nullable private property, so it would
 // still be hacky to grab it and add a listener anyway.)
 interface PatchedTransaction extends Transaction {

--- a/server/src/tracing.ts
+++ b/server/src/tracing.ts
@@ -85,6 +85,7 @@ export function finishSpan(span: Span, timestamp?: number): void {
  * const id = await withSpan({ op: "saveData" }, async (span) => {
  *   const id = await saveData(data);
  *   await updateSomeRelatedRecord(id, otherData);
+ *   return id;
  * });
  */
 export function withSpan<T extends (span?: Span) => any>(

--- a/server/src/tracing.ts
+++ b/server/src/tracing.ts
@@ -59,7 +59,7 @@ export function startSpan(options: SpanOptions): Span {
     setTimeout(() => {
       cancelSpan(newSpan, "deadline_exceeded");
     }, timeout).unref();
-  } else if (newSpan.transaction) {
+  } else if (newSpan.transaction && newSpan.transaction !== newSpan) {
     // FIXME: newer Sentry has an event for this: "finishTransaction" emitted
     // on the hub's client:
     // - Code: https://github.com/getsentry/sentry-javascript/blob/ba99e7cdf725725e5a1b99e9d814353dbb3ae2b6/packages/core/src/tracing/transaction.ts#L144-L147

--- a/server/src/tracing.ts
+++ b/server/src/tracing.ts
@@ -32,7 +32,7 @@ interface SpanOptions extends SpanContext {
  * with a reason.
  *
  * More on why spans need canceling:
- * https://github.com/getsentry/sentry-javascript/issues/4165
+ * https://github.com/getsentry/sentry-javascript/issues/4165#issuecomment-971424754
  */
 export function startSpan(options: SpanOptions): Span {
   let { parentSpan, timeout, ...spanOptions } = options;

--- a/server/src/tracing.ts
+++ b/server/src/tracing.ts
@@ -216,7 +216,7 @@ export function withSpan<T extends (span?: Span) => any>(
     throw error;
   }
 
-  if ("then" in callbackResult) {
+  if (callbackResult && "then" in callbackResult) {
     return callbackResult.then(
       (result: any) => {
         finishSpan(span);

--- a/server/src/tracing.ts
+++ b/server/src/tracing.ts
@@ -116,7 +116,7 @@ export function startSpan(options: SpanOptions): Span {
   let scope;
   if (!parentSpan) {
     scope = Sentry.getCurrentHub().getScope();
-    parentSpan = scope.getSpan();
+    parentSpan = scope?.getSpan();
   }
 
   let newSpan: Span;

--- a/server/src/tracing.ts
+++ b/server/src/tracing.ts
@@ -1,0 +1,142 @@
+/**
+ * Tools for instrumenting code with traces. This is mainly designed to support
+ * Sentry's tracing features, but could be expanded support other approaches,
+ * like OpenTelemetry.
+ */
+
+import * as Sentry from "@sentry/node";
+import type { Span } from "@sentry/tracing";
+import type { SpanContext } from "@sentry/types";
+export type { Span } from "@sentry/tracing";
+
+interface SpanOptions extends SpanContext {
+  parentSpan?: Span;
+}
+
+/**
+ * Start a tracing span. The returned span should be explicitly ended with
+ * `finishSpan`. The created span will be a child of whatever span is currently
+ * active (and then become the current span itself), or if there is no current
+ * span or transaction, this will start one for you.
+ *
+ * Alternatively, can explicitly pass an actual span object to be the parent:
+ * `startSpan({ parentSpan: yourSpan })`. In this case, the new span won't
+ * automatically become the global "current" span.
+ */
+export function startSpan(options: SpanOptions): Span {
+  let { parentSpan, ...spanOptions } = options;
+
+  let scope;
+  if (!parentSpan) {
+    scope = Sentry.getCurrentHub().getScope();
+    parentSpan = scope.getSpan();
+  }
+
+  let newSpan: Span;
+  if (parentSpan) {
+    newSpan = parentSpan.startChild(spanOptions);
+  } else {
+    newSpan = Sentry.startTransaction(spanOptions as any);
+  }
+
+  // If we retrieved the span from the scope, update the scope.
+  if (scope) {
+    scope.setSpan(newSpan);
+  }
+
+  return newSpan;
+}
+
+/**
+ * Finish a tracing span. This will also replace the global "current" span with
+ * this span's parent (if it has a parent).
+ */
+export function finishSpan(span: Span, timestamp?: number): void {
+  span.finish(timestamp);
+
+  let parent;
+  if (span.parentSpanId) {
+    parent = span.spanRecorder?.spans?.find(
+      (s) => s.spanId === span.parentSpanId
+    );
+  }
+
+  const scope = Sentry.getCurrentHub().getScope();
+  if (scope.getSpan() === span) {
+    scope.setSpan(parent);
+  }
+}
+
+/**
+ * Create a new span, run the provided function inside of it, and finish the
+ * span afterward. The function can be async, in which case this will return an
+ * awaitable promise.
+ *
+ * The provided function can take the span as the first argument, in case it
+ * needs to modify the span in some way. If the function returns a value,
+ * `withSpan` will return that value as well.
+ *
+ * @example
+ * withSpan({ op: "validateData" }, (span) => {
+ *   doSomeDataValidation();
+ * });
+ *
+ * let data = { some: "data" };
+ * const id = await withSpan({ op: "saveData" }, async (span) => {
+ *   const id = await saveData(data);
+ *   await updateSomeRelatedRecord(id, otherData);
+ * });
+ */
+export function withSpan<T extends (span?: Span) => any>(
+  options: SpanOptions,
+  callback: T
+): ReturnType<T> {
+  const span = startSpan(options);
+
+  let callbackResult;
+  try {
+    callbackResult = callback(span);
+  } catch (error) {
+    finishSpan(span);
+    throw error;
+  }
+
+  if ("then" in callbackResult && "finally" in callbackResult) {
+    return callbackResult.finally(() => finishSpan(span));
+  } else {
+    finishSpan(span);
+    return callbackResult;
+  }
+}
+
+/**
+ * Wrap a function so that it is always called with a span (named the same as
+ * the function). Keeps typings of the original function intact.
+ *
+ * @example
+ * function privateDoSomeStuff(arg1, arg2) { ... }
+ * export const doSomeStuff = wrapWithSpan(privateDoSomeStuff);
+ */
+export function wrapWithSpan<T extends (...x: any) => any>(callable: T): T {
+  const options = { op: callable.name };
+  // @ts-expect-error Cannot figure out how to type this correctly. :(
+  return (...args: any) => withSpan<T>(options, () => callable(...args));
+}
+
+/**
+ * Shortcut for `withSpan` if you are only wrapping a single function. Uses the
+ * function's name as the span's name.
+ *
+ * @example
+ * // This shortcut:
+ * callWithSpan(someFunction, arg1, arg)
+ * // Is equivalent to:
+ * withSpan({ op: "someFunction" }, () => someFunction(arg1, arg2))
+ */
+export function callWithSpan<T extends (...x: any) => any>(
+  callable: T,
+  ...args: Parameters<T>
+): ReturnType<T> {
+  // @ts-expect-error Cannot figure out how to type this correctly. :(
+  return withSpan({ op: callable.name }, () => callable(...args));
+}

--- a/server/test/support/globalSetup.ts
+++ b/server/test/support/globalSetup.ts
@@ -1,8 +1,11 @@
+import * as Sentry from "@sentry/node";
 import { knex } from "knex";
 import { loadDbConfig } from "../../src/config";
 import { clearDatabase } from "./database-core";
 
 module.exports = async () => {
+  Sentry.init({ enabled: false });
+
   const testDb = knex(loadDbConfig());
   await clearDatabase(testDb);
   await testDb.destroy();


### PR DESCRIPTION
This uses Sentry's tracing support to add some more spans around various operations (mostly in the update path) so we get more detailed traces. There's a lot "seems like it should be built in" utility tooling I had to write here, which was a bit disappointing.

It’s messy, and makes some of our code more complex (returning early is hard, as you can see in the “updateAvailability” route handler), and I’m not 100% sure this was totally worthwhile. Gonna let it sit for a while. May throw it out. 🤷 

Before:
![Screen Shot 2022-09-15 at 12 25 16 PM](https://user-images.githubusercontent.com/74178/190492841-8469e9c5-4080-450f-8367-d0cf794112c4.png)

After:
![Screen Shot 2022-09-15 at 12 25 35 PM](https://user-images.githubusercontent.com/74178/190492866-0ac616f0-2e63-4ed2-adab-f656508fa575.png)