### PR TITLE
Fix broken autoscaling configuration in Terraform

### DIFF
--- a/terraform/auto_scaling.tf
+++ b/terraform/auto_scaling.tf
@@ -42,7 +42,7 @@ resource "aws_appautoscaling_policy" "down" {
     metric_aggregation_type = "Maximum"
 
     step_adjustment {
-      metric_interval_lower_bound = 0
+      metric_interval_upper_bound = 0
       scaling_adjustment          = -1
     }
   }

--- a/terraform/deprecated/auto_scaling.tf
+++ b/terraform/deprecated/auto_scaling.tf
@@ -21,7 +21,7 @@ resource "aws_appautoscaling_policy" "up" {
     metric_aggregation_type = "Maximum"
 
     step_adjustment {
-      metric_interval_lower_bound = 0
+      metric_interval_upper_bound = 0
       scaling_adjustment          = 1
     }
   }


### PR DESCRIPTION
This is pretty subtle! After turning off the loaders in AWS today (#941), I expected the API to scale down to its minimum, but it did not. At first I thought something must somehow still be sending it data or reaching it for queries, but no, it's actually because we had a lower bound instead of an upper bound set on the downscaling (clearly a copy-paste error). This fixes it and also updates the deprecated configurations so someone referencing them won't make the same mistake.

Hilariously, I had noticed long ago that the API service rarely seemed to scale down (I guess it was actually *never*), but just assumed that was because the time interval it evaluated things over was too long. I clearly should have made more noise about it at the time. (File under: another way the simpler config options in Render help avoid dumb mistakes.)