### PR TITLE
Move nightly snapshot closer to midnight UTC

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -72,7 +72,7 @@ services:
   - name: "Daily Data Snapshot"
     region: oregon
     type: cron
-    schedule: "0 5 * * *"
+    schedule: "0 1 * * *"
     # The main bottleneck on this job is actually uploading to S3; even minimal
     # CPU/memory don't impact overall run time.
     plan: starter


### PR DESCRIPTION
Out of an abundance of caution, we've been waiting until 5am UTC to archive the previous day's data. That's probably a lot longer than we really need to wait, though, so this moves it up to 1am UTC, making our archived data in S3 show up in a more timely fashion and (for everything except logs) more accurately reflect what the DB looked like at the end of the day.