### PR TITLE
Remove daily data snapshot task from AWS

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -121,16 +121,16 @@ module "api_task" {
 # The data_snapshot_log_* resources are associated with a task that no longer
 # runs, but we are preserving the logs for a little while longer.
 resource "aws_cloudwatch_log_group" "data_snapshot_log_group" {
-  name              = "/ecs/${module.daily_data_snapshot_task.name}"
+  name              = "/ecs/daily-data-snapshot"
   retention_in_days = 30
 
   tags = {
-    Name = module.daily_data_snapshot_task.name
+    Name = "daily-data-snapshot"
   }
 }
 
 resource "aws_cloudwatch_log_stream" "data_snapshot_log_stream" {
-  name           = "${module.daily_data_snapshot_task.name}-log-stream"
+  name           = "daily-data-snapshot-log-stream"
   log_group_name = aws_cloudwatch_log_group.data_snapshot_log_group.name
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -112,14 +112,6 @@ variable "data_snapshot_s3_bucket" {
   default     = "univaf-data-snapshots"
 }
 
-variable "data_snapshot_aws_key_id" {
-  sensitive = true
-}
-
-variable "data_snapshot_aws_secret_key" {
-  sensitive = true
-}
-
 variable "datadog_api_key" {
   sensitive = true
 }


### PR DESCRIPTION
The snapshot task has been suspended for a few days with no issues, so I think it’s time to delete it entirely.