### PR TITLE
Support bivalent vaccines at H-E-B

### DIFF
--- a/loader/src/sources/heb/index.js
+++ b/loader/src/sources/heb/index.js
@@ -80,7 +80,7 @@ async function getData(states) {
       });
       return formatted;
     })
-    .filter((location) => states.includes(location.state));
+    .filter((location) => states.includes(location?.state));
 }
 
 function formatAvailability(openSlots) {

--- a/loader/src/sources/heb/index.js
+++ b/loader/src/sources/heb/index.js
@@ -23,15 +23,52 @@ const { assertSchema } = require("../../schema-validation");
 const API_URL =
   "https://heb-ecom-covid-vaccine.hebdigital-prd.com/vaccine_locations.json";
 
-// Maps H-E-B product names to our product names.
-const PRODUCT_NAMES = {
-  pfizer: VaccineProduct.pfizer,
-  moderna: VaccineProduct.moderna,
-  // NOTE: the naming progression for Moderna is different than Pfizer.
-  pediatric_moderna: VaccineProduct.modernaAge0_5,
-  janssen: VaccineProduct.janssen,
-  pediatric_pfizer: VaccineProduct.pfizerAge5_11,
-  ultra_pediatric_pfizer: VaccineProduct.pfizerAge0_4,
+// The way this works is a little funky. Locations list an array of
+// `availableImmunizations`, which are strings, and map to the keys here.
+// Locations also list slot groups, which each list a `manufacturer`.
+// These objects join the values of those fields to our internal product types.
+const IMMUNIZATION_TYPES = {
+  Flu: {
+    manufacturer: null,
+    product: null,
+  },
+  "COVID-19 Pfizer": {
+    manufacturer: "pfizer",
+    product: VaccineProduct.pfizer,
+  },
+  "COVID-19 Pediatric_Pfizer": {
+    manufacturer: "pediatric_pfizer",
+    product: VaccineProduct.pfizerAge5_11,
+  },
+  "COVID-19 Pfizer_Updated_Booster": {
+    manufacturer: "pfizer",
+    product: VaccineProduct.pfizerBa4Ba5,
+  },
+  "COVID-19 Moderna_Updated_Booster": {
+    manufacturer: "moderna",
+    product: VaccineProduct.modernaBa4Ba5,
+  },
+  "COVID-19 Moderna": {
+    manufacturer: "moderna",
+    product: VaccineProduct.moderna,
+  },
+  "COVID-19 Pediatric_Moderna": {
+    manufacturer: "pediatric_moderna",
+    product: VaccineProduct.modernaAge0_5,
+  },
+  "COVID-19 Novavax": {
+    // We haven't seen a "manufacturer" field with this, so it's a guess.
+    manufacturer: "novavax",
+    product: VaccineProduct.novavax,
+  },
+  "COVID-19 Ultra_Pediatric_Pfizer": {
+    manufacturer: "ultra_pediatric_pfizer",
+    product: VaccineProduct.pfizerAge0_4,
+  },
+  "COVID-19 Janssen": {
+    manufacturer: "janssen",
+    product: VaccineProduct.janssen,
+  },
 };
 
 const warn = createWarningLogger("heb");
@@ -92,33 +129,71 @@ function formatAvailability(openSlots) {
 }
 
 /**
- * H-E-B includes "other" products in their list
- * of available vaccine types. Likely a flu vaccine /
- * not relevant for covid vaccine scheduling.
+ * Given an array of slot detail objects and the immunizations available at a
+ * location, produce an array of product types that are available.
+ *
+ * This is a little complex, some locations have an `availableImmunizations`
+ * array of strings that identify the products on offer. Many (not all)
+ * locations with open slots also have a `slotDetails` array of objects, where
+ * each entry lists the available slot count for a given `manufacturer`. The
+ * manufacturer isn't really a manufacturer, but just an older, slightly more
+ * generic way of identifying the product (critically, it does not differ
+ * between original and bivalent vaccines). If a variety of vaccines can be
+ * given a slot, the manufacturer is "multiple". If the slots are for non-COVID
+ * vaccines, the manufacturer is "other". If `availableImmunizations` is set,
+ * this maps the manufacturer for each slot to the values in that list. If not,
+ * this maps the manufacturer to the whole set of known values.
+ *
+ * @param {any[]} [slots]
+ * @param {string[]} [availableImmunizations]
+ * @returns {string[]}
  */
-function formatAvailableProducts(raw) {
-  if (!raw) return undefined;
+function formatAvailableProducts(slots, availableImmunizations) {
+  if (!slots) return undefined;
 
-  const formatted = raw
-    .map((value) => {
-      const productType = value.manufacturer.toLowerCase();
-      const formatted = PRODUCT_NAMES[productType];
-      // "other" denotes non-COVID vaccines, like the flu vaccine.
-      // "multiple" denotes more than one possible vaccine in a time slot.
-      // Unfortunately, there doesn't seem to be a way to get details without
-      // making an additional call for each location, which we don't want to
-      // do. On the other hand, we can get usually get the list of products from
-      // the CDC, so this is probably OK.
-      if (productType !== "other" && productType !== "multiple" && !formatted) {
-        warn(`Unknown product type`, value.manufacturer, true);
-      }
-      if (value.openAppointmentSlots > 0) {
+  // Convert the location-level availableImmunizations field to a list of
+  // objects with manufacturer and product code mappings.
+  let availableTypes;
+  if (availableImmunizations?.length) {
+    availableTypes = availableImmunizations
+      .map((key) => {
+        if (!Object.hasOwn(IMMUNIZATION_TYPES, key)) {
+          warn(`Unknown immunization type: ${key}`);
+        } else if (IMMUNIZATION_TYPES[key].product) {
+          return IMMUNIZATION_TYPES[key];
+        }
+      })
+      .filter(Boolean);
+  }
+
+  const formatted = slots
+    .flatMap((slot) => {
+      const manufacturer = slot.manufacturer.toLowerCase();
+      if (manufacturer === "other" || slot.openAppointmentSlots <= 0) {
+        // "other" denotes non-COVID vaccines, like the flu.
+        return [];
+      } else if (manufacturer === "multiple") {
+        return availableTypes.map((type) => type.product);
+      } else {
+        const types = availableTypes || Object.values(IMMUNIZATION_TYPES);
+        const formatted = types
+          .filter((type) => type.manufacturer === manufacturer)
+          .map((type) => type.product);
+
+        if (!formatted.length) {
+          if (availableTypes) {
+            warn(`No available products match manufacturer: "${manufacturer}"`);
+          } else {
+            warn(`Unknown manufacturer: "${manufacturer}"`);
+          }
+        }
+
         return formatted;
       }
     })
     .filter(Boolean);
 
-  return formatted.length ? formatted : undefined;
+  return formatted.length ? [...new Set(formatted)] : undefined;
 }
 
 // API data for each location should look like this. The schema is fairly strict
@@ -165,6 +240,11 @@ const hebLocationSchema = {
         additionalProperties: false,
       },
     },
+    availableImmunizations: {
+      type: "array",
+      nullable: true,
+      items: { type: "string", minLength: 1 },
+    },
   },
   additionalProperties: false,
 };
@@ -199,7 +279,10 @@ function formatLocation(data, checkedAt, validAt) {
       is_public: true,
       available: formatAvailability(data.openAppointmentSlots),
       available_count: data.openAppointmentSlots,
-      products: formatAvailableProducts(data.slotDetails),
+      products: formatAvailableProducts(
+        data.slotDetails,
+        data.availableImmunizations
+      ),
     },
   };
 }

--- a/loader/test/fixtures/nock/h-e-b_should_output_valid_data.json
+++ b/loader/test/fixtures/nock/h-e-b_should_output_valid_data.json
@@ -2,11 +2,203 @@
     {
         "scope": "https://heb-ecom-covid-vaccine.hebdigital-prd.com:443",
         "method": "GET",
-        "path": "/vaccine_locations.json?v=365490625576.8615",
+        "path": "/vaccine_locations.json?v=790016882856.6163",
         "body": "",
         "status": 200,
         "response": {
             "locations": [
+                {
+                    "zip": "78654",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h6P0000004EAwQAM",
+                    "type": "offsite",
+                    "street": "177 Broadmoor",
+                    "storeNumber": null,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 162,
+                            "openAppointmentSlots": 162,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 162,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 162,
+                    "name": "H-E-B Hosted City of Meadowlakes-Totten Hall",
+                    "longitude": null,
+                    "latitude": null,
+                    "fluUrl": "",
+                    "city": "Marble Falls",
+                    "availableImmunizations": [
+                        "Flu"
+                    ]
+                },
+                {
+                    "zip": "78654",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h6P0000004EAmQAM",
+                    "type": "offsite",
+                    "street": "1101 Bluebonnet Drive",
+                    "storeNumber": null,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 89,
+                            "openAppointmentSlots": 89,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 89,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 89,
+                    "name": "H-E-B Hosted First United Methodist Church",
+                    "longitude": null,
+                    "latitude": null,
+                    "fluUrl": "",
+                    "city": "Marble Falls",
+                    "availableImmunizations": [
+                        "Flu"
+                    ]
+                },
+                {
+                    "zip": "78643",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h6P000000064xQAA",
+                    "type": "offsite",
+                    "street": "200 Sunrise Drive",
+                    "storeNumber": null,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 43,
+                            "openAppointmentSlots": 43,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 43,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 43,
+                    "name": "H-E-B Hosted Vaccine Clinic at Sunrise Beach VFD",
+                    "longitude": null,
+                    "latitude": null,
+                    "fluUrl": "",
+                    "city": "Sunrise Beach",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
+                },
+                {
+                    "zip": "79602",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h6P0000004EGBQA2",
+                    "type": "offsite",
+                    "street": "2758 Jeanette St.",
+                    "storeNumber": null,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 8,
+                            "openAppointmentSlots": 8,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 8,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 8,
+                    "name": "2022-2023 Hendrick Home for Children - Flu Clinic",
+                    "longitude": null,
+                    "latitude": null,
+                    "fluUrl": "",
+                    "city": "Abilene",
+                    "availableImmunizations": [
+                        "Flu"
+                    ]
+                },
+                {
+                    "zip": "",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h6P0000004EKmQAM",
+                    "type": "offsite",
+                    "street": "",
+                    "storeNumber": null,
+                    "state": "",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 4,
+                            "openAppointmentSlots": 4,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 4,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 4,
+                    "name": "2022 Groves Elementary",
+                    "longitude": null,
+                    "latitude": null,
+                    "fluUrl": "",
+                    "city": "",
+                    "availableImmunizations": [
+                        "Flu"
+                    ]
+                },
+                {
+                    "zip": "78639",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h6P0000004EO0QAM",
+                    "type": "offsite",
+                    "street": "1136 RM 1431",
+                    "storeNumber": null,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 44,
+                            "openAppointmentSlots": 44,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 44,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 44,
+                    "name": "H-E-B Hosted Kingsland Community Church",
+                    "longitude": null,
+                    "latitude": null,
+                    "fluUrl": "",
+                    "city": "Kingsland",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
+                },
+                {
+                    "zip": "78654",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h6P0000004ENvQAM",
+                    "type": "offsite",
+                    "street": "1803 Hwy 1431 West",
+                    "storeNumber": null,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 27,
+                            "openAppointmentSlots": 27,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 27,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 27,
+                    "name": "H-E-B Hosted St Peter's Lutheran Church",
+                    "longitude": null,
+                    "latitude": null,
+                    "fluUrl": "",
+                    "city": "Marble Falls",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
+                },
                 {
                     "zip": "78664-4677",
                     "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudGQAS",
@@ -16,30 +208,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 116,
-                            "openAppointmentSlots": 116,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 143,
-                            "openAppointmentSlots": 143,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 114,
-                            "openAppointmentSlots": 114,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 27,
+                            "openAppointmentSlots": 27,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 373,
+                    "openTimeslots": 27,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 373,
+                    "openAppointmentSlots": 27,
                     "name": "Round Rock H-E-B plus!",
                     "longitude": -97.65978,
                     "latitude": 30.5177,
                     "fluUrl": "",
-                    "city": "ROUND ROCK"
+                    "city": "ROUND ROCK",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "76574-7059",
@@ -50,30 +238,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 79,
-                            "openAppointmentSlots": 79,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 80,
-                            "openAppointmentSlots": 80,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 77,
-                            "openAppointmentSlots": 77,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 321,
+                            "openAppointmentSlots": 321,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 236,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 236,
+                    "openTimeslots": 283,
+                    "openFluTimeslots": 38,
+                    "openFluAppointmentSlots": 38,
+                    "openAppointmentSlots": 283,
                     "name": "Taylor H-E-B",
                     "longitude": -97.4167,
                     "latitude": 30.6007,
-                    "fluUrl": "",
-                    "city": "TAYLOR"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3oQAE",
+                    "city": "TAYLOR",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer"
+                    ]
                 },
                 {
                     "zip": "78654-4902",
@@ -84,30 +267,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 5,
-                            "openAppointmentSlots": 5,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 56,
-                            "openAppointmentSlots": 56,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 4,
-                            "openAppointmentSlots": 4,
-                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                            "openTimeslots": 201,
+                            "openAppointmentSlots": 201,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 65,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 65,
+                    "openTimeslots": 190,
+                    "openFluTimeslots": 11,
+                    "openFluAppointmentSlots": 11,
+                    "openAppointmentSlots": 190,
                     "name": "Marble Falls H-E-B",
                     "longitude": -98.27972,
                     "latitude": 30.58301,
-                    "fluUrl": "",
-                    "city": "MARBLE FALLS"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF1mQAE",
+                    "city": "MARBLE FALLS",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78660-3153",
@@ -118,30 +296,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 135,
-                            "openAppointmentSlots": 135,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 119,
-                            "openAppointmentSlots": 119,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 48,
-                            "openAppointmentSlots": 48,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 1122,
+                            "openAppointmentSlots": 1122,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 302,
+                    "openTimeslots": 1122,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 302,
+                    "openAppointmentSlots": 1122,
                     "name": "Wells Branch H-E-B",
                     "longitude": -97.66419,
                     "latitude": 30.44263,
                     "fluUrl": "",
-                    "city": "PFLUGERVILLE"
+                    "city": "PFLUGERVILLE",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna"
+                    ]
                 },
                 {
                     "zip": "78664-7186",
@@ -152,30 +326,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 38,
-                            "openAppointmentSlots": 38,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 39,
-                            "openAppointmentSlots": 39,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 6,
-                            "openAppointmentSlots": 6,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 21,
+                            "openAppointmentSlots": 21,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 83,
+                    "openTimeslots": 21,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 83,
+                    "openAppointmentSlots": 21,
                     "name": "Louis Henna Blvd H-E-B",
                     "longitude": -97.65938,
                     "latitude": 30.48179,
                     "fluUrl": "",
-                    "city": "ROUND ROCK"
+                    "city": "ROUND ROCK",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78628-0",
@@ -186,45 +354,28 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 35,
-                            "openAppointmentSlots": 35,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 19,
-                            "openAppointmentSlots": 19,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 28,
-                            "openAppointmentSlots": 28,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 43,
-                            "openAppointmentSlots": 43,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 21,
-                            "openAppointmentSlots": 21,
-                            "manufacturer": "Ultra_Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 52,
-                            "openAppointmentSlots": 52,
+                            "openTimeslots": 96,
+                            "openAppointmentSlots": 96,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 198,
+                    "openTimeslots": 96,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 198,
+                    "openAppointmentSlots": 96,
                     "name": "H-E-B at Ronald Reagan Blvd",
                     "longitude": -97.82446,
                     "latitude": 30.63307,
                     "fluUrl": "",
-                    "city": "GEORGETOWN"
+                    "city": "GEORGETOWN",
+                    "availableImmunizations": [
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Novavax",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77598-0",
@@ -235,48 +386,55 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 96,
-                            "openAppointmentSlots": 96,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 99,
-                            "openAppointmentSlots": 99,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 66,
-                            "openAppointmentSlots": 66,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 31,
+                            "openAppointmentSlots": 31,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 261,
+                    "openTimeslots": 31,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 261,
+                    "openAppointmentSlots": 31,
                     "name": "El Dorado H-E-B",
                     "longitude": -95.14874,
                     "latitude": 29.55117,
                     "fluUrl": "",
-                    "city": "WEBSTER"
+                    "city": "WEBSTER",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78045-2802",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucLQAS",
                     "type": "store",
                     "street": "7811 MCPHERSON RD.",
                     "storeNumber": 449,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 1,
+                            "openAppointmentSlots": 1,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 1,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 1,
                     "name": "McPherson Rd H-E-B",
                     "longitude": -99.4733,
                     "latitude": 27.5754,
                     "fluUrl": "",
-                    "city": "LAREDO"
+                    "city": "LAREDO",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78355-4365",
@@ -287,35 +445,28 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 21,
-                            "openAppointmentSlots": 21,
-                            "manufacturer": "Other"
-                        },
-                        {
-                            "openTimeslots": 21,
-                            "openAppointmentSlots": 21,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 20,
-                            "openAppointmentSlots": 20,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 21,
-                            "openAppointmentSlots": 21,
-                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                            "openTimeslots": 54,
+                            "openAppointmentSlots": 54,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 62,
-                    "openFluTimeslots": 21,
-                    "openFluAppointmentSlots": 21,
-                    "openAppointmentSlots": 62,
+                    "openTimeslots": 27,
+                    "openFluTimeslots": 27,
+                    "openFluAppointmentSlots": 27,
+                    "openAppointmentSlots": 27,
                     "name": "Falfurrias H-E-B",
                     "longitude": -98.14572,
                     "latitude": 27.22043,
                     "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF15QAE",
-                    "city": "FALFURRIAS"
+                    "city": "FALFURRIAS",
+                    "availableImmunizations": [
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Novavax",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu"
+                    ]
                 },
                 {
                     "zip": "78756-1100",
@@ -326,30 +477,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 32,
-                            "openAppointmentSlots": 32,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 12,
-                            "openAppointmentSlots": 12,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 16,
-                            "openAppointmentSlots": 16,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 1,
+                            "openAppointmentSlots": 1,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 60,
+                    "openTimeslots": 1,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 60,
+                    "openAppointmentSlots": 1,
                     "name": "Burnet Rd H-E-B",
                     "longitude": -97.74016,
                     "latitude": 30.33374,
                     "fluUrl": "",
-                    "city": "AUSTIN"
+                    "city": "AUSTIN",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78237-3134",
@@ -360,30 +504,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 221,
-                            "openAppointmentSlots": 221,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 220,
-                            "openAppointmentSlots": 220,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 222,
-                            "openAppointmentSlots": 222,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 494,
+                            "openAppointmentSlots": 494,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 663,
+                    "openTimeslots": 494,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 663,
+                    "openAppointmentSlots": 494,
                     "name": "Las Palmas H-E-B",
                     "longitude": -98.55132,
                     "latitude": 29.41734,
                     "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78040-5343",
@@ -394,35 +533,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 7,
-                            "openAppointmentSlots": 7,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 9,
-                            "openAppointmentSlots": 9,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 2,
-                            "openAppointmentSlots": 2,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 14,
-                            "openAppointmentSlots": 14,
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 32,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 32,
+                    "openTimeslots": 43,
+                    "openFluTimeslots": 7,
+                    "openFluAppointmentSlots": 7,
+                    "openAppointmentSlots": 43,
                     "name": "Guadalupe and Stone H-E-B",
                     "longitude": -99.48344,
                     "latitude": 27.50656,
-                    "fluUrl": "",
-                    "city": "LAREDO"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF18QAE",
+                    "city": "LAREDO",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "Flu",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Moderna"
+                    ]
                 },
                 {
                     "zip": "78412-2412",
@@ -433,20 +564,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 13,
-                            "openAppointmentSlots": 13,
-                            "manufacturer": "Moderna"
+                            "openTimeslots": 95,
+                            "openAppointmentSlots": 95,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 13,
+                    "openTimeslots": 95,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 13,
+                    "openAppointmentSlots": 95,
                     "name": "Alameda and Robert H-E-B",
                     "longitude": -97.37175,
                     "latitude": 27.73002,
                     "fluUrl": "",
-                    "city": "CORPUS CHRISTI"
+                    "city": "CORPUS CHRISTI",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78202-3050",
@@ -464,7 +601,8 @@
                     "longitude": -98.46143,
                     "latitude": 29.42444,
                     "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78501-1926",
@@ -482,7 +620,8 @@
                     "longitude": -98.22523,
                     "latitude": 26.23246,
                     "fluUrl": "",
-                    "city": "MCALLEN"
+                    "city": "MCALLEN",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78758-2475",
@@ -493,25 +632,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 55,
-                            "openAppointmentSlots": 55,
-                            "manufacturer": "Moderna"
-                        },
-                        {
                             "openTimeslots": 79,
                             "openAppointmentSlots": 79,
-                            "manufacturer": "Pfizer"
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 134,
+                    "openTimeslots": 79,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 134,
+                    "openAppointmentSlots": 79,
                     "name": "Parmer and Mopac H-E-B",
                     "longitude": -97.70326,
                     "latitude": 30.41883,
                     "fluUrl": "",
-                    "city": "AUSTIN"
+                    "city": "AUSTIN",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78064-4221",
@@ -522,54 +663,47 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 139,
-                            "openAppointmentSlots": 139,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 137,
-                            "openAppointmentSlots": 137,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 138,
-                            "openAppointmentSlots": 138,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 289,
+                            "openAppointmentSlots": 289,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 414,
+                    "openTimeslots": 289,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 414,
+                    "openAppointmentSlots": 289,
                     "name": "Pleasanton H-E-B",
                     "longitude": -98.48567,
                     "latitude": 28.95696,
                     "fluUrl": "",
-                    "city": "PLEASANTON"
+                    "city": "PLEASANTON",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78102-5613",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubzQAC",
+                    "url": null,
                     "type": "store",
                     "street": "100 EAST HOUSTON ST.",
                     "storeNumber": 412,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 28,
-                            "openAppointmentSlots": 28,
-                            "manufacturer": "Moderna"
-                        }
-                    ],
-                    "openTimeslots": 28,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 28,
+                    "openAppointmentSlots": 0,
                     "name": "Beeville H-E-B",
                     "longitude": -97.74667,
                     "latitude": 28.40071,
                     "fluUrl": "",
-                    "city": "BEEVILLE"
+                    "city": "BEEVILLE",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78404-2505",
@@ -580,30 +714,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 45,
-                            "openAppointmentSlots": 45,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 54,
-                            "openAppointmentSlots": 54,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 29,
-                            "openAppointmentSlots": 29,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 98,
+                            "openAppointmentSlots": 98,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 128,
+                    "openTimeslots": 98,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 128,
+                    "openAppointmentSlots": 98,
                     "name": "Alameda / Texan Trail (Medical District)",
                     "longitude": -97.3912,
                     "latitude": 27.75745,
                     "fluUrl": "",
-                    "city": "CORPUS CHRISTI"
+                    "city": "CORPUS CHRISTI",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer"
+                    ]
                 },
                 {
                     "zip": "77833-5521",
@@ -614,59 +743,46 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 71,
-                            "openAppointmentSlots": 71,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 114,
-                            "openAppointmentSlots": 114,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 97,
-                            "openAppointmentSlots": 97,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 1213,
+                            "openAppointmentSlots": 1213,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 282,
+                    "openTimeslots": 1213,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 282,
+                    "openAppointmentSlots": 1213,
                     "name": "Brenham H-E-B",
                     "longitude": -96.39591,
                     "latitude": 30.14381,
                     "fluUrl": "",
-                    "city": "BRENHAM"
+                    "city": "BRENHAM",
+                    "availableImmunizations": [
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer",
+                        "Flu"
+                    ]
                 },
                 {
                     "zip": "78154-1264",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Guc2QAC",
+                    "url": null,
                     "type": "store",
                     "street": "17460 I.H. 35 NORTH",
                     "storeNumber": 415,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 32,
-                            "openAppointmentSlots": 32,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 80,
-                            "openAppointmentSlots": 80,
-                            "manufacturer": "Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 112,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 112,
+                    "openAppointmentSlots": 0,
                     "name": "Schertz H-E-B plus!",
                     "longitude": -98.27742,
                     "latitude": 29.59717,
                     "fluUrl": "",
-                    "city": "SCHERTZ"
+                    "city": "SCHERTZ",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78945-2655",
@@ -677,30 +793,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 27,
-                            "openAppointmentSlots": 27,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 27,
-                            "openAppointmentSlots": 27,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 27,
-                            "openAppointmentSlots": 27,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 180,
+                            "openAppointmentSlots": 180,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 81,
+                    "openTimeslots": 180,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 81,
+                    "openAppointmentSlots": 180,
                     "name": "La Grange H-E-B",
                     "longitude": -96.87264,
                     "latitude": 29.9073,
                     "fluUrl": "",
-                    "city": "LA GRANGE"
+                    "city": "LA GRANGE",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78840-4658",
@@ -711,35 +824,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 13,
-                            "openAppointmentSlots": 13,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 14,
-                            "openAppointmentSlots": 14,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 1,
-                            "openAppointmentSlots": 1,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 6,
-                            "openAppointmentSlots": 6,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 17,
+                            "openAppointmentSlots": 17,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 34,
+                    "openTimeslots": 17,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 34,
+                    "openAppointmentSlots": 17,
                     "name": "Avenue F and Gibbs H-E-B",
                     "longitude": -100.8998,
                     "latitude": 29.36632,
                     "fluUrl": "",
-                    "city": "DEL RIO"
+                    "city": "DEL RIO",
+                    "availableImmunizations": [
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Ultra_Pediatric_Pfizer"
+                    ]
                 },
                 {
                     "zip": "78852-4718",
@@ -750,59 +853,42 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 8,
-                            "openAppointmentSlots": 8,
-                            "manufacturer": "Pediatric_Moderna"
+                            "openTimeslots": 6,
+                            "openAppointmentSlots": 6,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 8,
+                    "openTimeslots": 6,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 8,
+                    "openAppointmentSlots": 6,
                     "name": "Eagle Pass H-E-B",
                     "longitude": -100.48583,
                     "latitude": 28.70894,
                     "fluUrl": "",
-                    "city": "EAGLE PASS"
+                    "city": "EAGLE PASS",
+                    "availableImmunizations": [
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78516-2315",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Guc6QAC",
+                    "url": null,
                     "type": "store",
                     "street": "1211 EAST FRONTAGE RD.",
                     "storeNumber": 421,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 15,
-                            "openAppointmentSlots": 15,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 15,
-                            "openAppointmentSlots": 15,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 14,
-                            "openAppointmentSlots": 14,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 14,
-                            "openAppointmentSlots": 14,
-                            "manufacturer": "Ultra_Pediatric_Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 58,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 58,
+                    "openAppointmentSlots": 0,
                     "name": "Alamo H-E-B",
                     "longitude": -98.12414,
                     "latitude": 26.19073,
                     "fluUrl": "",
-                    "city": "ALAMO"
+                    "city": "ALAMO",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "76710-4437",
@@ -820,25 +906,39 @@
                     "longitude": -97.1894,
                     "latitude": 31.53274,
                     "fluUrl": "",
-                    "city": "WACO"
+                    "city": "WACO",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78861-2504",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Guc8QAC",
                     "type": "store",
                     "street": "609 19TH STREET",
                     "storeNumber": 424,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 20,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 20,
                     "name": "Hondo H-E-B",
                     "longitude": -99.13501,
                     "latitude": 29.34784,
                     "fluUrl": "",
-                    "city": "HONDO"
+                    "city": "HONDO",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78751-4810",
@@ -849,35 +949,29 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 198,
-                            "openAppointmentSlots": 198,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 198,
-                            "openAppointmentSlots": 198,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 95,
-                            "openAppointmentSlots": 95,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 60,
-                            "openAppointmentSlots": 60,
+                            "openTimeslots": 307,
+                            "openAppointmentSlots": 307,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 551,
+                    "openTimeslots": 307,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 551,
+                    "openAppointmentSlots": 307,
                     "name": "Hancock Center H-E-B",
                     "longitude": -97.71973,
                     "latitude": 30.30057,
                     "fluUrl": "",
-                    "city": "AUSTIN"
+                    "city": "AUSTIN",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Janssen",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "75165-1884",
@@ -888,45 +982,32 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 51,
-                            "openAppointmentSlots": 51,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 32,
-                            "openAppointmentSlots": 32,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 29,
-                            "openAppointmentSlots": 29,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 36,
-                            "openAppointmentSlots": 36,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 24,
-                            "openAppointmentSlots": 24,
-                            "manufacturer": "Ultra_Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 63,
-                            "openAppointmentSlots": 63,
+                            "openTimeslots": 176,
+                            "openAppointmentSlots": 176,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 235,
+                    "openTimeslots": 176,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 235,
+                    "openAppointmentSlots": 176,
                     "name": "Waxahachie H-E-B",
                     "longitude": -96.83983,
                     "latitude": 32.41159,
                     "fluUrl": "",
-                    "city": "WAXAHACHIE"
+                    "city": "WAXAHACHIE",
+                    "availableImmunizations": [
+                        "COVID-19 Moderna_Updated_Booster",
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Janssen",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Novavax",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78221-1642",
@@ -937,30 +1018,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 119,
-                            "openAppointmentSlots": 119,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 120,
-                            "openAppointmentSlots": 120,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 41,
-                            "openAppointmentSlots": 41,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 95,
+                            "openAppointmentSlots": 95,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 280,
+                    "openTimeslots": 95,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 280,
+                    "openAppointmentSlots": 95,
                     "name": "Military and Pleasanton H-E-B",
                     "longitude": -98.50277,
                     "latitude": 29.35666,
                     "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer"
+                    ]
                 },
                 {
                     "zip": "78213-1343",
@@ -971,30 +1047,28 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 79,
-                            "openAppointmentSlots": 79,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 69,
-                            "openAppointmentSlots": 69,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 168,
-                            "openAppointmentSlots": 168,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 745,
+                            "openAppointmentSlots": 745,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 316,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 316,
+                    "openTimeslots": 645,
+                    "openFluTimeslots": 100,
+                    "openFluAppointmentSlots": 100,
+                    "openAppointmentSlots": 645,
                     "name": "Blanco and West Ave H-E-B",
                     "longitude": -98.51025,
                     "latitude": 29.54526,
-                    "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF14QAE",
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": [
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Moderna",
+                        "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78660-8045",
@@ -1005,30 +1079,28 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 208,
-                            "openAppointmentSlots": 208,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 211,
-                            "openAppointmentSlots": 211,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 211,
-                            "openAppointmentSlots": 211,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 759,
+                            "openAppointmentSlots": 759,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 630,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 630,
+                    "openTimeslots": 564,
+                    "openFluTimeslots": 195,
+                    "openFluAppointmentSlots": 195,
+                    "openAppointmentSlots": 564,
                     "name": "Pflugerville H-E-B",
                     "longitude": -97.6133,
                     "latitude": 30.4373,
-                    "fluUrl": "",
-                    "city": "PFLUGERVILLE"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF34QAE",
+                    "city": "PFLUGERVILLE",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78230-2212",
@@ -1039,30 +1111,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 45,
-                            "openAppointmentSlots": 45,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 42,
-                            "openAppointmentSlots": 42,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 22,
-                            "openAppointmentSlots": 22,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 64,
+                            "openAppointmentSlots": 64,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 109,
+                    "openTimeslots": 64,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 109,
+                    "openAppointmentSlots": 64,
                     "name": "I10 and Wurzbach H-E-B",
                     "longitude": -98.5595,
                     "latitude": 29.5336,
                     "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78596-2700",
@@ -1073,56 +1140,82 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 24,
-                            "openAppointmentSlots": 24,
+                            "openTimeslots": 18,
+                            "openAppointmentSlots": 18,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 24,
+                    "openTimeslots": 18,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 24,
+                    "openAppointmentSlots": 18,
                     "name": "83 and Westgate H-E-B",
                     "longitude": -97.98934,
                     "latitude": 26.17109,
                     "fluUrl": "",
-                    "city": "WESLACO"
+                    "city": "WESLACO",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78628-0",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucbQAC",
                     "type": "store",
                     "street": "4500 WILLIAMS DRIVE",
                     "storeNumber": 487,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 66,
+                            "openAppointmentSlots": 66,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 66,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 66,
                     "name": "Williams Drive H-E-B",
                     "longitude": -97.71873,
                     "latitude": 30.68312,
                     "fluUrl": "",
-                    "city": "GEORGETOWN"
+                    "city": "GEORGETOWN",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78543-9800",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudxQAC",
                     "type": "store",
                     "street": "512 E. EDINBURG AVE.",
                     "storeNumber": 677,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 14,
+                            "openAppointmentSlots": 14,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 14,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 14,
                     "name": "Elsa H-E-B",
                     "longitude": -97.99272,
                     "latitude": 26.29384,
                     "fluUrl": "",
-                    "city": "ELSA"
+                    "city": "ELSA",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78227-4602",
@@ -1133,74 +1226,49 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 420,
-                            "openAppointmentSlots": 420,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 41,
-                            "openAppointmentSlots": 41,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 829,
-                            "openAppointmentSlots": 829,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 70,
-                            "openAppointmentSlots": 70,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 69,
-                            "openAppointmentSlots": 69,
-                            "manufacturer": "Ultra_Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 30,
-                            "openAppointmentSlots": 30,
+                            "openTimeslots": 933,
+                            "openAppointmentSlots": 933,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 1459,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 1459,
+                    "openTimeslots": 761,
+                    "openFluTimeslots": 172,
+                    "openFluAppointmentSlots": 172,
+                    "openAppointmentSlots": 761,
                     "name": "Valley Hi H-E-B",
                     "longitude": -98.64021,
                     "latitude": 29.38099,
-                    "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF59QAE",
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": [
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "76033-4830",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudzQAC",
+                    "url": null,
                     "type": "store",
                     "street": "600 W HENDERSON",
                     "storeNumber": 679,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 44,
-                            "openAppointmentSlots": 44,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 82,
-                            "openAppointmentSlots": 82,
-                            "manufacturer": "Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 126,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 126,
+                    "openAppointmentSlots": 0,
                     "name": "Cleburne H-E-B",
                     "longitude": -97.39485,
                     "latitude": 32.3478,
                     "fluUrl": "",
-                    "city": "CLEBURNE"
+                    "city": "CLEBURNE",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77375-1478",
@@ -1211,30 +1279,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 55,
-                            "openAppointmentSlots": 55,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 53,
-                            "openAppointmentSlots": 53,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 27,
-                            "openAppointmentSlots": 27,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 101,
+                            "openAppointmentSlots": 101,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 135,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 135,
+                    "openTimeslots": 41,
+                    "openFluTimeslots": 60,
+                    "openFluAppointmentSlots": 60,
+                    "openAppointmentSlots": 41,
                     "name": "Creekside Park H-E-B",
                     "longitude": -95.55072,
                     "latitude": 30.14362,
-                    "fluUrl": "",
-                    "city": "TOMBALL"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF5BQAU",
+                    "city": "TOMBALL",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77057-3061",
@@ -1245,43 +1310,53 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 93,
-                            "openAppointmentSlots": 93,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 78,
-                            "openAppointmentSlots": 78,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 89,
+                            "openAppointmentSlots": 89,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 171,
+                    "openTimeslots": 89,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 171,
+                    "openAppointmentSlots": 89,
                     "name": "San Felipe H-E-B",
                     "longitude": -95.48512,
                     "latitude": 29.74797,
                     "fluUrl": "",
-                    "city": "HOUSTON"
+                    "city": "HOUSTON",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer"
+                    ]
                 },
                 {
                     "zip": "78332-5046",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubGQAS",
                     "type": "store",
                     "street": "1115 E. MAIN",
                     "storeNumber": 223,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 46,
+                            "openAppointmentSlots": 46,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 46,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 46,
                     "name": "Alice H-E-B",
                     "longitude": -98.06425,
                     "latitude": 27.75141,
                     "fluUrl": "",
-                    "city": "ALICE"
+                    "city": "ALICE",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78250-3232",
@@ -1292,30 +1367,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 239,
-                            "openAppointmentSlots": 239,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 253,
-                            "openAppointmentSlots": 253,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 67,
-                            "openAppointmentSlots": 67,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 291,
+                            "openAppointmentSlots": 291,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 559,
+                    "openTimeslots": 291,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 559,
+                    "openAppointmentSlots": 291,
                     "name": "Bandera and Guilbeau H-E-B",
                     "longitude": -98.64364,
                     "latitude": 29.51985,
                     "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer"
+                    ]
                 },
                 {
                     "zip": "78736-8300",
@@ -1326,30 +1398,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 9,
-                            "openAppointmentSlots": 9,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 12,
-                            "openAppointmentSlots": 12,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 40,
-                            "openAppointmentSlots": 40,
+                            "openTimeslots": 11,
+                            "openAppointmentSlots": 11,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 61,
+                    "openTimeslots": 11,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 61,
+                    "openAppointmentSlots": 11,
                     "name": "Oak Hill H-E-B",
                     "longitude": -97.88755,
                     "latitude": 30.22696,
                     "fluUrl": "",
-                    "city": "AUSTIN"
+                    "city": "AUSTIN",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78611-3201",
@@ -1360,20 +1425,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 629,
-                            "openAppointmentSlots": 629,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 183,
+                            "openAppointmentSlots": 183,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 629,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 629,
+                    "openTimeslots": 129,
+                    "openFluTimeslots": 54,
+                    "openFluAppointmentSlots": 54,
+                    "openAppointmentSlots": 129,
                     "name": "Burnet H-E-B",
                     "longitude": -98.22452,
                     "latitude": 30.7588,
-                    "fluUrl": "",
-                    "city": "BURNET"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2kQAE",
+                    "city": "BURNET",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pfizer",
+                        "Flu"
+                    ]
                 },
                 {
                     "zip": "77979-2423",
@@ -1391,7 +1461,8 @@
                     "longitude": -96.64126,
                     "latitude": 28.62096,
                     "fluUrl": "",
-                    "city": "PORT LAVACA"
+                    "city": "PORT LAVACA",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78801-5638",
@@ -1409,7 +1480,8 @@
                     "longitude": -99.78378,
                     "latitude": 29.21013,
                     "fluUrl": "",
-                    "city": "UVALDE"
+                    "city": "UVALDE",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78223-3814",
@@ -1420,30 +1492,28 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 70,
-                            "openAppointmentSlots": 70,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 69,
-                            "openAppointmentSlots": 69,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 72,
-                            "openAppointmentSlots": 72,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 171,
+                            "openAppointmentSlots": 171,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 211,
+                    "openTimeslots": 171,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 211,
+                    "openAppointmentSlots": 171,
                     "name": "Military and Goliad H-E-B",
                     "longitude": -98.4362,
                     "latitude": 29.35194,
                     "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78644-2702",
@@ -1454,25 +1524,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 140,
-                            "openAppointmentSlots": 140,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 140,
-                            "openAppointmentSlots": 140,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 122,
+                            "openAppointmentSlots": 122,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 280,
+                    "openTimeslots": 122,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 280,
+                    "openAppointmentSlots": 122,
                     "name": "Lockhart H-E-B",
                     "longitude": -97.66994,
                     "latitude": 29.88213,
                     "fluUrl": "",
-                    "city": "LOCKHART"
+                    "city": "LOCKHART",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78521-1609",
@@ -1490,7 +1562,8 @@
                     "longitude": -97.48904,
                     "latitude": 25.95015,
                     "fluUrl": "",
-                    "city": "BROWNSVILLE"
+                    "city": "BROWNSVILLE",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78572-5362",
@@ -1508,7 +1581,8 @@
                     "longitude": -98.3262,
                     "latitude": 26.21354,
                     "fluUrl": "",
-                    "city": "MISSION"
+                    "city": "MISSION",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78374-2816",
@@ -1526,7 +1600,8 @@
                     "longitude": -97.31836,
                     "latitude": 27.88722,
                     "fluUrl": "",
-                    "city": "PORTLAND"
+                    "city": "PORTLAND",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78521-2216",
@@ -1544,41 +1619,27 @@
                     "longitude": -97.48722,
                     "latitude": 25.92214,
                     "fluUrl": "",
-                    "city": "BROWNSVILLE"
+                    "city": "BROWNSVILLE",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77084-5813",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuceQAC",
+                    "url": null,
                     "type": "store",
                     "street": "1550 FRY RD",
                     "storeNumber": 492,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 16,
-                            "openAppointmentSlots": 16,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 16,
-                            "openAppointmentSlots": 16,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 16,
-                            "openAppointmentSlots": 16,
-                            "manufacturer": "Pediatric_Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 48,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 48,
+                    "openAppointmentSlots": 0,
                     "name": "Fry Rd and I10 H-E-B",
                     "longitude": -95.7189,
                     "latitude": 29.7898,
                     "fluUrl": "",
-                    "city": "HOUSTON"
+                    "city": "HOUSTON",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78251-1320",
@@ -1589,50 +1650,32 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 63,
-                            "openAppointmentSlots": 63,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 88,
-                            "openAppointmentSlots": 88,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 7,
-                            "openAppointmentSlots": 7,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 627,
-                            "openAppointmentSlots": 627,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 39,
-                            "openAppointmentSlots": 39,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 7,
-                            "openAppointmentSlots": 7,
-                            "manufacturer": "Ultra_Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
+                            "openTimeslots": 636,
+                            "openAppointmentSlots": 636,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 881,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 881,
+                    "openTimeslots": 351,
+                    "openFluTimeslots": 285,
+                    "openFluAppointmentSlots": 285,
+                    "openAppointmentSlots": 351,
                     "name": "Culebra and 1604 H-E-B",
                     "longitude": -98.70445,
                     "latitude": 29.49292,
-                    "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3BQAU",
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": [
+                        "COVID-19 Novavax",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Janssen",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77701-0",
@@ -1643,53 +1686,55 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 30,
-                            "openAppointmentSlots": 30,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 34,
-                            "openAppointmentSlots": 34,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 38,
-                            "openAppointmentSlots": 38,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 40,
-                            "openAppointmentSlots": 40,
-                            "manufacturer": "Other"
+                            "openTimeslots": 162,
+                            "openAppointmentSlots": 162,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 102,
-                    "openFluTimeslots": 40,
-                    "openFluAppointmentSlots": 40,
-                    "openAppointmentSlots": 102,
+                    "openTimeslots": 82,
+                    "openFluTimeslots": 80,
+                    "openFluAppointmentSlots": 80,
+                    "openAppointmentSlots": 82,
                     "name": "Beaumont 6 H-E-B",
                     "longitude": -94.12834,
                     "latitude": 30.06853,
                     "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF0qQAE",
-                    "city": "BEAUMONT"
+                    "city": "BEAUMONT",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer"
+                    ]
                 },
                 {
                     "zip": "78119-0",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gue3QAC",
                     "type": "store",
                     "street": "107 N. SUNSET STRIP",
                     "storeNumber": 693,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 41,
+                            "openAppointmentSlots": 41,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 41,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 41,
                     "name": "Kenedy H-E-B",
                     "longitude": -97.85797,
                     "latitude": 28.81419,
                     "fluUrl": "",
-                    "city": "KENEDY"
+                    "city": "KENEDY",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78130-4678",
@@ -1700,35 +1745,29 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 29,
-                            "openAppointmentSlots": 29,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 175,
-                            "openAppointmentSlots": 175,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 105,
-                            "openAppointmentSlots": 105,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 60,
-                            "openAppointmentSlots": 60,
-                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                            "openTimeslots": 512,
+                            "openAppointmentSlots": 512,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 369,
+                    "openTimeslots": 512,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 369,
+                    "openAppointmentSlots": 512,
                     "name": "New Braunfels H-E-B plus!",
                     "longitude": -98.0782,
                     "latitude": 29.731,
                     "fluUrl": "",
-                    "city": "NEW BRAUNFELS"
+                    "city": "NEW BRAUNFELS",
+                    "availableImmunizations": [
+                        "COVID-19 Pediatric_Moderna",
+                        "Flu",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Novavax",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78634-2025",
@@ -1739,35 +1778,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 94,
-                            "openAppointmentSlots": 94,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 88,
-                            "openAppointmentSlots": 88,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 67,
-                            "openAppointmentSlots": 67,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 471,
-                            "openAppointmentSlots": 471,
+                            "openTimeslots": 687,
+                            "openAppointmentSlots": 687,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 720,
+                    "openTimeslots": 687,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 720,
+                    "openAppointmentSlots": 687,
                     "name": "Hutto 130 and Gattis School H-E-B plus!",
                     "longitude": -97.58284,
                     "latitude": 30.50112,
                     "fluUrl": "",
-                    "city": "HUTTO"
+                    "city": "HUTTO",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77573-3360",
@@ -1778,74 +1809,46 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 179,
-                            "openAppointmentSlots": 179,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 156,
-                            "openAppointmentSlots": 156,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 40,
-                            "openAppointmentSlots": 40,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 643,
+                            "openAppointmentSlots": 643,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 375,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 375,
+                    "openTimeslots": 469,
+                    "openFluTimeslots": 174,
+                    "openFluAppointmentSlots": 174,
+                    "openAppointmentSlots": 469,
                     "name": "League City Market H-E-B",
                     "longitude": -95.04131,
                     "latitude": 29.50588,
-                    "fluUrl": "",
-                    "city": "LEAGUE CITY"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF0uQAE",
+                    "city": "LEAGUE CITY",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna",
+                        "Flu",
+                        "COVID-19 Pediatric_Pfizer"
+                    ]
                 },
                 {
                     "zip": "79764-7155",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueGQAS",
+                    "url": null,
                     "type": "store",
                     "street": "2501 W UNIVERSITY BLVD",
                     "storeNumber": 711,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 52,
-                            "openAppointmentSlots": 52,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 51,
-                            "openAppointmentSlots": 51,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 47,
-                            "openAppointmentSlots": 47,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 16,
-                            "openAppointmentSlots": 16,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 73,
-                            "openAppointmentSlots": 73,
-                            "manufacturer": "Ultra_Pediatric_Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 239,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 239,
+                    "openAppointmentSlots": 0,
                     "name": "Odessa H-E-B University Blvd",
                     "longitude": -102.41008,
                     "latitude": 31.86213,
                     "fluUrl": "",
-                    "city": "ODESSA"
+                    "city": "ODESSA",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77954-2126",
@@ -1863,7 +1866,8 @@
                     "longitude": -97.28051,
                     "latitude": 29.08949,
                     "fluUrl": "",
-                    "city": "CUERO"
+                    "city": "CUERO",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77059-2511",
@@ -1874,30 +1878,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 194,
-                            "openAppointmentSlots": 194,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 119,
-                            "openAppointmentSlots": 119,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 100,
-                            "openAppointmentSlots": 100,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 77,
+                            "openAppointmentSlots": 77,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 413,
+                    "openTimeslots": 77,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 413,
+                    "openAppointmentSlots": 77,
                     "name": "Clear Lake Marketplace H-E-B",
                     "longitude": -95.12473,
                     "latitude": 29.60563,
                     "fluUrl": "",
-                    "city": "HOUSTON"
+                    "city": "HOUSTON",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer"
+                    ]
                 },
                 {
                     "zip": "78734-6238",
@@ -1908,25 +1907,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 14,
-                            "openAppointmentSlots": 14,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 14,
-                            "openAppointmentSlots": 14,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 35,
+                            "openAppointmentSlots": 35,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 28,
+                    "openTimeslots": 35,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 28,
+                    "openAppointmentSlots": 35,
                     "name": "Lakeway H-E-B",
                     "longitude": -97.96662,
                     "latitude": 30.34368,
                     "fluUrl": "",
-                    "city": "LAKEWAY"
+                    "city": "LAKEWAY",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77536-5404",
@@ -1944,7 +1943,8 @@
                     "longitude": -95.09805,
                     "latitude": 29.6652,
                     "fluUrl": "",
-                    "city": "DEER PARK"
+                    "city": "DEER PARK",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78041-2205",
@@ -1962,7 +1962,8 @@
                     "longitude": -99.49676,
                     "latitude": 27.56786,
                     "fluUrl": "",
-                    "city": "LAREDO"
+                    "city": "LAREDO",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78572-2912",
@@ -1980,7 +1981,8 @@
                     "longitude": -98.32225,
                     "latitude": 26.22834,
                     "fluUrl": "",
-                    "city": "MISSION"
+                    "city": "MISSION",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77375-4546",
@@ -1991,69 +1993,58 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 31,
-                            "openAppointmentSlots": 31,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 19,
-                            "openAppointmentSlots": 19,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 35,
-                            "openAppointmentSlots": 35,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 28,
-                            "openAppointmentSlots": 28,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 20,
-                            "openAppointmentSlots": 20,
-                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                            "openTimeslots": 57,
+                            "openAppointmentSlots": 57,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 133,
+                    "openTimeslots": 57,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 133,
+                    "openAppointmentSlots": 57,
                     "name": "Tomball Pkwy and Graham H-E-B",
                     "longitude": -95.63218,
                     "latitude": 30.08868,
                     "fluUrl": "",
-                    "city": "TOMBALL"
+                    "city": "TOMBALL",
+                    "availableImmunizations": [
+                        "COVID-19 Novavax",
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77379-7234",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gud4QAC",
+                    "url": null,
                     "type": "store",
                     "street": "7310 LOUETTA",
                     "storeNumber": 576,
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 22,
-                            "openAppointmentSlots": 22,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 5,
-                            "openAppointmentSlots": 5,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 14,
+                            "openAppointmentSlots": 14,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 27,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 27,
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 14,
+                    "openFluAppointmentSlots": 14,
+                    "openAppointmentSlots": 0,
                     "name": "Louetta and Stuebner H-E-B",
                     "longitude": -95.5243,
                     "latitude": 30.0209,
-                    "fluUrl": "",
-                    "city": "SPRING"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3aQAE",
+                    "city": "SPRING",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77043-1803",
@@ -2064,30 +2055,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 98,
-                            "openAppointmentSlots": 98,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 112,
-                            "openAppointmentSlots": 112,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 98,
-                            "openAppointmentSlots": 98,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 224,
+                            "openAppointmentSlots": 224,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 308,
+                    "openTimeslots": 224,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 308,
+                    "openAppointmentSlots": 224,
                     "name": "Kempwood and Gessner H-E-B",
                     "longitude": -95.5468,
                     "latitude": 29.8226,
                     "fluUrl": "",
-                    "city": "HOUSTON"
+                    "city": "HOUSTON",
+                    "availableImmunizations": [
+                        "Flu"
+                    ]
                 },
                 {
                     "zip": "77380-1531",
@@ -2098,30 +2082,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 24,
-                            "openAppointmentSlots": 24,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 15,
-                            "openAppointmentSlots": 15,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 17,
-                            "openAppointmentSlots": 17,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 25,
+                            "openAppointmentSlots": 25,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 56,
+                    "openTimeslots": 25,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 56,
+                    "openAppointmentSlots": 25,
                     "name": "Woodlands Market H-E-B",
                     "longitude": -95.46575,
                     "latitude": 30.16409,
                     "fluUrl": "",
-                    "city": "THE WOODLANDS"
+                    "city": "THE WOODLANDS",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78613-7273",
@@ -2132,30 +2113,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 489,
-                            "openAppointmentSlots": 489,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 449,
-                            "openAppointmentSlots": 449,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 216,
-                            "openAppointmentSlots": 216,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 1154,
+                    "openTimeslots": 20,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 1154,
+                    "openAppointmentSlots": 20,
                     "name": "Parmer and Whitestone H-E-B",
                     "longitude": -97.78545,
                     "latitude": 30.5328,
                     "fluUrl": "",
-                    "city": "CEDAR PARK"
+                    "city": "CEDAR PARK",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pfizer"
+                    ]
                 },
                 {
                     "zip": "76401-3928",
@@ -2166,30 +2142,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 82,
-                            "openAppointmentSlots": 82,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 84,
-                            "openAppointmentSlots": 84,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 43,
-                            "openAppointmentSlots": 43,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 59,
+                            "openAppointmentSlots": 59,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 209,
+                    "openTimeslots": 59,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 209,
+                    "openAppointmentSlots": 59,
                     "name": "Stephenville H-E-B",
                     "longitude": -98.22569,
                     "latitude": 32.20975,
                     "fluUrl": "",
-                    "city": "STEPHENVILLE"
+                    "city": "STEPHENVILLE",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78748-5992",
@@ -2200,40 +2173,28 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 84,
-                            "openAppointmentSlots": 84,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 28,
-                            "openAppointmentSlots": 28,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 70,
-                            "openAppointmentSlots": 70,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 46,
-                            "openAppointmentSlots": 46,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 28,
-                            "openAppointmentSlots": 28,
-                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                            "openTimeslots": 322,
+                            "openAppointmentSlots": 322,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 256,
+                    "openTimeslots": 322,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 256,
+                    "openAppointmentSlots": 322,
                     "name": "Slaughter and Manchaca H-E-B",
                     "longitude": -97.82509,
                     "latitude": 30.17524,
                     "fluUrl": "",
-                    "city": "AUSTIN"
+                    "city": "AUSTIN",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer",
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Novavax",
+                        "COVID-19 Pediatric_Moderna"
+                    ]
                 },
                 {
                     "zip": "78744-3410",
@@ -2244,30 +2205,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 6,
-                            "openAppointmentSlots": 6,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 4,
-                            "openAppointmentSlots": 4,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 31,
-                            "openAppointmentSlots": 31,
+                            "openTimeslots": 100,
+                            "openAppointmentSlots": 100,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 41,
+                    "openTimeslots": 100,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 41,
+                    "openAppointmentSlots": 100,
                     "name": "I 35 and William Cannon H-E-B",
                     "longitude": -97.76922,
                     "latitude": 30.19107,
                     "fluUrl": "",
-                    "city": "AUSTIN"
+                    "city": "AUSTIN",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78247-1979",
@@ -2278,30 +2233,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 122,
-                            "openAppointmentSlots": 122,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 156,
-                            "openAppointmentSlots": 156,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 58,
-                            "openAppointmentSlots": 58,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 693,
+                            "openAppointmentSlots": 693,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 336,
+                    "openTimeslots": 693,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 336,
+                    "openAppointmentSlots": 693,
                     "name": "Nacogdoches and O'Connor H-E-B",
                     "longitude": -98.3856,
                     "latitude": 29.56937,
                     "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer"
+                    ]
                 },
                 {
                     "zip": "78596-4511",
@@ -2312,76 +2264,84 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 104,
-                            "openAppointmentSlots": 104,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 17,
-                            "openAppointmentSlots": 17,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 94,
-                            "openAppointmentSlots": 94,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 103,
-                            "openAppointmentSlots": 103,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 14,
-                            "openAppointmentSlots": 14,
-                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                            "openTimeslots": 85,
+                            "openAppointmentSlots": 85,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 332,
+                    "openTimeslots": 85,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 332,
+                    "openAppointmentSlots": 85,
                     "name": "83 and N Texas H-E-B",
                     "longitude": -97.99096,
                     "latitude": 26.17103,
                     "fluUrl": "",
-                    "city": "WESLACO"
+                    "city": "WESLACO",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77488-3204",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubOQAS",
                     "type": "store",
                     "street": "1616 N ALABAMA",
                     "storeNumber": 233,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 29,
+                            "openAppointmentSlots": 29,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 29,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 29,
                     "name": "Wharton H-E-B",
                     "longitude": -96.08492,
                     "latitude": 29.32162,
                     "fluUrl": "",
-                    "city": "WHARTON"
+                    "city": "WHARTON",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77450-4564",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuchQAC",
                     "type": "store",
                     "street": "1621 MASON ROAD",
                     "storeNumber": 497,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 46,
+                            "openAppointmentSlots": 46,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 46,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 46,
                     "name": "Mason Rd H-E-B",
                     "longitude": -95.75102,
                     "latitude": 29.75787,
                     "fluUrl": "",
-                    "city": "KATY"
+                    "city": "KATY",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77346-3128",
@@ -2392,25 +2352,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 67,
-                            "openAppointmentSlots": 67,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 69,
-                            "openAppointmentSlots": 69,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 504,
+                            "openAppointmentSlots": 504,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 136,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 136,
+                    "openTimeslots": 385,
+                    "openFluTimeslots": 119,
+                    "openFluAppointmentSlots": 119,
+                    "openAppointmentSlots": 385,
                     "name": "Atascocita H-E-B",
                     "longitude": -95.1642,
                     "latitude": 29.9983,
-                    "fluUrl": "",
-                    "city": "HUMBLE"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3EQAU",
+                    "city": "HUMBLE",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Moderna"
+                    ]
                 },
                 {
                     "zip": "77087-2558",
@@ -2421,40 +2383,30 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 106,
-                            "openAppointmentSlots": 106,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 47,
-                            "openAppointmentSlots": 47,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 88,
-                            "openAppointmentSlots": 88,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 105,
-                            "openAppointmentSlots": 105,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 87,
-                            "openAppointmentSlots": 87,
-                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                            "openTimeslots": 70,
+                            "openAppointmentSlots": 70,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 433,
+                    "openTimeslots": 70,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 433,
+                    "openAppointmentSlots": 70,
                     "name": "Gulfgate H-E-B",
                     "longitude": -95.2968,
                     "latitude": 29.6994,
                     "fluUrl": "",
-                    "city": "HOUSTON"
+                    "city": "HOUSTON",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Novavax",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna"
+                    ]
                 },
                 {
                     "zip": "77072-5000",
@@ -2465,25 +2417,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 20,
-                            "openAppointmentSlots": 20,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 60,
+                            "openAppointmentSlots": 60,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 30,
+                    "openTimeslots": 60,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 30,
+                    "openAppointmentSlots": 60,
                     "name": "Beechnut H-E-B",
                     "longitude": -95.5604,
                     "latitude": 29.6896,
                     "fluUrl": "",
-                    "city": "HOUSTON"
+                    "city": "HOUSTON",
+                    "availableImmunizations": [
+                        "Flu"
+                    ]
                 },
                 {
                     "zip": "77840-3914",
@@ -2494,25 +2444,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 92,
-                            "openAppointmentSlots": 92,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 100,
-                            "openAppointmentSlots": 100,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 120,
+                            "openAppointmentSlots": 120,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 192,
+                    "openTimeslots": 120,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 192,
+                    "openAppointmentSlots": 120,
                     "name": "Texas Avenue H-E-B",
                     "longitude": -96.3165,
                     "latitude": 30.6131,
                     "fluUrl": "",
-                    "city": "COLLEGE STATION"
+                    "city": "COLLEGE STATION",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77429-6286",
@@ -2523,25 +2472,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 46,
-                            "openAppointmentSlots": 46,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 24,
-                            "openAppointmentSlots": 24,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 262,
+                            "openAppointmentSlots": 262,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 70,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 70,
+                    "openTimeslots": 189,
+                    "openFluTimeslots": 73,
+                    "openFluAppointmentSlots": 73,
+                    "openAppointmentSlots": 189,
                     "name": "Grant and Spring Cypress H-E-B",
                     "longitude": -95.63698,
                     "latitude": 30.00365,
-                    "fluUrl": "",
-                    "city": "CYPRESS"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF0vQAE",
+                    "city": "CYPRESS",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78204-2427",
@@ -2552,30 +2503,28 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 104,
-                            "openAppointmentSlots": 104,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 104,
-                            "openAppointmentSlots": 104,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 104,
-                            "openAppointmentSlots": 104,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 408,
+                            "openAppointmentSlots": 408,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 312,
+                    "openTimeslots": 408,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 312,
+                    "openAppointmentSlots": 408,
                     "name": "Nogalitos H-E-B",
                     "longitude": -98.51485,
                     "latitude": 29.39799,
                     "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "79761-5034",
@@ -2593,7 +2542,8 @@
                     "longitude": -102.37476,
                     "latitude": 31.84625,
                     "fluUrl": "",
-                    "city": "ODESSA"
+                    "city": "ODESSA",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78201-3848",
@@ -2611,31 +2561,27 @@
                     "longitude": -98.53904,
                     "latitude": 29.47602,
                     "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78501-2951",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueBQAS",
+                    "url": null,
                     "type": "store",
                     "street": "200 US EXPRESSWAY 83",
                     "storeNumber": 702,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 2,
-                            "openAppointmentSlots": 2,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 2,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 2,
+                    "openAppointmentSlots": 0,
                     "name": "South 2nd Street H-E-B",
                     "longitude": -98.22546,
                     "latitude": 26.18953,
                     "fluUrl": "",
-                    "city": "MCALLEN"
+                    "city": "MCALLEN",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77386-4343",
@@ -2646,101 +2592,91 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 119,
-                            "openAppointmentSlots": 119,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 176,
-                            "openAppointmentSlots": 176,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 119,
-                            "openAppointmentSlots": 119,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 113,
+                            "openAppointmentSlots": 113,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 414,
+                    "openTimeslots": 113,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 414,
+                    "openAppointmentSlots": 113,
                     "name": "Spring Creek Market H-E-B",
                     "longitude": -95.38801,
                     "latitude": 30.11036,
                     "fluUrl": "",
-                    "city": "SPRING"
+                    "city": "SPRING",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78155-5131",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueLQAS",
+                    "url": null,
                     "type": "store",
                     "street": "1340 E COURT ST",
                     "storeNumber": 716,
-                    "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 363,
-                            "openAppointmentSlots": 363,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 363,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 363,
-                    "name": "Seguin H-E-B",
-                    "longitude": -97.94366,
-                    "latitude": 29.57065,
-                    "fluUrl": "",
-                    "city": "SEGUIN"
-                },
-                {
-                    "zip": "79706-2851",
-                    "url": null,
-                    "type": "store",
-                    "street": "5407 ANDREWS HIGHWAY",
-                    "storeNumber": 717,
                     "state": "TX",
                     "slotDetails": [],
                     "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
                     "openAppointmentSlots": 0,
+                    "name": "Seguin H-E-B",
+                    "longitude": -97.94366,
+                    "latitude": 29.57065,
+                    "fluUrl": "",
+                    "city": "SEGUIN",
+                    "availableImmunizations": null
+                },
+                {
+                    "zip": "79706-2851",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueMQAS",
+                    "type": "store",
+                    "street": "5407 ANDREWS HIGHWAY",
+                    "storeNumber": 717,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 45,
+                            "openAppointmentSlots": 45,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 11,
+                    "openFluTimeslots": 34,
+                    "openFluAppointmentSlots": 34,
+                    "openAppointmentSlots": 11,
                     "name": "Midland Loop 250 H-E-B",
                     "longitude": -102.15509,
                     "latitude": 31.99588,
-                    "fluUrl": "",
-                    "city": "MIDLAND"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF1MQAU",
+                    "city": "MIDLAND",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77345-2621",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueNQAS",
+                    "url": null,
                     "type": "store",
                     "street": "4517 KINGWOOD DRIVE",
                     "storeNumber": 720,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 28,
-                            "openAppointmentSlots": 28,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 30,
-                            "openAppointmentSlots": 30,
-                            "manufacturer": "Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 58,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 58,
+                    "openAppointmentSlots": 0,
                     "name": "Kingwood Market H-E-B",
                     "longitude": -95.18375,
                     "latitude": 30.05329,
                     "fluUrl": "",
-                    "city": "KINGWOOD"
+                    "city": "KINGWOOD",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "76542-0",
@@ -2751,48 +2687,56 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 15,
-                            "openAppointmentSlots": 15,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 41,
-                            "openAppointmentSlots": 41,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 15,
-                            "openAppointmentSlots": 15,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 10,
+                            "openAppointmentSlots": 10,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 71,
+                    "openTimeslots": 10,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 71,
+                    "openAppointmentSlots": 10,
                     "name": "Fort Hood Stan Schlueter H-E-B",
                     "longitude": -97.75988,
                     "latitude": 31.07989,
                     "fluUrl": "",
-                    "city": "KILLEEN"
+                    "city": "KILLEEN",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77354-1611",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuePQAS",
                     "type": "store",
                     "street": "7988 FM 1488",
                     "storeNumber": 722,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 43,
+                            "openAppointmentSlots": 43,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 43,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 43,
                     "name": "Magnolia Market H-E-B",
                     "longitude": -95.5837,
                     "latitude": 30.2217,
                     "fluUrl": "",
-                    "city": "MAGNOLIA"
+                    "city": "MAGNOLIA",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77407-8643",
@@ -2803,48 +2747,57 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 29,
-                            "openAppointmentSlots": 29,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 32,
-                            "openAppointmentSlots": 32,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 47,
-                            "openAppointmentSlots": 47,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 99,
+                            "openAppointmentSlots": 99,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 108,
+                    "openTimeslots": 99,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 108,
+                    "openAppointmentSlots": 99,
                     "name": "Aliana Market H-E-B",
                     "longitude": -95.7137,
                     "latitude": 29.6597,
                     "fluUrl": "",
-                    "city": "RICHMOND"
+                    "city": "RICHMOND",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer"
+                    ]
                 },
                 {
                     "zip": "78572-9139",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucKQAS",
                     "type": "store",
                     "street": "6010 W EXPRESSWAY 83",
                     "storeNumber": 448,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 101,
+                            "openAppointmentSlots": 101,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 101,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 101,
                     "name": "Palmview H-E-B",
                     "longitude": -98.38385,
                     "latitude": 26.23538,
                     "fluUrl": "",
-                    "city": "PALMVIEW"
+                    "city": "PALMVIEW",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78726-4539",
@@ -2855,59 +2808,43 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 31,
-                            "openAppointmentSlots": 31,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 24,
-                            "openAppointmentSlots": 24,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 44,
+                            "openAppointmentSlots": 44,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 65,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 65,
+                    "openTimeslots": 21,
+                    "openFluTimeslots": 23,
+                    "openFluAppointmentSlots": 23,
+                    "openAppointmentSlots": 21,
                     "name": "Four Points H-E-B",
                     "longitude": -97.85202,
                     "latitude": 30.40458,
-                    "fluUrl": "",
-                    "city": "AUSTIN"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2sQAE",
+                    "city": "AUSTIN",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78666-5615",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucNQAS",
+                    "url": null,
                     "type": "store",
                     "street": "200 WEST HOPKINS ST.",
                     "storeNumber": 455,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 18,
-                            "openAppointmentSlots": 18,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 12,
-                            "openAppointmentSlots": 12,
-                            "manufacturer": "Pediatric_Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 30,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 30,
+                    "openAppointmentSlots": 0,
                     "name": "West Hopkins H-E-B",
                     "longitude": -97.94292,
                     "latitude": 29.88305,
                     "fluUrl": "",
-                    "city": "SAN MARCOS"
+                    "city": "SAN MARCOS",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78405-2040",
@@ -2925,7 +2862,8 @@
                     "longitude": -97.42137,
                     "latitude": 27.76687,
                     "fluUrl": "",
-                    "city": "CORPUS CHRISTI"
+                    "city": "CORPUS CHRISTI",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78248-4552",
@@ -2936,40 +2874,31 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 424,
-                            "openAppointmentSlots": 424,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 13,
-                            "openAppointmentSlots": 13,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 499,
-                            "openAppointmentSlots": 499,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 415,
-                            "openAppointmentSlots": 415,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 18,
-                            "openAppointmentSlots": 18,
-                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                            "openTimeslots": 1072,
+                            "openAppointmentSlots": 1072,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 1369,
+                    "openTimeslots": 1072,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 1369,
+                    "openAppointmentSlots": 1072,
                     "name": "Loop 1604 and Blanco Rd H-E-B plus!",
                     "longitude": -98.50968,
                     "latitude": 29.60792,
                     "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer",
+                        "Flu",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Novavax"
+                    ]
                 },
                 {
                     "zip": "78702-3907",
@@ -2980,54 +2909,46 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 150,
-                            "openAppointmentSlots": 150,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 303,
-                            "openAppointmentSlots": 303,
+                            "openTimeslots": 628,
+                            "openAppointmentSlots": 628,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 453,
+                    "openTimeslots": 628,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 453,
+                    "openAppointmentSlots": 628,
                     "name": "7th Street H-E-B",
                     "longitude": -97.71143,
                     "latitude": 30.26046,
                     "fluUrl": "",
-                    "city": "AUSTIN"
+                    "city": "AUSTIN",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer",
+                        "Flu",
+                        "COVID-19 Novavax",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78207-3706",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucRQAS",
+                    "url": null,
                     "type": "store",
                     "street": "108 N ROSILLO",
                     "storeNumber": 466,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 30,
-                            "openAppointmentSlots": 30,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 30,
-                            "openAppointmentSlots": 30,
-                            "manufacturer": "Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 60,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 60,
+                    "openAppointmentSlots": 0,
                     "name": "Commerce and Rosillo H-E-B",
                     "longitude": -98.5256,
                     "latitude": 29.4281,
                     "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "76667-2445",
@@ -3045,7 +2966,8 @@
                     "longitude": -96.47858,
                     "latitude": 31.68434,
                     "fluUrl": "",
-                    "city": "MEXIA"
+                    "city": "MEXIA",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77505-4027",
@@ -3056,30 +2978,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 195,
-                            "openAppointmentSlots": 195,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 214,
-                            "openAppointmentSlots": 214,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 163,
-                            "openAppointmentSlots": 163,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 249,
+                            "openAppointmentSlots": 249,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 572,
+                    "openTimeslots": 249,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 572,
+                    "openAppointmentSlots": 249,
                     "name": "Fairmont Pkwy H-E-B",
                     "longitude": -95.14512,
                     "latitude": 29.6497,
                     "fluUrl": "",
-                    "city": "PASADENA"
+                    "city": "PASADENA",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77459-4180",
@@ -3090,30 +3009,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 51,
-                            "openAppointmentSlots": 51,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 43,
-                            "openAppointmentSlots": 43,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 38,
-                            "openAppointmentSlots": 38,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 769,
+                            "openAppointmentSlots": 769,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 132,
+                    "openTimeslots": 769,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 132,
+                    "openAppointmentSlots": 769,
                     "name": "Lake Colony H-E-B",
                     "longitude": -95.58244,
                     "latitude": 29.58032,
                     "fluUrl": "",
-                    "city": "MISSOURI CITY"
+                    "city": "MISSOURI CITY",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78621-2519",
@@ -3124,30 +3040,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 36,
-                            "openAppointmentSlots": 36,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 69,
-                            "openAppointmentSlots": 69,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 20,
-                            "openAppointmentSlots": 20,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 308,
+                            "openAppointmentSlots": 308,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 125,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 125,
+                    "openTimeslots": 179,
+                    "openFluTimeslots": 129,
+                    "openFluAppointmentSlots": 129,
+                    "openAppointmentSlots": 179,
                     "name": "Elgin H-E-B",
                     "longitude": -97.38258,
                     "latitude": 30.34701,
-                    "fluUrl": "",
-                    "city": "ELGIN"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF31QAE",
+                    "city": "ELGIN",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer"
+                    ]
                 },
                 {
                     "zip": "78753-1632",
@@ -3158,45 +3071,29 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 9,
-                            "openAppointmentSlots": 9,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 1,
-                            "openAppointmentSlots": 1,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 5,
-                            "openAppointmentSlots": 5,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 23,
-                            "openAppointmentSlots": 23,
-                            "manufacturer": "Ultra_Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 9,
-                            "openAppointmentSlots": 9,
+                            "openTimeslots": 74,
+                            "openAppointmentSlots": 74,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 57,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 57,
+                    "openTimeslots": 32,
+                    "openFluTimeslots": 42,
+                    "openFluAppointmentSlots": 42,
+                    "openAppointmentSlots": 32,
                     "name": "Tech Ridge H-E-B",
                     "longitude": -97.67201,
                     "latitude": 30.40443,
-                    "fluUrl": "",
-                    "city": "AUSTIN"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF32QAE",
+                    "city": "AUSTIN",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Novavax",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78610-9703",
@@ -3207,20 +3104,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 49,
-                            "openAppointmentSlots": 49,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 169,
+                            "openAppointmentSlots": 169,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 49,
+                    "openTimeslots": 169,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 49,
+                    "openAppointmentSlots": 169,
                     "name": "Buda H-E-B",
                     "longitude": -97.82074,
                     "latitude": 30.08769,
                     "fluUrl": "",
-                    "city": "BUDA"
+                    "city": "BUDA",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78251-2805",
@@ -3231,69 +3133,44 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 61,
-                            "openAppointmentSlots": 61,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 59,
-                            "openAppointmentSlots": 59,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 63,
-                            "openAppointmentSlots": 63,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 112,
-                            "openAppointmentSlots": 112,
+                            "openTimeslots": 263,
+                            "openAppointmentSlots": 263,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 295,
+                    "openTimeslots": 263,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 295,
+                    "openAppointmentSlots": 263,
                     "name": "Grissom and Tezel H-E-B",
                     "longitude": -98.66574,
                     "latitude": 29.48432,
                     "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78626-5400",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubRQAS",
+                    "url": null,
                     "type": "store",
                     "street": "1100 SOUTH IH35",
                     "storeNumber": 237,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 29,
-                            "openAppointmentSlots": 29,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 44,
-                            "openAppointmentSlots": 44,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 26,
-                            "openAppointmentSlots": 26,
-                            "manufacturer": "Pediatric_Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 99,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 99,
+                    "openAppointmentSlots": 0,
                     "name": "35 and West University H-E-B",
                     "longitude": -97.69028,
                     "latitude": 30.63446,
                     "fluUrl": "",
-                    "city": "GEORGETOWN"
+                    "city": "GEORGETOWN",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "75110-5138",
@@ -3311,7 +3188,8 @@
                     "longitude": -96.46827,
                     "latitude": 32.09005,
                     "fluUrl": "",
-                    "city": "CORSICANA"
+                    "city": "CORSICANA",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78666-7055",
@@ -3322,64 +3200,54 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 28,
-                            "openAppointmentSlots": 28,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 33,
-                            "openAppointmentSlots": 33,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 9,
-                            "openAppointmentSlots": 9,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 563,
+                            "openAppointmentSlots": 563,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 70,
+                    "openTimeslots": 563,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 70,
+                    "openAppointmentSlots": 563,
                     "name": "East Hopkins H-E-B",
                     "longitude": -97.93132,
                     "latitude": 29.88489,
                     "fluUrl": "",
-                    "city": "SAN MARCOS"
+                    "city": "SAN MARCOS",
+                    "availableImmunizations": [
+                        "COVID-19 Moderna",
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78408-3204",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubUQAS",
+                    "url": null,
                     "type": "store",
                     "street": "3500 LEOPARD",
                     "storeNumber": 253,
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 666,
-                            "openAppointmentSlots": 666,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 72,
-                            "openAppointmentSlots": 72,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 83,
-                            "openAppointmentSlots": 83,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 38,
+                            "openAppointmentSlots": 38,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 821,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 821,
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 38,
+                    "openFluAppointmentSlots": 38,
+                    "openAppointmentSlots": 0,
                     "name": "Leopard and Nueces Bay H-E-B",
                     "longitude": -97.42774,
                     "latitude": 27.79695,
-                    "fluUrl": "",
-                    "city": "CORPUS CHRISTI"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF1gQAE",
+                    "city": "CORPUS CHRISTI",
+                    "availableImmunizations": [
+                        "Flu"
+                    ]
                 },
                 {
                     "zip": "77802-5320",
@@ -3390,30 +3258,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 186,
-                            "openAppointmentSlots": 186,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 190,
-                            "openAppointmentSlots": 190,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 60,
-                            "openAppointmentSlots": 60,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 88,
+                            "openAppointmentSlots": 88,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 436,
+                    "openTimeslots": 88,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 436,
+                    "openAppointmentSlots": 88,
                     "name": "Tejas Center H-E-B",
                     "longitude": -96.3513,
                     "latitude": 30.64506,
                     "fluUrl": "",
-                    "city": "BRYAN"
+                    "city": "BRYAN",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer"
+                    ]
                 },
                 {
                     "zip": "77077-6860",
@@ -3424,25 +3289,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 36,
-                            "openAppointmentSlots": 36,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 47,
-                            "openAppointmentSlots": 47,
+                            "openTimeslots": 97,
+                            "openAppointmentSlots": 97,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 83,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 83,
+                    "openTimeslots": 67,
+                    "openFluTimeslots": 30,
+                    "openFluAppointmentSlots": 30,
+                    "openAppointmentSlots": 67,
                     "name": "Westheimer and Kirkwood H-E-B",
                     "longitude": -95.587,
                     "latitude": 29.7363,
-                    "fluUrl": "",
-                    "city": "HOUSTON"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3JQAU",
+                    "city": "HOUSTON",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu"
+                    ]
                 },
                 {
                     "zip": "77084-2718",
@@ -3453,30 +3317,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 55,
-                            "openAppointmentSlots": 55,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 107,
-                            "openAppointmentSlots": 107,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 479,
+                            "openAppointmentSlots": 479,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 212,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 212,
+                    "openTimeslots": 45,
+                    "openFluTimeslots": 434,
+                    "openFluAppointmentSlots": 434,
+                    "openAppointmentSlots": 45,
                     "name": "Bear Creek H-E-B",
                     "longitude": -95.6457,
                     "latitude": 29.8487,
-                    "fluUrl": "",
-                    "city": "HOUSTON"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3KQAU",
+                    "city": "HOUSTON",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pediatric_Pfizer"
+                    ]
                 },
                 {
                     "zip": "77901-6220",
@@ -3494,25 +3352,36 @@
                     "longitude": -96.9896,
                     "latitude": 28.8062,
                     "fluUrl": "",
-                    "city": "VICTORIA"
+                    "city": "VICTORIA",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78148-3806",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucqQAC",
                     "type": "store",
                     "street": "910 KITTY HAWK ROAD",
                     "storeNumber": 555,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 4,
+                            "openAppointmentSlots": 4,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 4,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 4,
                     "name": "Kitty Hawk H-E-B",
                     "longitude": -98.31298,
                     "latitude": 29.54766,
                     "fluUrl": "",
-                    "city": "UNIVERSAL CITY"
+                    "city": "UNIVERSAL CITY",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78201-4407",
@@ -3523,38 +3392,50 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 183,
-                            "openAppointmentSlots": 183,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 183,
+                    "openTimeslots": 20,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 183,
+                    "openAppointmentSlots": 20,
                     "name": "Deco District H-E-B",
                     "longitude": -98.5261,
                     "latitude": 29.4646,
                     "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "76705-2874",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucsQAC",
                     "type": "store",
                     "street": "801 NORTH I-H 35",
                     "storeNumber": 557,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 30,
+                            "openAppointmentSlots": 30,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 30,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 30,
                     "name": "35 and 84 H-E-B plus!",
                     "longitude": -97.10723,
                     "latitude": 31.58764,
                     "fluUrl": "",
-                    "city": "BELLMEAD"
+                    "city": "BELLMEAD",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77546-5405",
@@ -3565,30 +3446,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 464,
-                            "openAppointmentSlots": 464,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 468,
-                            "openAppointmentSlots": 468,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 88,
-                            "openAppointmentSlots": 88,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 247,
+                            "openAppointmentSlots": 247,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 1020,
+                    "openTimeslots": 247,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 1020,
+                    "openAppointmentSlots": 247,
                     "name": "Friendswood H-E-B",
                     "longitude": -95.1912,
                     "latitude": 29.5066,
                     "fluUrl": "",
-                    "city": "FRIENDSWOOD"
+                    "city": "FRIENDSWOOD",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77566-4622",
@@ -3599,35 +3474,28 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 32,
-                            "openAppointmentSlots": 32,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 29,
-                            "openAppointmentSlots": 29,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 32,
-                            "openAppointmentSlots": 32,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 29,
-                            "openAppointmentSlots": 29,
-                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                            "openTimeslots": 91,
+                            "openAppointmentSlots": 91,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 122,
+                    "openTimeslots": 91,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 122,
+                    "openAppointmentSlots": 91,
                     "name": "Lake Jackson H-E-B",
                     "longitude": -95.44554,
                     "latitude": 29.04151,
                     "fluUrl": "",
-                    "city": "LAKE JACKSON"
+                    "city": "LAKE JACKSON",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pediatric_Moderna"
+                    ]
                 },
                 {
                     "zip": "78676-6215",
@@ -3638,25 +3506,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 94,
-                            "openAppointmentSlots": 94,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 72,
-                            "openAppointmentSlots": 72,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 29,
+                            "openAppointmentSlots": 29,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 166,
+                    "openTimeslots": 29,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 166,
+                    "openAppointmentSlots": 29,
                     "name": "Wimberley H-E-B",
                     "longitude": -98.10174,
                     "latitude": 30.00144,
                     "fluUrl": "",
-                    "city": "WIMBERLEY"
+                    "city": "WIMBERLEY",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77433-4847",
@@ -3667,30 +3537,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 38,
-                            "openAppointmentSlots": 38,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 164,
-                            "openAppointmentSlots": 164,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 48,
-                            "openAppointmentSlots": 48,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 109,
+                            "openAppointmentSlots": 109,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 250,
+                    "openTimeslots": 109,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 250,
+                    "openAppointmentSlots": 109,
                     "name": "H-E-B Market at Tuckerton",
                     "longitude": -95.72501,
                     "latitude": 29.92737,
                     "fluUrl": "",
-                    "city": "CYPRESS"
+                    "city": "CYPRESS",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77379-8693",
@@ -3701,59 +3566,44 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 95,
+                            "openAppointmentSlots": 95,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 50,
+                    "openTimeslots": 95,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 50,
+                    "openAppointmentSlots": 95,
                     "name": "Champion Forest Market H-E-B",
                     "longitude": -95.57475,
                     "latitude": 30.0551,
                     "fluUrl": "",
-                    "city": "SPRING"
+                    "city": "SPRING",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer"
+                    ]
                 },
                 {
                     "zip": "77469-2509",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueSQAS",
+                    "url": null,
                     "type": "store",
                     "street": "23500 CIRCLE OAK PARKWAY",
                     "storeNumber": 727,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 9,
-                            "openAppointmentSlots": 9,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 4,
-                            "openAppointmentSlots": 4,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 6,
-                            "openAppointmentSlots": 6,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 18,
-                            "openAppointmentSlots": 18,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 37,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 37,
+                    "openAppointmentSlots": 0,
                     "name": "Richmond Market H-E-B",
                     "longitude": -95.74781,
                     "latitude": 29.55142,
                     "fluUrl": "",
-                    "city": "RICHMOND"
+                    "city": "RICHMOND",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77340-3723",
@@ -3764,30 +3614,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 59,
-                            "openAppointmentSlots": 59,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 60,
-                            "openAppointmentSlots": 60,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 59,
-                            "openAppointmentSlots": 59,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 64,
+                            "openAppointmentSlots": 64,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 178,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 178,
+                    "openTimeslots": 26,
+                    "openFluTimeslots": 38,
+                    "openFluAppointmentSlots": 38,
+                    "openAppointmentSlots": 26,
                     "name": "Huntsville H-E-B",
                     "longitude": -95.56075,
                     "latitude": 30.72274,
-                    "fluUrl": "",
-                    "city": "HUNTSVILLE"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF1TQAU",
+                    "city": "HUNTSVILLE",
+                    "availableImmunizations": [
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu"
+                    ]
                 },
                 {
                     "zip": "78247-0",
@@ -3798,40 +3645,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 194,
-                            "openAppointmentSlots": 194,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 16,
-                            "openAppointmentSlots": 16,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 252,
-                            "openAppointmentSlots": 252,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 185,
-                            "openAppointmentSlots": 185,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 25,
-                            "openAppointmentSlots": 25,
-                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                            "openTimeslots": 1106,
+                            "openAppointmentSlots": 1106,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 672,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 672,
+                    "openTimeslots": 938,
+                    "openFluTimeslots": 168,
+                    "openFluAppointmentSlots": 168,
+                    "openAppointmentSlots": 938,
                     "name": "Bulverde and 1604 H-E-B",
                     "longitude": -98.41746,
                     "latitude": 29.59497,
-                    "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF1UQAU",
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78041-5754",
@@ -3842,20 +3674,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 18,
-                            "openAppointmentSlots": 18,
+                            "openTimeslots": 3,
+                            "openAppointmentSlots": 3,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 18,
+                    "openTimeslots": 3,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 18,
+                    "openAppointmentSlots": 3,
                     "name": "35 and Calton H-E-B",
                     "longitude": -99.50182,
                     "latitude": 27.54172,
                     "fluUrl": "",
-                    "city": "LAREDO"
+                    "city": "LAREDO",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer",
+                        "COVID-19 Moderna"
+                    ]
                 },
                 {
                     "zip": "78238-1986",
@@ -3873,7 +3709,8 @@
                     "longitude": -98.59477,
                     "latitude": 29.48119,
                     "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78520-8327",
@@ -3884,40 +3721,28 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 59,
-                            "openAppointmentSlots": 59,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 14,
-                            "openAppointmentSlots": 14,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 51,
-                            "openAppointmentSlots": 51,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 32,
-                            "openAppointmentSlots": 32,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 14,
-                            "openAppointmentSlots": 14,
-                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                            "openTimeslots": 48,
+                            "openAppointmentSlots": 48,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 170,
+                    "openTimeslots": 48,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 170,
+                    "openAppointmentSlots": 48,
                     "name": "Central Blvd H-E-B",
                     "longitude": -97.51093,
                     "latitude": 25.92849,
                     "fluUrl": "",
-                    "city": "BROWNSVILLE"
+                    "city": "BROWNSVILLE",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna"
+                    ]
                 },
                 {
                     "zip": "78613-1900",
@@ -3928,30 +3753,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 65,
-                            "openAppointmentSlots": 65,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 57,
-                            "openAppointmentSlots": 57,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 17,
-                            "openAppointmentSlots": 17,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 40,
+                            "openAppointmentSlots": 40,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 139,
+                    "openTimeslots": 40,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 139,
+                    "openAppointmentSlots": 40,
                     "name": "Hwy 183 and Whitestone Blvd H-E-B",
                     "longitude": -97.82911,
                     "latitude": 30.5225,
                     "fluUrl": "",
-                    "city": "CEDAR PARK"
+                    "city": "CEDAR PARK",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78759-5780",
@@ -3962,30 +3782,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 32,
-                            "openAppointmentSlots": 32,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 27,
-                            "openAppointmentSlots": 27,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 13,
-                            "openAppointmentSlots": 13,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 131,
+                            "openAppointmentSlots": 131,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 72,
+                    "openTimeslots": 131,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 72,
+                    "openAppointmentSlots": 131,
                     "name": "North Hills H-E-B",
                     "longitude": -97.74832,
                     "latitude": 30.39868,
                     "fluUrl": "",
-                    "city": "AUSTIN"
+                    "city": "AUSTIN",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78411-5301",
@@ -3996,25 +3812,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 25,
-                            "openAppointmentSlots": 25,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 25,
-                            "openAppointmentSlots": 25,
-                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                            "openTimeslots": 39,
+                            "openAppointmentSlots": 39,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 50,
+                    "openTimeslots": 39,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 50,
+                    "openAppointmentSlots": 39,
                     "name": "Moore Plaza H-E-B",
                     "longitude": -97.37238,
                     "latitude": 27.70605,
                     "fluUrl": "",
-                    "city": "CORPUS CHRISTI"
+                    "city": "CORPUS CHRISTI",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu"
+                    ]
                 },
                 {
                     "zip": "78624-4146",
@@ -4025,25 +3840,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 17,
-                            "openAppointmentSlots": 17,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 20,
-                            "openAppointmentSlots": 20,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 9,
+                            "openAppointmentSlots": 9,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 37,
+                    "openTimeslots": 9,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 37,
+                    "openAppointmentSlots": 9,
                     "name": "Fredericksburg H-E-B",
                     "longitude": -98.87538,
                     "latitude": 30.27006,
                     "fluUrl": "",
-                    "city": "FREDERICKSBURG"
+                    "city": "FREDERICKSBURG",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78382-3314",
@@ -4061,7 +3874,8 @@
                     "longitude": -97.0425,
                     "latitude": 28.0378,
                     "fluUrl": "",
-                    "city": "ROCKPORT"
+                    "city": "ROCKPORT",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77479-6505",
@@ -4072,53 +3886,55 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 36,
-                            "openAppointmentSlots": 36,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 93,
-                            "openAppointmentSlots": 93,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 20,
-                            "openAppointmentSlots": 20,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 8,
-                            "openAppointmentSlots": 8,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 294,
+                            "openAppointmentSlots": 294,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 157,
+                    "openTimeslots": 294,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 157,
+                    "openAppointmentSlots": 294,
                     "name": "Riverpark H-E-B",
                     "longitude": -95.6815,
                     "latitude": 29.5636,
                     "fluUrl": "",
-                    "city": "SUGAR LAND"
+                    "city": "SUGAR LAND",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu",
+                        "COVID-19 Novavax",
+                        "COVID-19 Pediatric_Pfizer"
+                    ]
                 },
                 {
                     "zip": "77380-2272",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucxQAC",
                     "type": "store",
                     "street": "130 SAWDUST ROAD",
                     "storeNumber": 564,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 115,
+                            "openAppointmentSlots": 115,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 115,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 115,
                     "name": "Sawdust Rd and 45 H-E-B",
                     "longitude": -95.44512,
                     "latitude": 30.12684,
                     "fluUrl": "",
-                    "city": "SPRING"
+                    "city": "SPRING",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78257-1161",
@@ -4129,25 +3945,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 56,
-                            "openAppointmentSlots": 56,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 43,
-                            "openAppointmentSlots": 43,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 402,
+                            "openAppointmentSlots": 402,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 99,
+                    "openTimeslots": 402,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 99,
+                    "openAppointmentSlots": 402,
                     "name": "Leon Springs H-E-B",
                     "longitude": -98.63218,
                     "latitude": 29.6659,
                     "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78209-1804",
@@ -4165,7 +3983,8 @@
                     "longitude": -98.4682,
                     "latitude": 29.4967,
                     "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78217-2116",
@@ -4176,20 +3995,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 218,
-                            "openAppointmentSlots": 218,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 22,
+                            "openAppointmentSlots": 22,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 218,
+                    "openTimeslots": 22,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 218,
+                    "openAppointmentSlots": 22,
                     "name": "Perrin Beitel and Thousand Oaks H-E-B",
                     "longitude": -98.4082,
                     "latitude": 29.5491,
                     "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78582-4815",
@@ -4200,40 +4025,29 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 54,
-                            "openAppointmentSlots": 54,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 54,
-                            "openAppointmentSlots": 54,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 48,
-                            "openAppointmentSlots": 48,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 54,
-                            "openAppointmentSlots": 54,
-                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                            "openTimeslots": 45,
+                            "openAppointmentSlots": 45,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 260,
+                    "openTimeslots": 45,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 260,
+                    "openAppointmentSlots": 45,
                     "name": "Rio Grande City H-E-B plus!",
                     "longitude": -98.80031,
                     "latitude": 26.37244,
                     "fluUrl": "",
-                    "city": "RIO GRANDE CITY"
+                    "city": "RIO GRANDE CITY",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78550-5905",
@@ -4251,7 +4065,8 @@
                     "longitude": -97.71403,
                     "latitude": 26.18328,
                     "fluUrl": "",
-                    "city": "HARLINGEN"
+                    "city": "HARLINGEN",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77414-5305",
@@ -4262,106 +4077,90 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 20,
-                            "openAppointmentSlots": 20,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 28,
-                            "openAppointmentSlots": 28,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 16,
+                            "openAppointmentSlots": 16,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 48,
+                    "openTimeslots": 16,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 48,
+                    "openAppointmentSlots": 16,
                     "name": "Bay City H-E-B",
                     "longitude": -95.95804,
                     "latitude": 28.98306,
                     "fluUrl": "",
-                    "city": "BAY CITY"
+                    "city": "BAY CITY",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78244-1300",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubdQAC",
+                    "url": null,
                     "type": "store",
                     "street": "6580 F.M. 78",
                     "storeNumber": 294,
-                    "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 15,
-                            "openAppointmentSlots": 15,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 15,
-                            "openAppointmentSlots": 15,
-                            "manufacturer": "Pediatric_Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 30,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 30,
-                    "name": "Foster Rd H-E-B",
-                    "longitude": -98.3591,
-                    "latitude": 29.48109,
-                    "fluUrl": "",
-                    "city": "SAN ANTONIO"
-                },
-                {
-                    "zip": "78521-4787",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubeQAC",
-                    "type": "store",
-                    "street": "2950 SOUTHMOST ROAD",
-                    "storeNumber": 332,
-                    "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 72,
-                            "openAppointmentSlots": 72,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 57,
-                            "openAppointmentSlots": 57,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 48,
-                            "openAppointmentSlots": 48,
-                            "manufacturer": "Pediatric_Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 177,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 177,
-                    "name": "Southmost and 30th H-E-B",
-                    "longitude": -97.46481,
-                    "latitude": 25.90552,
-                    "fluUrl": "",
-                    "city": "BROWNSVILLE"
-                },
-                {
-                    "zip": "78336-1919",
-                    "url": null,
-                    "type": "store",
-                    "street": "101 E. GOODNIGHT",
-                    "storeNumber": 333,
                     "state": "TX",
                     "slotDetails": [],
                     "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
                     "openAppointmentSlots": 0,
+                    "name": "Foster Rd H-E-B",
+                    "longitude": -98.3591,
+                    "latitude": 29.48109,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": null
+                },
+                {
+                    "zip": "78521-4787",
+                    "url": null,
+                    "type": "store",
+                    "street": "2950 SOUTHMOST ROAD",
+                    "storeNumber": 332,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Southmost and 30th H-E-B",
+                    "longitude": -97.46481,
+                    "latitude": 25.90552,
+                    "fluUrl": "",
+                    "city": "BROWNSVILLE",
+                    "availableImmunizations": null
+                },
+                {
+                    "zip": "78336-1919",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubfQAC",
+                    "type": "store",
+                    "street": "101 E. GOODNIGHT",
+                    "storeNumber": 333,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 240,
+                            "openAppointmentSlots": 240,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 240,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 240,
                     "name": "Aransas Pass H-E-B",
                     "longitude": -97.14616,
                     "latitude": 27.90255,
                     "fluUrl": "",
-                    "city": "ARANSAS PASS"
+                    "city": "ARANSAS PASS",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78501-3512",
@@ -4372,35 +4171,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 19,
-                            "openAppointmentSlots": 19,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 17,
-                            "openAppointmentSlots": 17,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 29,
-                            "openAppointmentSlots": 29,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 29,
-                            "openAppointmentSlots": 29,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 30,
+                            "openAppointmentSlots": 30,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 94,
+                    "openTimeslots": 30,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 94,
+                    "openAppointmentSlots": 30,
                     "name": "Pecan and Ware H-E-B",
                     "longitude": -98.25799,
                     "latitude": 26.21925,
                     "fluUrl": "",
-                    "city": "MCALLEN"
+                    "city": "MCALLEN",
+                    "availableImmunizations": [
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78640-6038",
@@ -4411,35 +4199,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 21,
-                            "openAppointmentSlots": 21,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 7,
-                            "openAppointmentSlots": 7,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 24,
-                            "openAppointmentSlots": 24,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 15,
-                            "openAppointmentSlots": 15,
-                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                            "openTimeslots": 17,
+                            "openAppointmentSlots": 17,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 67,
+                    "openTimeslots": 17,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 67,
+                    "openAppointmentSlots": 17,
                     "name": "Kyle H-E-B plus!",
                     "longitude": -97.86258,
                     "latitude": 30.01533,
                     "fluUrl": "",
-                    "city": "KYLE"
+                    "city": "KYLE",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "76028-5154",
@@ -4450,30 +4230,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 60,
-                            "openAppointmentSlots": 60,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 68,
-                            "openAppointmentSlots": 68,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 51,
-                            "openAppointmentSlots": 51,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 155,
+                            "openAppointmentSlots": 155,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 179,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 179,
+                    "openTimeslots": 121,
+                    "openFluTimeslots": 34,
+                    "openFluAppointmentSlots": 34,
+                    "openAppointmentSlots": 121,
                     "name": "Burleson H-E-B plus!",
                     "longitude": -97.34901,
                     "latitude": 32.52083,
-                    "fluUrl": "",
-                    "city": "BURLESON"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3wQAE",
+                    "city": "BURLESON",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78052-3622",
@@ -4484,30 +4261,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 119,
-                            "openAppointmentSlots": 119,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 88,
-                            "openAppointmentSlots": 88,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 82,
-                            "openAppointmentSlots": 82,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 285,
+                            "openAppointmentSlots": 285,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 289,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 289,
+                    "openTimeslots": 68,
+                    "openFluTimeslots": 217,
+                    "openFluAppointmentSlots": 217,
+                    "openAppointmentSlots": 68,
                     "name": "Lytle H-E-B plus!",
                     "longitude": -98.78924,
                     "latitude": 29.23224,
-                    "fluUrl": "",
-                    "city": "LYTLE"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3xQAE",
+                    "city": "LYTLE",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer"
+                    ]
                 },
                 {
                     "zip": "77429-5683",
@@ -4518,30 +4291,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 38,
-                            "openAppointmentSlots": 38,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 46,
-                            "openAppointmentSlots": 46,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 26,
-                            "openAppointmentSlots": 26,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 78,
+                            "openAppointmentSlots": 78,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 110,
+                    "openTimeslots": 78,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 110,
+                    "openAppointmentSlots": 78,
                     "name": "Cypress Market H-E-B",
                     "longitude": -95.6765,
                     "latitude": 29.95569,
                     "fluUrl": "",
-                    "city": "CYPRESS"
+                    "city": "CYPRESS",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78726-1168",
@@ -4552,25 +4322,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 7,
-                            "openAppointmentSlots": 7,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 26,
-                            "openAppointmentSlots": 26,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 33,
+                    "openTimeslots": 20,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 33,
+                    "openAppointmentSlots": 20,
                     "name": "Anderson Mill H-E-B plus!",
                     "longitude": -97.82626,
                     "latitude": 30.45495,
                     "fluUrl": "",
-                    "city": "AUSTIN"
+                    "city": "AUSTIN",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer"
+                    ]
                 },
                 {
                     "zip": "76542-1910",
@@ -4581,53 +4352,61 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 72,
-                            "openAppointmentSlots": 72,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 23,
-                            "openAppointmentSlots": 23,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 67,
-                            "openAppointmentSlots": 67,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 26,
-                            "openAppointmentSlots": 26,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 171,
+                            "openAppointmentSlots": 171,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 188,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 188,
+                    "openTimeslots": 78,
+                    "openFluTimeslots": 93,
+                    "openFluAppointmentSlots": 93,
+                    "openAppointmentSlots": 78,
                     "name": "Trimmier H-E-B plus!",
                     "longitude": -97.7338,
                     "latitude": 31.0909,
-                    "fluUrl": "",
-                    "city": "KILLEEN"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3eQAE",
+                    "city": "KILLEEN",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna"
+                    ]
                 },
                 {
                     "zip": "78602-3740",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gud9QAC",
                     "type": "store",
                     "street": "104 N HASLER BLVD",
                     "storeNumber": 582,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 5,
+                            "openAppointmentSlots": 5,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 5,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 5,
                     "name": "Bastrop H-E-B plus!",
                     "longitude": -97.33458,
                     "latitude": 30.10981,
                     "fluUrl": "",
-                    "city": "BASTROP"
+                    "city": "BASTROP",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "76712-3371",
@@ -4645,25 +4424,36 @@
                     "longitude": -97.22132,
                     "latitude": 31.49664,
                     "fluUrl": "",
-                    "city": "WOODWAY"
+                    "city": "WOODWAY",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77437-4420",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudBQAS",
                     "type": "store",
                     "street": "306 N. MECHANIC",
                     "storeNumber": 584,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 217,
+                            "openAppointmentSlots": 217,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 217,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 217,
                     "name": "El Campo H-E-B",
                     "longitude": -96.26988,
                     "latitude": 29.19683,
                     "fluUrl": "",
-                    "city": "EL CAMPO"
+                    "city": "EL CAMPO",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu"
+                    ]
                 },
                 {
                     "zip": "78218-6039",
@@ -4674,35 +4464,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 8,
-                            "openAppointmentSlots": 8,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 44,
-                            "openAppointmentSlots": 44,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 51,
-                            "openAppointmentSlots": 51,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 16,
-                            "openAppointmentSlots": 16,
+                            "openTimeslots": 93,
+                            "openAppointmentSlots": 93,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 119,
+                    "openTimeslots": 93,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 119,
+                    "openAppointmentSlots": 93,
                     "name": "Austin Highway H-E-B",
                     "longitude": -98.43132,
                     "latitude": 29.4937,
                     "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78046-6563",
@@ -4713,35 +4494,28 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 9,
-                            "openAppointmentSlots": 9,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 36,
-                            "openAppointmentSlots": 36,
+                            "openTimeslots": 91,
+                            "openAppointmentSlots": 91,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 65,
+                    "openTimeslots": 91,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 65,
+                    "openAppointmentSlots": 91,
                     "name": "Zapata Highway H-E-B",
                     "longitude": -99.47479,
                     "latitude": 27.47673,
                     "fluUrl": "",
-                    "city": "LAREDO"
+                    "city": "LAREDO",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78253-0",
@@ -4759,7 +4533,8 @@
                     "longitude": -98.73294,
                     "latitude": 29.48572,
                     "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "76901-0",
@@ -4777,7 +4552,8 @@
                     "longitude": -100.51103,
                     "latitude": 31.43158,
                     "fluUrl": "",
-                    "city": "SAN ANGELO"
+                    "city": "SAN ANGELO",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77494-5426",
@@ -4788,35 +4564,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 5,
-                            "openAppointmentSlots": 5,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 5,
-                            "openAppointmentSlots": 5,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 13,
-                            "openAppointmentSlots": 13,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 63,
-                            "openAppointmentSlots": 63,
+                            "openTimeslots": 98,
+                            "openAppointmentSlots": 98,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 86,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 86,
+                    "openTimeslots": 50,
+                    "openFluTimeslots": 48,
+                    "openFluAppointmentSlots": 48,
+                    "openAppointmentSlots": 50,
                     "name": "Cross Creek Ranch H-E-B",
                     "longitude": -95.84788,
                     "latitude": 29.71936,
-                    "fluUrl": "",
-                    "city": "KATY"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF1nQAE",
+                    "city": "KATY",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77008-0",
@@ -4827,20 +4593,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 39,
-                            "openAppointmentSlots": 39,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 257,
+                            "openAppointmentSlots": 257,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 39,
+                    "openTimeslots": 257,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 39,
+                    "openAppointmentSlots": 257,
                     "name": "The Heights H-E-B",
                     "longitude": -95.40865,
                     "latitude": 29.80735,
                     "fluUrl": "",
-                    "city": "HOUSTON"
+                    "city": "HOUSTON",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Janssen"
+                    ]
                 },
                 {
                     "zip": "77401-4019",
@@ -4851,30 +4622,30 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 6,
-                            "openAppointmentSlots": 6,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 4,
-                            "openAppointmentSlots": 4,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 94,
-                            "openAppointmentSlots": 94,
+                            "openTimeslots": 380,
+                            "openAppointmentSlots": 380,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 104,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 104,
+                    "openTimeslots": 182,
+                    "openFluTimeslots": 198,
+                    "openFluAppointmentSlots": 198,
+                    "openAppointmentSlots": 182,
                     "name": "Bellaire Market H-E-B",
                     "longitude": -95.46938,
                     "latitude": 29.70764,
-                    "fluUrl": "",
-                    "city": "BELLAIRE"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF1pQAE",
+                    "city": "BELLAIRE",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Novavax",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77523-0",
@@ -4885,30 +4656,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 44,
-                            "openAppointmentSlots": 44,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 29,
-                            "openAppointmentSlots": 29,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 154,
+                            "openAppointmentSlots": 154,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 123,
+                    "openTimeslots": 154,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 123,
+                    "openAppointmentSlots": 154,
                     "name": "Mont Belvieu H-E-B",
                     "longitude": -94.84973,
                     "latitude": 29.82755,
                     "fluUrl": "",
-                    "city": "MONT BELVIEU"
+                    "city": "MONT BELVIEU",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78114-1851",
@@ -4919,25 +4687,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 12,
-                            "openAppointmentSlots": 12,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 23,
-                            "openAppointmentSlots": 23,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 60,
+                            "openAppointmentSlots": 60,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 35,
+                    "openTimeslots": 60,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 35,
+                    "openAppointmentSlots": 60,
                     "name": "Floresville H-E-B",
                     "longitude": -98.15681,
                     "latitude": 29.14284,
                     "fluUrl": "",
-                    "city": "FLORESVILLE"
+                    "city": "FLORESVILLE",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78223-1717",
@@ -4948,35 +4715,29 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 30,
-                            "openAppointmentSlots": 30,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 37,
-                            "openAppointmentSlots": 37,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 188,
-                            "openAppointmentSlots": 188,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 126,
-                            "openAppointmentSlots": 126,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 658,
+                            "openAppointmentSlots": 658,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 381,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 381,
+                    "openTimeslots": 551,
+                    "openFluTimeslots": 107,
+                    "openFluAppointmentSlots": 107,
+                    "openAppointmentSlots": 551,
                     "name": "McCreless Market H-E-B plus!",
                     "longitude": -98.46115,
                     "latitude": 29.37828,
-                    "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF41QAE",
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Novavax"
+                    ]
                 },
                 {
                     "zip": "77573-6750",
@@ -4987,30 +4748,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 77,
-                            "openAppointmentSlots": 77,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 47,
-                            "openAppointmentSlots": 47,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 325,
+                            "openAppointmentSlots": 325,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 174,
+                    "openTimeslots": 325,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 174,
+                    "openAppointmentSlots": 325,
                     "name": "Bay Colony H-E-B",
                     "longitude": -95.0926,
                     "latitude": 29.4677,
                     "fluUrl": "",
-                    "city": "LEAGUE CITY"
+                    "city": "LEAGUE CITY",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78746-5256",
@@ -5021,25 +4777,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 12,
-                            "openAppointmentSlots": 12,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 12,
-                            "openAppointmentSlots": 12,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 2,
+                            "openAppointmentSlots": 2,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 24,
+                    "openTimeslots": 2,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 24,
+                    "openAppointmentSlots": 2,
                     "name": "Westlake H-E-B",
                     "longitude": -97.82813,
                     "latitude": 30.2928,
                     "fluUrl": "",
-                    "city": "WEST LAKE HILLS"
+                    "city": "WEST LAKE HILLS",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78750-3222",
@@ -5050,40 +4805,28 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 84,
-                            "openAppointmentSlots": 84,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 15,
-                            "openAppointmentSlots": 15,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 11,
-                            "openAppointmentSlots": 11,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 55,
-                            "openAppointmentSlots": 55,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 19,
-                            "openAppointmentSlots": 19,
-                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                            "openTimeslots": 363,
+                            "openAppointmentSlots": 363,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 184,
+                    "openTimeslots": 363,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 184,
+                    "openAppointmentSlots": 363,
                     "name": "Spicewood Springs H-E-B",
                     "longitude": -97.7713,
                     "latitude": 30.43494,
                     "fluUrl": "",
-                    "city": "AUSTIN"
+                    "city": "AUSTIN",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Novavax"
+                    ]
                 },
                 {
                     "zip": "78664-4642",
@@ -5094,30 +4837,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 47,
-                            "openAppointmentSlots": 47,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 46,
-                            "openAppointmentSlots": 46,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 9,
-                            "openAppointmentSlots": 9,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 1232,
+                            "openAppointmentSlots": 1232,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 102,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 102,
+                    "openTimeslots": 586,
+                    "openFluTimeslots": 646,
+                    "openFluAppointmentSlots": 646,
+                    "openAppointmentSlots": 586,
                     "name": "Red Bud Lane and Gattis School H-E-B",
                     "longitude": -97.61475,
                     "latitude": 30.49721,
-                    "fluUrl": "",
-                    "city": "ROUND ROCK"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4IQAU",
+                    "city": "ROUND ROCK",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77957-2728",
@@ -5128,30 +4868,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 20,
-                            "openAppointmentSlots": 20,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 23,
-                            "openAppointmentSlots": 23,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 46,
+                            "openAppointmentSlots": 46,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 53,
+                    "openTimeslots": 46,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 53,
+                    "openAppointmentSlots": 46,
                     "name": "Edna H-E-B",
                     "longitude": -96.64731,
                     "latitude": 28.97947,
                     "fluUrl": "",
-                    "city": "EDNA"
+                    "city": "EDNA",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer"
+                    ]
                 },
                 {
                     "zip": "78209-2217",
@@ -5162,35 +4898,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 94,
-                            "openAppointmentSlots": 94,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 84,
-                            "openAppointmentSlots": 84,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 48,
-                            "openAppointmentSlots": 48,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 280,
-                            "openAppointmentSlots": 280,
+                            "openTimeslots": 206,
+                            "openAppointmentSlots": 206,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 506,
+                    "openTimeslots": 206,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 506,
+                    "openAppointmentSlots": 206,
                     "name": "Oak Park H-E-B",
                     "longitude": -98.45759,
                     "latitude": 29.50774,
                     "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": [
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78681-3922",
@@ -5201,48 +4926,61 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 1765,
-                            "openAppointmentSlots": 1765,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 1761,
-                            "openAppointmentSlots": 1761,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 1762,
-                            "openAppointmentSlots": 1762,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 1423,
+                            "openAppointmentSlots": 1423,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 5288,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 5288,
+                    "openTimeslots": 1054,
+                    "openFluTimeslots": 369,
+                    "openFluAppointmentSlots": 369,
+                    "openAppointmentSlots": 1054,
                     "name": "620 and O'Connor H-E-B",
                     "longitude": -97.72218,
                     "latitude": 30.50028,
-                    "fluUrl": "",
-                    "city": "ROUND ROCK"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2AQAU",
+                    "city": "ROUND ROCK",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Janssen",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Novavax"
+                    ]
                 },
                 {
                     "zip": "78130-5722",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubkQAC",
                     "type": "store",
                     "street": "651 S.WALNUT",
                     "storeNumber": 775,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 284,
+                            "openAppointmentSlots": 284,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 284,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 284,
                     "name": "New Braunfels H-E-B at Walnut",
                     "longitude": -98.12631,
                     "latitude": 29.68903,
                     "fluUrl": "",
-                    "city": "NEW BRAUNFELS"
+                    "city": "NEW BRAUNFELS",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Janssen",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "76548-1347",
@@ -5253,30 +4991,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 29,
-                            "openAppointmentSlots": 29,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 122,
-                            "openAppointmentSlots": 122,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 29,
-                            "openAppointmentSlots": 29,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 263,
+                            "openAppointmentSlots": 263,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 180,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 180,
+                    "openTimeslots": 166,
+                    "openFluTimeslots": 97,
+                    "openFluAppointmentSlots": 97,
+                    "openAppointmentSlots": 166,
                     "name": "Harker Heights H-E-B",
                     "longitude": -97.65511,
                     "latitude": 31.07905,
-                    "fluUrl": "",
-                    "city": "HARKER HEIGHTS"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2CQAU",
+                    "city": "HARKER HEIGHTS",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pediatric_Pfizer"
+                    ]
                 },
                 {
                     "zip": "79707-5714",
@@ -5287,35 +5022,28 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 42,
-                            "openAppointmentSlots": 42,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 44,
-                            "openAppointmentSlots": 44,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 21,
-                            "openAppointmentSlots": 21,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 196,
-                            "openAppointmentSlots": 196,
+                            "openTimeslots": 240,
+                            "openAppointmentSlots": 240,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 303,
+                    "openTimeslots": 240,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 303,
+                    "openAppointmentSlots": 240,
                     "name": "West Wadley H-E-B",
                     "longitude": -102.12562,
                     "latitude": 32.01955,
                     "fluUrl": "",
-                    "city": "MIDLAND"
+                    "city": "MIDLAND",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78239-3233",
@@ -5326,30 +5054,28 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 222,
-                            "openAppointmentSlots": 222,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 284,
-                            "openAppointmentSlots": 284,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 135,
-                            "openAppointmentSlots": 135,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 80,
+                            "openAppointmentSlots": 80,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 641,
+                    "openTimeslots": 80,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 641,
+                    "openAppointmentSlots": 80,
                     "name": "Montgomery at Walzem",
                     "longitude": -98.37092,
                     "latitude": 29.5105,
                     "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78212-1958",
@@ -5360,30 +5086,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 65,
-                            "openAppointmentSlots": 65,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 106,
-                            "openAppointmentSlots": 106,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 7,
-                            "openAppointmentSlots": 7,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 124,
+                            "openAppointmentSlots": 124,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 178,
+                    "openTimeslots": 124,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 178,
+                    "openAppointmentSlots": 124,
                     "name": "Olmos Park H-E-B",
                     "longitude": -98.497,
                     "latitude": 29.4707,
                     "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "79762-5947",
@@ -5401,7 +5121,8 @@
                     "longitude": -102.34383,
                     "latitude": 31.89134,
                     "fluUrl": "",
-                    "city": "ODESSA"
+                    "city": "ODESSA",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78727-3901",
@@ -5412,35 +5133,28 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 5,
-                            "openAppointmentSlots": 5,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 3,
-                            "openAppointmentSlots": 3,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 36,
-                            "openAppointmentSlots": 36,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 9,
-                            "openAppointmentSlots": 9,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 105,
+                            "openAppointmentSlots": 105,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 53,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 53,
+                    "openTimeslots": 34,
+                    "openFluTimeslots": 71,
+                    "openFluAppointmentSlots": 71,
+                    "openAppointmentSlots": 34,
                     "name": "Parmer and McNeil H-E-B",
                     "longitude": -97.74278,
                     "latitude": 30.44181,
-                    "fluUrl": "",
-                    "city": "AUSTIN"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2MQAU",
+                    "city": "AUSTIN",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna"
+                    ]
                 },
                 {
                     "zip": "77642-7403",
@@ -5451,64 +5165,49 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 18,
-                            "openAppointmentSlots": 18,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 25,
-                            "openAppointmentSlots": 25,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 12,
-                            "openAppointmentSlots": 12,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 30,
-                            "openAppointmentSlots": 30,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 15,
-                            "openAppointmentSlots": 15,
-                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                            "openTimeslots": 196,
+                            "openAppointmentSlots": 196,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 100,
+                    "openTimeslots": 196,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 100,
+                    "openAppointmentSlots": 196,
                     "name": "Mid County H-E-B",
                     "longitude": -93.9758,
                     "latitude": 29.966,
                     "fluUrl": "",
-                    "city": "PORT ARTHUR"
+                    "city": "PORT ARTHUR",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Novavax"
+                    ]
                 },
                 {
                     "zip": "78504-7705",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudFQAS",
+                    "url": null,
                     "type": "store",
                     "street": "901 TRENTON RD",
                     "storeNumber": 590,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 8,
-                            "openAppointmentSlots": 8,
-                            "manufacturer": "Moderna"
-                        }
-                    ],
-                    "openTimeslots": 8,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 8,
+                    "openAppointmentSlots": 0,
                     "name": "10th and Trenton H-E-B",
                     "longitude": -98.2188,
                     "latitude": 26.2678,
                     "fluUrl": "",
-                    "city": "MCALLEN"
+                    "city": "MCALLEN",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78641-7001",
@@ -5519,35 +5218,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 40,
-                            "openAppointmentSlots": 40,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 38,
-                            "openAppointmentSlots": 38,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 9,
-                            "openAppointmentSlots": 9,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 54,
-                            "openAppointmentSlots": 54,
+                            "openTimeslots": 114,
+                            "openAppointmentSlots": 114,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 141,
+                    "openTimeslots": 114,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 141,
+                    "openAppointmentSlots": 114,
                     "name": "Leander H-E-B plus!",
                     "longitude": -97.8582,
                     "latitude": 30.58369,
                     "fluUrl": "",
-                    "city": "LEANDER"
+                    "city": "LEANDER",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77521-9638",
@@ -5558,30 +5247,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 60,
-                            "openAppointmentSlots": 60,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 59,
-                            "openAppointmentSlots": 59,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 60,
-                            "openAppointmentSlots": 60,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 179,
+                    "openTimeslots": 50,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 179,
+                    "openAppointmentSlots": 50,
                     "name": "Baytown H-E-B",
                     "longitude": -94.9788,
                     "latitude": 29.79503,
                     "fluUrl": "",
-                    "city": "BAYTOWN"
+                    "city": "BAYTOWN",
+                    "availableImmunizations": [
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77007-0",
@@ -5592,30 +5277,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 69,
-                            "openAppointmentSlots": 69,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 35,
-                            "openAppointmentSlots": 35,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 18,
-                            "openAppointmentSlots": 18,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 233,
+                            "openAppointmentSlots": 233,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 122,
+                    "openTimeslots": 233,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 122,
+                    "openAppointmentSlots": 233,
                     "name": "Buffalo Heights H-E-B On Washington Ave",
                     "longitude": -95.39658,
                     "latitude": 29.76901,
                     "fluUrl": "",
-                    "city": "HOUSTON"
+                    "city": "HOUSTON",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer"
+                    ]
                 },
                 {
                     "zip": "77096-4001",
@@ -5626,30 +5308,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 48,
-                            "openAppointmentSlots": 48,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 26,
-                            "openAppointmentSlots": 26,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 18,
-                            "openAppointmentSlots": 18,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 225,
+                            "openAppointmentSlots": 225,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 92,
+                    "openTimeslots": 225,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 92,
+                    "openAppointmentSlots": 225,
                     "name": "Meyerland Market H-E-B",
                     "longitude": -95.46406,
                     "latitude": 29.68854,
                     "fluUrl": "",
-                    "city": "HOUSTON"
+                    "city": "HOUSTON",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pfizer"
+                    ]
                 },
                 {
                     "zip": "77845-4737",
@@ -5660,72 +5337,76 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 34,
-                            "openAppointmentSlots": 34,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 14,
+                            "openAppointmentSlots": 14,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 34,
+                    "openTimeslots": 14,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 34,
+                    "openAppointmentSlots": 14,
                     "name": "Jones Crossing H-E-B",
                     "longitude": -96.32324,
                     "latitude": 30.58444,
                     "fluUrl": "",
-                    "city": "COLLEGE STATION"
+                    "city": "COLLEGE STATION",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78589-3734",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaQQAS",
+                    "url": null,
                     "type": "store",
                     "street": "901 WEST EXPRESSWAY 83",
                     "storeNumber": 38,
-                    "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 15,
-                            "openAppointmentSlots": 15,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 17,
-                            "openAppointmentSlots": 17,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 15,
-                            "openAppointmentSlots": 15,
-                            "manufacturer": "Pediatric_Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 47,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 47,
-                    "name": "San Juan H-E-B plus!",
-                    "longitude": -98.1647,
-                    "latitude": 26.20274,
-                    "fluUrl": "",
-                    "city": "SAN JUAN"
-                },
-                {
-                    "zip": "76513-1519",
-                    "url": null,
-                    "type": "store",
-                    "street": "2509 NORTH MAIN STREET",
-                    "storeNumber": 39,
                     "state": "TX",
                     "slotDetails": [],
                     "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
                     "openAppointmentSlots": 0,
+                    "name": "San Juan H-E-B plus!",
+                    "longitude": -98.1647,
+                    "latitude": 26.20274,
+                    "fluUrl": "",
+                    "city": "SAN JUAN",
+                    "availableImmunizations": null
+                },
+                {
+                    "zip": "76513-1519",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaRQAS",
+                    "type": "store",
+                    "street": "2509 NORTH MAIN STREET",
+                    "storeNumber": 39,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 46,
+                            "openAppointmentSlots": 46,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 46,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 46,
                     "name": "Belton H-E-B plus!",
                     "longitude": -97.45759,
                     "latitude": 31.0805,
                     "fluUrl": "",
-                    "city": "BELTON"
+                    "city": "BELTON",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78704-0",
@@ -5736,25 +5417,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 86,
-                            "openAppointmentSlots": 86,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 70,
-                            "openAppointmentSlots": 70,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 151,
+                            "openAppointmentSlots": 151,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 156,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 156,
+                    "openTimeslots": 70,
+                    "openFluTimeslots": 81,
+                    "openFluAppointmentSlots": 81,
+                    "openAppointmentSlots": 70,
                     "name": "South Congress H-E-B",
                     "longitude": -97.7516,
                     "latitude": 30.23963,
-                    "fluUrl": "",
-                    "city": "AUSTIN"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4LQAU",
+                    "city": "AUSTIN",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77706-7213",
@@ -5765,25 +5445,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 120,
-                            "openAppointmentSlots": 120,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 34,
-                            "openAppointmentSlots": 34,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 191,
+                            "openAppointmentSlots": 191,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 154,
+                    "openTimeslots": 191,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 154,
+                    "openAppointmentSlots": 191,
                     "name": "Beaumont H-E-B plus!",
                     "longitude": -94.1685,
                     "latitude": 30.10501,
                     "fluUrl": "",
-                    "city": "BEAUMONT"
+                    "city": "BEAUMONT",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78213-2714",
@@ -5794,40 +5476,29 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 73,
-                            "openAppointmentSlots": 73,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 26,
-                            "openAppointmentSlots": 26,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 73,
-                            "openAppointmentSlots": 73,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 23,
-                            "openAppointmentSlots": 23,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 33,
-                            "openAppointmentSlots": 33,
-                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                            "openTimeslots": 132,
+                            "openAppointmentSlots": 132,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 228,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 228,
+                    "openTimeslots": 121,
+                    "openFluTimeslots": 11,
+                    "openFluAppointmentSlots": 11,
+                    "openAppointmentSlots": 121,
                     "name": "West Ave and Jackson Keller H-E-B",
                     "longitude": -98.52574,
                     "latitude": 29.51639,
-                    "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2NQAU",
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78230-1014",
@@ -5838,30 +5509,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 9,
-                            "openAppointmentSlots": 9,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 9,
-                            "openAppointmentSlots": 9,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 28,
-                            "openAppointmentSlots": 28,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 147,
+                            "openAppointmentSlots": 147,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 46,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 46,
+                    "openTimeslots": 79,
+                    "openFluTimeslots": 68,
+                    "openFluAppointmentSlots": 68,
+                    "openAppointmentSlots": 79,
                     "name": "De Zavala H-E-B",
                     "longitude": -98.5889,
                     "latitude": 29.56222,
-                    "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2OQAU",
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78232-1421",
@@ -5872,64 +5539,44 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 27,
-                            "openAppointmentSlots": 27,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 87,
-                            "openAppointmentSlots": 87,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 509,
+                            "openAppointmentSlots": 509,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 114,
+                    "openTimeslots": 509,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 114,
+                    "openAppointmentSlots": 509,
                     "name": "281 and 1604 H-E-B",
                     "longitude": -98.46828,
                     "latitude": 29.60772,
                     "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78247-3312",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubuQAC",
+                    "url": null,
                     "type": "store",
                     "street": "2929 THOUSAND OAKS",
                     "storeNumber": 398,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 178,
-                            "openAppointmentSlots": 178,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 228,
-                            "openAppointmentSlots": 228,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 230,
-                            "openAppointmentSlots": 230,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 75,
-                            "openAppointmentSlots": 75,
-                            "manufacturer": "Pediatric_Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 711,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 711,
+                    "openAppointmentSlots": 0,
                     "name": "Thousand Oaks H-E-B",
                     "longitude": -98.44108,
                     "latitude": 29.57781,
                     "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78363-3872",
@@ -5940,30 +5587,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 18,
-                            "openAppointmentSlots": 18,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 36,
-                            "openAppointmentSlots": 36,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 29,
-                            "openAppointmentSlots": 29,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 111,
+                            "openAppointmentSlots": 111,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 83,
+                    "openTimeslots": 111,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 83,
+                    "openAppointmentSlots": 111,
                     "name": "Kingsville H-E-B",
                     "longitude": -97.86453,
                     "latitude": 27.51658,
                     "fluUrl": "",
-                    "city": "KINGSVILLE"
+                    "city": "KINGSVILLE",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77382-2772",
@@ -5974,25 +5618,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 14,
-                            "openAppointmentSlots": 14,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 12,
-                            "openAppointmentSlots": 12,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 35,
+                            "openAppointmentSlots": 35,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 26,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 26,
+                    "openTimeslots": 23,
+                    "openFluTimeslots": 12,
+                    "openFluAppointmentSlots": 12,
+                    "openAppointmentSlots": 23,
                     "name": "Indian Springs H-E-B",
                     "longitude": -95.53672,
                     "latitude": 30.17791,
-                    "fluUrl": "",
-                    "city": "THE WOODLANDS"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3pQAE",
+                    "city": "THE WOODLANDS",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77301-1220",
@@ -6003,30 +5646,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 252,
-                            "openAppointmentSlots": 252,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 251,
-                            "openAppointmentSlots": 251,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 280,
-                            "openAppointmentSlots": 280,
+                            "openTimeslots": 212,
+                            "openAppointmentSlots": 212,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 783,
+                    "openTimeslots": 212,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 783,
+                    "openAppointmentSlots": 212,
                     "name": "N Frazier At Loop 336 H-E-B",
                     "longitude": -95.46548,
                     "latitude": 30.33593,
                     "fluUrl": "",
-                    "city": "CONROE"
+                    "city": "CONROE",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77494-8100",
@@ -6037,59 +5677,45 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 46,
-                            "openAppointmentSlots": 46,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 58,
-                            "openAppointmentSlots": 58,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 54,
+                            "openAppointmentSlots": 54,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 204,
+                    "openTimeslots": 54,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 204,
+                    "openAppointmentSlots": 54,
                     "name": "Grand Parkway H-E-B plus!",
                     "longitude": -95.7739,
                     "latitude": 29.7144,
                     "fluUrl": "",
-                    "city": "KATY"
+                    "city": "KATY",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77005-4210",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudMQAS",
+                    "url": null,
                     "type": "store",
                     "street": "5225 BUFFALO SPEEDWAY",
                     "storeNumber": 599,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 27,
-                            "openAppointmentSlots": 27,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 27,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 27,
+                    "openAppointmentSlots": 0,
                     "name": "Buffalo Market H-E-B On Buffalo Speedway",
                     "longitude": -95.4271,
                     "latitude": 29.7261,
                     "fluUrl": "",
-                    "city": "HOUSTON"
+                    "city": "HOUSTON",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77388-3412",
@@ -6100,20 +5726,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 162,
-                            "openAppointmentSlots": 162,
+                            "openTimeslots": 249,
+                            "openAppointmentSlots": 249,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 162,
+                    "openTimeslots": 249,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 162,
+                    "openAppointmentSlots": 249,
                     "name": "Spring Market H-E-B",
                     "longitude": -95.44894,
                     "latitude": 30.07042,
                     "fluUrl": "",
-                    "city": "SPRING"
+                    "city": "SPRING",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer"
+                    ]
                 },
                 {
                     "zip": "78620-5482",
@@ -6124,66 +5755,81 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 22,
-                            "openAppointmentSlots": 22,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 22,
-                            "openAppointmentSlots": 22,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 102,
-                            "openAppointmentSlots": 102,
+                            "openTimeslots": 151,
+                            "openAppointmentSlots": 151,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 146,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 146,
+                    "openTimeslots": 134,
+                    "openFluTimeslots": 17,
+                    "openFluAppointmentSlots": 17,
+                    "openAppointmentSlots": 134,
                     "name": "Dripping Springs H-E-B",
                     "longitude": -98.08146,
                     "latitude": 30.18968,
-                    "fluUrl": "",
-                    "city": "DRIPPING SPRINGS"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF46QAE",
+                    "city": "DRIPPING SPRINGS",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78121-5922",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudPQAS",
                     "type": "store",
                     "street": "14414 US HWY 87 WEST",
                     "storeNumber": 612,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 20,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 20,
                     "name": "La Vernia H-E-B",
                     "longitude": -98.13514,
                     "latitude": 29.35803,
                     "fluUrl": "",
-                    "city": "LA VERNIA"
+                    "city": "LA VERNIA",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77388-0",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuegQAC",
                     "type": "store",
                     "street": "5251 FM 2920",
                     "storeNumber": 748,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 216,
+                            "openAppointmentSlots": 216,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 216,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 216,
                     "name": "H-E-B Market at Gosling",
                     "longitude": -95.50178,
                     "latitude": 30.07179,
                     "fluUrl": "",
-                    "city": "SPRING"
+                    "city": "SPRING",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer"
+                    ]
                 },
                 {
                     "zip": "78218-0",
@@ -6201,36 +5847,27 @@
                     "longitude": 0,
                     "latitude": 0,
                     "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "76087-0",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueiQAC",
+                    "url": null,
                     "type": "store",
                     "street": "100 HUDSON OAKS DR",
                     "storeNumber": 752,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 144,
-                            "openAppointmentSlots": 144,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 142,
-                            "openAppointmentSlots": 142,
-                            "manufacturer": "Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 286,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 286,
+                    "openAppointmentSlots": 0,
                     "name": "Hudson Oaks H-E-B",
                     "longitude": -97.69733,
                     "latitude": 32.75831,
                     "fluUrl": "",
-                    "city": "HUDSON OAKS"
+                    "city": "HUDSON OAKS",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77004-0",
@@ -6241,25 +5878,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 84,
-                            "openAppointmentSlots": 84,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 48,
-                            "openAppointmentSlots": 48,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 123,
+                            "openAppointmentSlots": 123,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 132,
+                    "openTimeslots": 123,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 132,
+                    "openAppointmentSlots": 123,
                     "name": "MacGregor Market H-E-B",
                     "longitude": -95.37644,
                     "latitude": 29.71432,
                     "fluUrl": "",
-                    "city": "HOUSTON"
+                    "city": "HOUSTON",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77385-0",
@@ -6270,35 +5906,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 104,
-                            "openAppointmentSlots": 104,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 220,
-                            "openAppointmentSlots": 220,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 164,
-                            "openAppointmentSlots": 164,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 220,
-                            "openAppointmentSlots": 220,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 129,
+                            "openAppointmentSlots": 129,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 708,
+                    "openTimeslots": 129,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 708,
+                    "openAppointmentSlots": 129,
                     "name": "Harper's Trace H-E-B",
                     "longitude": -95.42563,
                     "latitude": 30.20692,
                     "fluUrl": "",
-                    "city": "CONROE"
+                    "city": "CONROE",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77339-0",
@@ -6309,35 +5937,28 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 35,
-                            "openAppointmentSlots": 35,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 52,
-                            "openAppointmentSlots": 52,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 34,
-                            "openAppointmentSlots": 34,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 8,
-                            "openAppointmentSlots": 8,
+                            "openTimeslots": 172,
+                            "openAppointmentSlots": 172,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 129,
+                    "openTimeslots": 172,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 129,
+                    "openAppointmentSlots": 172,
                     "name": "H-E-B Market at Northpark",
                     "longitude": -95.25033,
                     "latitude": 30.06864,
                     "fluUrl": "",
-                    "city": "KINGWOOD"
+                    "city": "KINGWOOD",
+                    "availableImmunizations": [
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Janssen",
+                        "Flu"
+                    ]
                 },
                 {
                     "zip": "78253-0",
@@ -6348,30 +5969,28 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 212,
-                            "openAppointmentSlots": 212,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 215,
-                            "openAppointmentSlots": 215,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 106,
-                            "openAppointmentSlots": 106,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 149,
+                            "openAppointmentSlots": 149,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 533,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 533,
+                    "openTimeslots": 129,
+                    "openFluTimeslots": 20,
+                    "openFluAppointmentSlots": 20,
+                    "openAppointmentSlots": 129,
                     "name": "211 and Potranco H-E-B",
                     "longitude": -98.77966,
                     "latitude": 29.42367,
-                    "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2GQAU",
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "79424-0",
@@ -6382,30 +6001,29 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 97,
-                            "openAppointmentSlots": 97,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 19,
-                            "openAppointmentSlots": 19,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
-                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                            "openTimeslots": 76,
+                            "openAppointmentSlots": 76,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 166,
+                    "openTimeslots": 76,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 166,
+                    "openAppointmentSlots": 76,
                     "name": "Lubbock H-E-B",
                     "longitude": -101.90638,
                     "latitude": 33.48958,
                     "fluUrl": "",
-                    "city": "LUBBOCK"
+                    "city": "LUBBOCK",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Novavax"
+                    ]
                 },
                 {
                     "zip": "79720-5437",
@@ -6416,35 +6034,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 102,
-                            "openAppointmentSlots": 102,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 150,
-                            "openAppointmentSlots": 150,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 150,
-                            "openAppointmentSlots": 150,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 150,
-                            "openAppointmentSlots": 150,
-                            "manufacturer": "Other"
+                            "openTimeslots": 116,
+                            "openAppointmentSlots": 116,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 402,
-                    "openFluTimeslots": 150,
-                    "openFluAppointmentSlots": 150,
-                    "openAppointmentSlots": 402,
+                    "openTimeslots": 116,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 116,
                     "name": "Big Spring H-E-B",
                     "longitude": -101.47211,
                     "latitude": 32.23493,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4NQAU",
-                    "city": "BIG SPRING"
+                    "fluUrl": "",
+                    "city": "BIG SPRING",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "76901-3528",
@@ -6455,30 +6065,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 89,
-                            "openAppointmentSlots": 89,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 89,
-                            "openAppointmentSlots": 89,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 90,
-                            "openAppointmentSlots": 90,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 179,
+                            "openAppointmentSlots": 179,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 268,
+                    "openTimeslots": 179,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 268,
+                    "openAppointmentSlots": 179,
                     "name": "Sherwood Avenue N H-E-B",
                     "longitude": -100.47977,
                     "latitude": 31.44511,
                     "fluUrl": "",
-                    "city": "SAN ANGELO"
+                    "city": "SAN ANGELO",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77075-2246",
@@ -6489,30 +6096,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 14,
-                            "openAppointmentSlots": 14,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 49,
-                            "openAppointmentSlots": 49,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 20,
-                            "openAppointmentSlots": 20,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 192,
+                            "openAppointmentSlots": 192,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 83,
+                    "openTimeslots": 192,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 83,
+                    "openAppointmentSlots": 192,
                     "name": "Blackhawk H-E-B",
                     "longitude": -95.24868,
                     "latitude": 29.60234,
                     "fluUrl": "",
-                    "city": "HOUSTON"
+                    "city": "HOUSTON",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pediatric_Pfizer"
+                    ]
                 },
                 {
                     "zip": "78418-4426",
@@ -6523,20 +6126,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 135,
-                            "openAppointmentSlots": 135,
+                            "openTimeslots": 70,
+                            "openAppointmentSlots": 70,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 135,
+                    "openTimeslots": 70,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 135,
+                    "openAppointmentSlots": 70,
                     "name": "Flour Bluff H-E-B plus!",
                     "longitude": -97.28288,
                     "latitude": 27.66767,
                     "fluUrl": "",
-                    "city": "CORPUS CHRISTI"
+                    "city": "CORPUS CHRISTI",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77584-2191",
@@ -6547,35 +6154,31 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 161,
-                            "openAppointmentSlots": 161,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 161,
-                            "openAppointmentSlots": 161,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 108,
-                            "openAppointmentSlots": 108,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 40,
-                            "openAppointmentSlots": 40,
+                            "openTimeslots": 91,
+                            "openAppointmentSlots": 91,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 470,
+                    "openTimeslots": 91,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 470,
+                    "openAppointmentSlots": 91,
                     "name": "Pearland H-E-B plus!",
                     "longitude": -95.39002,
                     "latitude": 29.55932,
                     "fluUrl": "",
-                    "city": "PEARLAND"
+                    "city": "PEARLAND",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Novavax",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "76708-1675",
@@ -6586,35 +6189,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 55,
-                            "openAppointmentSlots": 55,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 59,
-                            "openAppointmentSlots": 59,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 20,
-                            "openAppointmentSlots": 20,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 28,
-                            "openAppointmentSlots": 28,
+                            "openTimeslots": 182,
+                            "openAppointmentSlots": 182,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 162,
+                    "openTimeslots": 182,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 162,
+                    "openAppointmentSlots": 182,
                     "name": "19th and Meridian H-E-B",
                     "longitude": -97.17255,
                     "latitude": 31.5804,
                     "fluUrl": "",
-                    "city": "WACO"
+                    "city": "WACO",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78749-6507",
@@ -6625,59 +6220,43 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 9,
-                            "openAppointmentSlots": 9,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 156,
-                            "openAppointmentSlots": 156,
+                            "openTimeslots": 48,
+                            "openAppointmentSlots": 48,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 175,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 175,
+                    "openTimeslots": 12,
+                    "openFluTimeslots": 36,
+                    "openFluAppointmentSlots": 36,
+                    "openAppointmentSlots": 12,
                     "name": "Slaughter and Escarpment H-E-B",
                     "longitude": -97.87642,
                     "latitude": 30.20247,
-                    "fluUrl": "",
-                    "city": "AUSTIN"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4TQAU",
+                    "city": "AUSTIN",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78413-2816",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuabQAC",
+                    "url": null,
                     "type": "store",
                     "street": "5313 SARATOGA",
                     "storeNumber": 69,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 40,
-                            "openAppointmentSlots": 40,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 19,
-                            "openAppointmentSlots": 19,
-                            "manufacturer": "Pediatric_Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 59,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 59,
+                    "openAppointmentSlots": 0,
                     "name": "Staples and Saratoga H-E-B plus!",
                     "longitude": -97.38802,
                     "latitude": 27.68613,
                     "fluUrl": "",
-                    "city": "CORPUS CHRISTI"
+                    "city": "CORPUS CHRISTI",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "76528-1628",
@@ -6695,7 +6274,8 @@
                     "longitude": -97.7428,
                     "latitude": 31.43586,
                     "fluUrl": "",
-                    "city": "GATESVILLE"
+                    "city": "GATESVILLE",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78738-6517",
@@ -6706,40 +6286,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 43,
-                            "openAppointmentSlots": 43,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 16,
-                            "openAppointmentSlots": 16,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 5,
-                            "openAppointmentSlots": 5,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 16,
-                            "openAppointmentSlots": 16,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 8,
-                            "openAppointmentSlots": 8,
-                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                            "openTimeslots": 58,
+                            "openAppointmentSlots": 58,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 88,
+                    "openTimeslots": 58,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 88,
+                    "openAppointmentSlots": 58,
                     "name": "Bee Cave H-E-B",
                     "longitude": -97.93238,
                     "latitude": 30.30489,
                     "fluUrl": "",
-                    "city": "BEE CAVE"
+                    "city": "BEE CAVE",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Pediatric_Pfizer"
+                    ]
                 },
                 {
                     "zip": "78227-1652",
@@ -6750,30 +6315,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 60,
-                            "openAppointmentSlots": 60,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 56,
-                            "openAppointmentSlots": 56,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 60,
-                            "openAppointmentSlots": 60,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 252,
+                            "openAppointmentSlots": 252,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 176,
+                    "openTimeslots": 252,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 176,
+                    "openAppointmentSlots": 252,
                     "name": "Marbach and 410 H-E-B plus!",
                     "longitude": -98.65227,
                     "latitude": 29.41837,
                     "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer"
+                    ]
                 },
                 {
                     "zip": "77044-6087",
@@ -6784,30 +6344,31 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 33,
-                            "openAppointmentSlots": 33,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 58,
-                            "openAppointmentSlots": 58,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 54,
-                            "openAppointmentSlots": 54,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 270,
+                            "openAppointmentSlots": 270,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 145,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 145,
+                    "openTimeslots": 252,
+                    "openFluTimeslots": 18,
+                    "openFluAppointmentSlots": 18,
+                    "openAppointmentSlots": 252,
                     "name": "Summerwood Market H-E-B",
                     "longitude": -95.19697,
                     "latitude": 29.92325,
-                    "fluUrl": "",
-                    "city": "HOUSTON"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF49QAE",
+                    "city": "HOUSTON",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Novavax",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77494-5904",
@@ -6818,25 +6379,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 89,
-                            "openAppointmentSlots": 89,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 82,
-                            "openAppointmentSlots": 82,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 853,
+                            "openAppointmentSlots": 853,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 171,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 171,
+                    "openTimeslots": 452,
+                    "openFluTimeslots": 401,
+                    "openFluAppointmentSlots": 401,
+                    "openAppointmentSlots": 452,
                     "name": "Katy Market H-E-B",
                     "longitude": -95.82005,
                     "latitude": 29.77644,
-                    "fluUrl": "",
-                    "city": "KATY"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4AQAU",
+                    "city": "KATY",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78240-2136",
@@ -6854,7 +6417,8 @@
                     "longitude": -98.60198,
                     "latitude": 29.5271,
                     "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77845-4638",
@@ -6865,45 +6429,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 42,
-                            "openAppointmentSlots": 42,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 51,
-                            "openAppointmentSlots": 51,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 40,
-                            "openAppointmentSlots": 40,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 160,
-                            "openAppointmentSlots": 160,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 85,
-                            "openAppointmentSlots": 85,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 60,
-                            "openAppointmentSlots": 60,
-                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                            "openTimeslots": 120,
+                            "openAppointmentSlots": 120,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 438,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 438,
+                    "openTimeslots": 11,
+                    "openFluTimeslots": 109,
+                    "openFluAppointmentSlots": 109,
+                    "openAppointmentSlots": 11,
                     "name": "Tower Point Market H-E-B",
                     "longitude": -96.26315,
                     "latitude": 30.55969,
-                    "fluUrl": "",
-                    "city": "COLLEGE STATION"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4CQAU",
+                    "city": "COLLEGE STATION",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu"
+                    ]
                 },
                 {
                     "zip": "78061-6630",
@@ -6921,7 +6464,8 @@
                     "longitude": -99.11446,
                     "latitude": 28.89503,
                     "fluUrl": "",
-                    "city": "PEARSALL"
+                    "city": "PEARSALL",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78712-0",
@@ -6932,25 +6476,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 89,
-                            "openAppointmentSlots": 89,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 94,
-                            "openAppointmentSlots": 94,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 132,
+                            "openAppointmentSlots": 132,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 183,
+                    "openTimeslots": 132,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 183,
+                    "openAppointmentSlots": 132,
                     "name": "H-E-B Pharmacy at the UTHTB",
                     "longitude": -97.73507,
                     "latitude": 30.27747,
                     "fluUrl": "",
-                    "city": "AUSTIN"
+                    "city": "AUSTIN",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "79605-5171",
@@ -6961,40 +6504,31 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 55,
-                            "openAppointmentSlots": 55,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 57,
-                            "openAppointmentSlots": 57,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 86,
-                            "openAppointmentSlots": 86,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 25,
-                            "openAppointmentSlots": 25,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 38,
-                            "openAppointmentSlots": 38,
-                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                            "openTimeslots": 277,
+                            "openAppointmentSlots": 277,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 261,
+                    "openTimeslots": 277,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 261,
+                    "openAppointmentSlots": 277,
                     "name": "Abilene H-E-B",
                     "longitude": -99.75934,
                     "latitude": 32.43348,
                     "fluUrl": "",
-                    "city": "ABILENE"
+                    "city": "ABILENE",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Novavax",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Moderna"
+                    ]
                 },
                 {
                     "zip": "76504-2448",
@@ -7012,7 +6546,8 @@
                     "longitude": -97.35378,
                     "latitude": 31.10153,
                     "fluUrl": "",
-                    "city": "TEMPLE"
+                    "city": "TEMPLE",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78006-2523",
@@ -7023,25 +6558,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 64,
-                            "openAppointmentSlots": 64,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 109,
-                            "openAppointmentSlots": 109,
+                            "openTimeslots": 264,
+                            "openAppointmentSlots": 264,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 173,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 173,
+                    "openTimeslots": 139,
+                    "openFluTimeslots": 125,
+                    "openFluAppointmentSlots": 125,
+                    "openAppointmentSlots": 139,
                     "name": "Boerne H-E-B plus!",
                     "longitude": -98.73481,
                     "latitude": 29.78173,
-                    "fluUrl": "",
-                    "city": "BOERNE"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4EQAU",
+                    "city": "BOERNE",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78070-6270",
@@ -7052,58 +6587,57 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 46,
-                            "openAppointmentSlots": 46,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 19,
-                            "openAppointmentSlots": 19,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 58,
-                            "openAppointmentSlots": 58,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 23,
-                            "openAppointmentSlots": 23,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
                             "openTimeslots": 10,
                             "openAppointmentSlots": 10,
-                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 156,
+                    "openTimeslots": 10,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 156,
+                    "openAppointmentSlots": 10,
                     "name": "Bulverde H-E-B plus!",
                     "longitude": -98.43022,
                     "latitude": 29.79882,
                     "fluUrl": "",
-                    "city": "SPRING BRANCH"
+                    "city": "SPRING BRANCH",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78249-2577",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudYQAS",
                     "type": "store",
                     "street": "9238 N.LOOP 1604 WEST",
                     "storeNumber": 623,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 301,
+                            "openAppointmentSlots": 301,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 145,
+                    "openFluTimeslots": 156,
+                    "openFluAppointmentSlots": 156,
+                    "openAppointmentSlots": 145,
                     "name": "Bandera and 1604 H-E-B plus!",
                     "longitude": -98.66444,
                     "latitude": 29.55498,
-                    "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4GQAU",
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78586-4395",
@@ -7114,20 +6648,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 152,
-                            "openAppointmentSlots": 152,
+                            "openTimeslots": 315,
+                            "openAppointmentSlots": 315,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 152,
+                    "openTimeslots": 315,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 152,
+                    "openAppointmentSlots": 315,
                     "name": "San Benito H-E-B",
                     "longitude": -97.63395,
                     "latitude": 26.14392,
                     "fluUrl": "",
-                    "city": "SAN BENITO"
+                    "city": "SAN BENITO",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77478-4947",
@@ -7138,25 +6679,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 26,
-                            "openAppointmentSlots": 26,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 49,
-                            "openAppointmentSlots": 49,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 21,
+                            "openAppointmentSlots": 21,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 75,
+                    "openTimeslots": 21,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 75,
+                    "openAppointmentSlots": 21,
                     "name": "Sugar Land Market H-E-B",
                     "longitude": -95.64596,
                     "latitude": 29.60871,
                     "fluUrl": "",
-                    "city": "SUGAR LAND"
+                    "city": "SUGAR LAND",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78218",
@@ -7174,7 +6713,8 @@
                     "longitude": -98.39355342726148,
                     "latitude": 29.48488847441163,
                     "fluUrl": "",
-                    "city": "San Antonio"
+                    "city": "San Antonio",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77406-0",
@@ -7185,30 +6725,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 33,
-                            "openAppointmentSlots": 33,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 33,
-                            "openAppointmentSlots": 33,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 29,
-                            "openAppointmentSlots": 29,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 22,
+                            "openAppointmentSlots": 22,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 95,
+                    "openTimeslots": 22,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 95,
+                    "openAppointmentSlots": 22,
                     "name": "Spring Green Market H-E-B",
                     "longitude": -95.81427,
                     "latitude": 29.69558,
                     "fluUrl": "",
-                    "city": "RICHMOND"
+                    "city": "RICHMOND",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78130-4753",
@@ -7219,25 +6756,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 70,
-                            "openAppointmentSlots": 70,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 108,
-                            "openAppointmentSlots": 108,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 91,
+                            "openAppointmentSlots": 91,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 178,
+                    "openTimeslots": 91,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 178,
+                    "openAppointmentSlots": 91,
                     "name": "New Braunfels H-E-B at Hwy 46",
                     "longitude": -98.16041,
                     "latitude": 29.71309,
                     "fluUrl": "",
-                    "city": "NEW BRAUNFELS"
+                    "city": "NEW BRAUNFELS",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78224-1136",
@@ -7248,35 +6784,29 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 285,
-                            "openAppointmentSlots": 285,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 263,
-                            "openAppointmentSlots": 263,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 266,
-                            "openAppointmentSlots": 266,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 260,
-                            "openAppointmentSlots": 260,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 762,
+                            "openAppointmentSlots": 762,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 1074,
+                    "openTimeslots": 762,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 1074,
+                    "openAppointmentSlots": 762,
                     "name": "Zarzamora and Military H-E-B plus!",
                     "longitude": -98.5339,
                     "latitude": 29.35787,
                     "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Janssen",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78251-3312",
@@ -7294,7 +6824,8 @@
                     "longitude": -98.70445,
                     "latitude": 29.43536,
                     "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78028-0",
@@ -7305,25 +6836,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 39,
-                            "openAppointmentSlots": 39,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 76,
-                            "openAppointmentSlots": 76,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 109,
+                            "openAppointmentSlots": 109,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 115,
+                    "openTimeslots": 109,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 115,
+                    "openAppointmentSlots": 109,
                     "name": "Kerrville H-E-B On Main Street",
                     "longitude": -99.14287,
                     "latitude": 30.05056,
                     "fluUrl": "",
-                    "city": "KERRVILLE"
+                    "city": "KERRVILLE",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78741-3037",
@@ -7334,74 +6863,46 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 52,
-                            "openAppointmentSlots": 52,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 23,
-                            "openAppointmentSlots": 23,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 5,
-                            "openAppointmentSlots": 5,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 282,
+                            "openAppointmentSlots": 282,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 80,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 80,
+                    "openTimeslots": 135,
+                    "openFluTimeslots": 147,
+                    "openFluAppointmentSlots": 147,
+                    "openAppointmentSlots": 135,
                     "name": "Riverside H-E-B plus!",
                     "longitude": -97.72401,
                     "latitude": 30.23547,
-                    "fluUrl": "",
-                    "city": "AUSTIN"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4qQAE",
+                    "city": "AUSTIN",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77904-1767",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuajQAC",
+                    "url": null,
                     "type": "store",
                     "street": "6106 N. NAVARRO",
                     "storeNumber": 92,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 89,
-                            "openAppointmentSlots": 89,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 85,
-                            "openAppointmentSlots": 85,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 89,
-                            "openAppointmentSlots": 89,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 88,
-                            "openAppointmentSlots": 88,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 86,
-                            "openAppointmentSlots": 86,
-                            "manufacturer": "Ultra_Pediatric_Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 437,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 437,
+                    "openAppointmentSlots": 0,
                     "name": "Victoria H-E-B plus!",
                     "longitude": -96.99736,
                     "latitude": 28.85159,
                     "fluUrl": "",
-                    "city": "VICTORIA"
+                    "city": "VICTORIA",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77055-6209",
@@ -7412,40 +6913,30 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 51,
-                            "openAppointmentSlots": 51,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 35,
-                            "openAppointmentSlots": 35,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 44,
-                            "openAppointmentSlots": 44,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 35,
-                            "openAppointmentSlots": 35,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 35,
-                            "openAppointmentSlots": 35,
-                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                            "openTimeslots": 456,
+                            "openAppointmentSlots": 456,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 200,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 200,
+                    "openTimeslots": 356,
+                    "openFluTimeslots": 100,
+                    "openFluAppointmentSlots": 100,
+                    "openAppointmentSlots": 356,
                     "name": "Bunker Hill H-E-B",
                     "longitude": -95.53206,
                     "latitude": 29.78485,
-                    "fluUrl": "",
-                    "city": "HOUSTON"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF0aQAE",
+                    "city": "HOUSTON",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Novavax",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Pediatric_Pfizer"
+                    ]
                 },
                 {
                     "zip": "77459-6931",
@@ -7456,30 +6947,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 40,
-                            "openAppointmentSlots": 40,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 39,
-                            "openAppointmentSlots": 39,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 39,
-                            "openAppointmentSlots": 39,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 30,
+                            "openAppointmentSlots": 30,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 118,
+                    "openTimeslots": 30,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 118,
+                    "openAppointmentSlots": 30,
                     "name": "Sienna Market H-E-B",
                     "longitude": -95.53497,
                     "latitude": 29.53928,
                     "fluUrl": "",
-                    "city": "MISSOURI CITY"
+                    "city": "MISSOURI CITY",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78550-7708",
@@ -7490,30 +6976,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 28,
-                            "openAppointmentSlots": 28,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 28,
-                            "openAppointmentSlots": 28,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 14,
+                            "openAppointmentSlots": 14,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 106,
+                    "openTimeslots": 14,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 106,
+                    "openAppointmentSlots": 14,
                     "name": "Southland and 12th St H-E-B",
                     "longitude": -97.68171,
                     "latitude": 26.18251,
                     "fluUrl": "",
-                    "city": "HARLINGEN"
+                    "city": "HARLINGEN",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Janssen"
+                    ]
                 },
                 {
                     "zip": "78413-3966",
@@ -7524,25 +7006,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 76,
-                            "openAppointmentSlots": 76,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 64,
-                            "openAppointmentSlots": 64,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 110,
+                            "openAppointmentSlots": 110,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 140,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 140,
+                    "openTimeslots": 91,
+                    "openFluTimeslots": 19,
+                    "openFluAppointmentSlots": 19,
+                    "openAppointmentSlots": 91,
                     "name": "Weber and Holly H-E-B",
                     "longitude": -97.40529,
                     "latitude": 27.71118,
-                    "fluUrl": "",
-                    "city": "CORPUS CHRISTI"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF0dQAE",
+                    "city": "CORPUS CHRISTI",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu"
+                    ]
                 },
                 {
                     "zip": "78723-2924",
@@ -7553,20 +7034,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 71,
-                            "openAppointmentSlots": 71,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 69,
+                            "openAppointmentSlots": 69,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 71,
+                    "openTimeslots": 69,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 71,
+                    "openAppointmentSlots": 69,
                     "name": "Ed Bluestein H-E-B",
                     "longitude": -97.66465,
                     "latitude": 30.31211,
                     "fluUrl": "",
-                    "city": "AUSTIN"
+                    "city": "AUSTIN",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78232-3714",
@@ -7584,7 +7069,8 @@
                     "longitude": -98.47734,
                     "latitude": 29.5774,
                     "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78572-8354",
@@ -7595,30 +7081,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 13,
-                            "openAppointmentSlots": 13,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 5,
-                            "openAppointmentSlots": 5,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 6,
-                            "openAppointmentSlots": 6,
-                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                            "openTimeslots": 25,
+                            "openAppointmentSlots": 25,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 24,
+                    "openTimeslots": 25,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 24,
+                    "openAppointmentSlots": 25,
                     "name": "Mission H-E-B plus!",
                     "longitude": -98.28628,
                     "latitude": 26.19755,
                     "fluUrl": "",
-                    "city": "MISSION"
+                    "city": "MISSION",
+                    "availableImmunizations": [
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Ultra_Pediatric_Pfizer"
+                    ]
                 },
                 {
                     "zip": "78045-6596",
@@ -7629,20 +7111,28 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 114,
-                            "openAppointmentSlots": 114,
+                            "openTimeslots": 35,
+                            "openAppointmentSlots": 35,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 114,
+                    "openTimeslots": 35,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 114,
+                    "openAppointmentSlots": 35,
                     "name": "Laredo H-E-B plus!",
                     "longitude": -99.47435,
                     "latitude": 27.60863,
                     "fluUrl": "",
-                    "city": "LAREDO"
+                    "city": "LAREDO",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78731-3023",
@@ -7653,30 +7143,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 25,
-                            "openAppointmentSlots": 25,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 14,
-                            "openAppointmentSlots": 14,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 7,
-                            "openAppointmentSlots": 7,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 362,
+                            "openAppointmentSlots": 362,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 46,
+                    "openTimeslots": 362,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 46,
+                    "openAppointmentSlots": 362,
                     "name": "Far West H-E-B",
                     "longitude": -97.75598,
                     "latitude": 30.35289,
                     "fluUrl": "",
-                    "city": "AUSTIN"
+                    "city": "AUSTIN",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77070-1667",
@@ -7687,30 +7174,28 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 144,
-                            "openAppointmentSlots": 144,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 140,
-                            "openAppointmentSlots": 140,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 146,
-                            "openAppointmentSlots": 146,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 216,
+                            "openAppointmentSlots": 216,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 430,
+                    "openTimeslots": 216,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 430,
+                    "openAppointmentSlots": 216,
                     "name": "Vintage Park Market H-E-B",
                     "longitude": -95.57661,
                     "latitude": 29.9967,
                     "fluUrl": "",
-                    "city": "HOUSTON"
+                    "city": "HOUSTON",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78231-1841",
@@ -7721,20 +7206,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 612,
-                            "openAppointmentSlots": 612,
+                            "openTimeslots": 710,
+                            "openAppointmentSlots": 710,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 612,
+                    "openTimeslots": 710,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 612,
+                    "openAppointmentSlots": 710,
                     "name": "Alon Market H-E-B",
                     "longitude": -98.53463,
                     "latitude": 29.55254,
                     "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78745-5008",
@@ -7745,59 +7235,43 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 6,
-                            "openAppointmentSlots": 6,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 5,
-                            "openAppointmentSlots": 5,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 24,
+                            "openAppointmentSlots": 24,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 11,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 11,
+                    "openTimeslots": 10,
+                    "openFluTimeslots": 14,
+                    "openFluAppointmentSlots": 14,
+                    "openAppointmentSlots": 10,
                     "name": "Brodie Lane H-E-B",
                     "longitude": -97.83076,
                     "latitude": 30.21489,
-                    "fluUrl": "",
-                    "city": "AUSTIN"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2iQAE",
+                    "city": "AUSTIN",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78539-7312",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucDQAS",
+                    "url": null,
                     "type": "store",
                     "street": "2700 W FREDDY GONZALES",
                     "storeNumber": 431,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 54,
-                            "openAppointmentSlots": 54,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 48,
-                            "openAppointmentSlots": 48,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 60,
-                            "openAppointmentSlots": 60,
-                            "manufacturer": "Other"
-                        }
-                    ],
-                    "openTimeslots": 102,
-                    "openFluTimeslots": 60,
-                    "openFluAppointmentSlots": 60,
-                    "openAppointmentSlots": 102,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
                     "name": "Edinburg H-E-B",
                     "longitude": -98.1958,
                     "latitude": 26.29078,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2jQAE",
-                    "city": "EDINBURG"
+                    "fluUrl": "",
+                    "city": "EDINBURG",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77098-2807",
@@ -7808,74 +7282,51 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 57,
-                            "openAppointmentSlots": 57,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 74,
-                            "openAppointmentSlots": 74,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 96,
-                            "openAppointmentSlots": 96,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 24,
-                            "openAppointmentSlots": 24,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 26,
-                            "openAppointmentSlots": 26,
+                            "openTimeslots": 29,
+                            "openAppointmentSlots": 29,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 277,
+                    "openTimeslots": 29,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 277,
+                    "openAppointmentSlots": 29,
                     "name": "Montrose Market H-E-B",
                     "longitude": -95.40284,
                     "latitude": 29.7379,
                     "fluUrl": "",
-                    "city": "HOUSTON"
+                    "city": "HOUSTON",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "76049-7428",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudcQAC",
+                    "url": null,
                     "type": "store",
                     "street": "3804 US HWY 377",
                     "storeNumber": 631,
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 36,
-                            "openAppointmentSlots": 36,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 36,
-                            "openAppointmentSlots": 36,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 36,
-                            "openAppointmentSlots": 36,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 98,
+                            "openAppointmentSlots": 98,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 108,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 108,
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 98,
+                    "openFluAppointmentSlots": 98,
+                    "openAppointmentSlots": 0,
                     "name": "Granbury H-E-B",
                     "longitude": -97.73026,
                     "latitude": 32.45528,
-                    "fluUrl": "",
-                    "city": "GRANBURY"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4ZQAU",
+                    "city": "GRANBURY",
+                    "availableImmunizations": [
+                        "Flu"
+                    ]
                 },
                 {
                     "zip": "77384-3943",
@@ -7886,77 +7337,71 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 129,
-                            "openAppointmentSlots": 129,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 92,
-                            "openAppointmentSlots": 92,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 74,
+                            "openAppointmentSlots": 74,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 221,
+                    "openTimeslots": 74,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 221,
+                    "openAppointmentSlots": 74,
                     "name": "North Woodlands Market H-E-B",
                     "longitude": -95.51296,
                     "latitude": 30.22918,
                     "fluUrl": "",
-                    "city": "THE WOODLANDS"
+                    "city": "THE WOODLANDS",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78723-3014",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudeQAC",
+                    "url": null,
                     "type": "store",
                     "street": "1801 E.51ST STREET",
                     "storeNumber": 639,
-                    "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 16,
-                            "openAppointmentSlots": 16,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 15,
-                            "openAppointmentSlots": 15,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 4,
-                            "openAppointmentSlots": 4,
-                            "manufacturer": "Pediatric_Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 35,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 35,
-                    "name": "Mueller H-E-B",
-                    "longitude": -97.69872,
-                    "latitude": 30.3013,
-                    "fluUrl": "",
-                    "city": "AUSTIN"
-                },
-                {
-                    "zip": "78629-2406",
-                    "url": null,
-                    "type": "store",
-                    "street": "1841 CHURCH ST.",
-                    "storeNumber": 641,
                     "state": "TX",
                     "slotDetails": [],
                     "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
                     "openAppointmentSlots": 0,
+                    "name": "Mueller H-E-B",
+                    "longitude": -97.69872,
+                    "latitude": 30.3013,
+                    "fluUrl": "",
+                    "city": "AUSTIN",
+                    "availableImmunizations": null
+                },
+                {
+                    "zip": "78629-2406",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudfQAC",
+                    "type": "store",
+                    "street": "1841 CHURCH ST.",
+                    "storeNumber": 641,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 32,
+                            "openAppointmentSlots": 32,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 32,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 32,
                     "name": "Gonzales H-E-B",
                     "longitude": -97.45202,
                     "latitude": 29.51832,
                     "fluUrl": "",
-                    "city": "GONZALES"
+                    "city": "GONZALES",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu"
+                    ]
                 },
                 {
                     "zip": "78577-6293",
@@ -7974,59 +7419,55 @@
                     "longitude": -98.18706,
                     "latitude": 26.1803,
                     "fluUrl": "",
-                    "city": "PHARR"
+                    "city": "PHARR",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78415-5021",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudhQAC",
                     "type": "store",
                     "street": "4444 KOSTORYZ",
                     "storeNumber": 643,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 10,
+                            "openAppointmentSlots": 10,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 10,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 10,
+                    "name": "Kostoryz and Gollihar H-E-B",
+                    "longitude": -97.40516,
+                    "latitude": 27.73917,
+                    "fluUrl": "",
+                    "city": "CORPUS CHRISTI",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
+                },
+                {
+                    "zip": "77803-1828",
+                    "url": null,
+                    "type": "store",
+                    "street": "1609 NORTH TEXAS AVENUE",
+                    "storeNumber": 644,
                     "state": "TX",
                     "slotDetails": [],
                     "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
                     "openAppointmentSlots": 0,
-                    "name": "Kostoryz and Gollihar H-E-B",
-                    "longitude": -97.40516,
-                    "latitude": 27.73917,
-                    "fluUrl": "",
-                    "city": "CORPUS CHRISTI"
-                },
-                {
-                    "zip": "77803-1828",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudiQAC",
-                    "type": "store",
-                    "street": "1609 NORTH TEXAS AVENUE",
-                    "storeNumber": 644,
-                    "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 5,
-                            "openAppointmentSlots": 5,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 7,
-                            "openAppointmentSlots": 7,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 12,
-                            "openAppointmentSlots": 12,
-                            "manufacturer": "Pediatric_Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 24,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 24,
                     "name": "Hwy 21 and N Texas Ave H-E-B",
                     "longitude": -96.3717,
                     "latitude": 30.6901,
                     "fluUrl": "",
-                    "city": "BRYAN"
+                    "city": "BRYAN",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78229-3931",
@@ -8044,41 +7485,27 @@
                     "longitude": -98.58335,
                     "latitude": 29.51552,
                     "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78028-5916",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudkQAC",
+                    "url": null,
                     "type": "store",
                     "street": "313 SIDNEY BAKER SOUTH",
                     "storeNumber": 655,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 148,
-                            "openAppointmentSlots": 148,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 149,
-                            "openAppointmentSlots": 149,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 45,
-                            "openAppointmentSlots": 45,
-                            "manufacturer": "Pediatric_Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 342,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 342,
+                    "openAppointmentSlots": 0,
                     "name": "Kerrville H-E-B on Sidney Baker St",
                     "longitude": -99.14342,
                     "latitude": 30.04152,
                     "fluUrl": "",
-                    "city": "KERRVILLE"
+                    "city": "KERRVILLE",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78550-5152",
@@ -8089,40 +7516,31 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 21,
-                            "openAppointmentSlots": 21,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 19,
-                            "openAppointmentSlots": 19,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 21,
-                            "openAppointmentSlots": 21,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 18,
-                            "openAppointmentSlots": 18,
-                            "manufacturer": "Ultra_Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 36,
-                            "openAppointmentSlots": 36,
+                            "openTimeslots": 117,
+                            "openAppointmentSlots": 117,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 115,
+                    "openTimeslots": 117,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 115,
+                    "openAppointmentSlots": 117,
                     "name": "Morgan and Grimes H-E-B",
                     "longitude": -97.67639,
                     "latitude": 26.20337,
                     "fluUrl": "",
-                    "city": "HARLINGEN"
+                    "city": "HARLINGEN",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Novavax",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78539-5664",
@@ -8133,25 +7551,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 16,
-                            "openAppointmentSlots": 16,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 15,
-                            "openAppointmentSlots": 15,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 12,
+                            "openAppointmentSlots": 12,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 31,
+                    "openTimeslots": 12,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 31,
+                    "openAppointmentSlots": 12,
                     "name": "Closner and Baker H-E-B",
                     "longitude": -98.1642,
                     "latitude": 26.29029,
                     "fluUrl": "",
-                    "city": "EDINBURG"
+                    "city": "EDINBURG",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu",
+                        "COVID-19 Pediatric_Pfizer"
+                    ]
                 },
                 {
                     "zip": "78216-7202",
@@ -8162,35 +7580,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 33,
-                            "openAppointmentSlots": 33,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 28,
-                            "openAppointmentSlots": 28,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 20,
-                            "openAppointmentSlots": 20,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 4,
-                            "openAppointmentSlots": 4,
+                            "openTimeslots": 133,
+                            "openAppointmentSlots": 133,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 85,
+                    "openTimeslots": 133,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 85,
+                    "openAppointmentSlots": 133,
                     "name": "San Pedro and Oblate H-E-B",
                     "longitude": -98.4995,
                     "latitude": 29.50282,
                     "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": [
+                        "COVID-19 Moderna",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "76502-1802",
@@ -8208,7 +7618,8 @@
                     "longitude": -97.37061,
                     "latitude": 31.07223,
                     "fluUrl": "",
-                    "city": "TEMPLE"
+                    "city": "TEMPLE",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78753-4106",
@@ -8219,82 +7630,71 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 78,
-                            "openAppointmentSlots": 78,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 66,
-                            "openAppointmentSlots": 66,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 107,
-                            "openAppointmentSlots": 107,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 431,
+                            "openAppointmentSlots": 431,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 251,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 251,
+                    "openTimeslots": 214,
+                    "openFluTimeslots": 217,
+                    "openFluAppointmentSlots": 217,
+                    "openAppointmentSlots": 214,
                     "name": "Lamar and Rundberg H-E-B",
                     "longitude": -97.69689,
                     "latitude": 30.36357,
-                    "fluUrl": "",
-                    "city": "AUSTIN"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF0kQAE",
+                    "city": "AUSTIN",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu"
+                    ]
                 },
                 {
                     "zip": "78410-2612",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gub3QAC",
                     "type": "store",
                     "street": "11100 LEOPARD",
                     "storeNumber": 184,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 23,
+                            "openAppointmentSlots": 23,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 23,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 23,
+                    "name": "Leopard and Violet H-E-B",
+                    "longitude": -97.58473,
+                    "latitude": 27.84494,
+                    "fluUrl": "",
+                    "city": "CORPUS CHRISTI",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
+                },
+                {
+                    "zip": "78041-5435",
+                    "url": null,
+                    "type": "store",
+                    "street": "2310 E SAUNDERS ST",
+                    "storeNumber": 186,
                     "state": "TX",
                     "slotDetails": [],
                     "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
                     "openAppointmentSlots": 0,
-                    "name": "Leopard and Violet H-E-B",
-                    "longitude": -97.58473,
-                    "latitude": 27.84494,
-                    "fluUrl": "",
-                    "city": "CORPUS CHRISTI"
-                },
-                {
-                    "zip": "78041-5435",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gub4QAC",
-                    "type": "store",
-                    "street": "2310 E SAUNDERS ST",
-                    "storeNumber": 186,
-                    "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 42,
-                            "openAppointmentSlots": 42,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 38,
-                            "openAppointmentSlots": 38,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 12,
-                            "openAppointmentSlots": 12,
-                            "manufacturer": "Pediatric_Pfizer"
-                        }
-                    ],
-                    "openTimeslots": 92,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 92,
                     "name": "Saunders St H-E-B",
                     "longitude": -99.47131,
                     "latitude": 27.53071,
                     "fluUrl": "",
-                    "city": "LAREDO"
+                    "city": "LAREDO",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78745-0",
@@ -8305,30 +7705,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 84,
-                            "openAppointmentSlots": 84,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 86,
-                            "openAppointmentSlots": 86,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 39,
-                            "openAppointmentSlots": 39,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 164,
+                            "openAppointmentSlots": 164,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 209,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 209,
+                    "openTimeslots": 69,
+                    "openFluTimeslots": 95,
+                    "openFluAppointmentSlots": 95,
+                    "openAppointmentSlots": 69,
                     "name": "Slaughter and South Congress H-E-B",
                     "longitude": -97.78723,
                     "latitude": 30.16862,
-                    "fluUrl": "",
-                    "city": "AUSTIN"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF5CQAU",
+                    "city": "AUSTIN",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer"
+                    ]
                 },
                 {
                     "zip": "78220-2530",
@@ -8339,25 +7735,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 33,
-                            "openAppointmentSlots": 33,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 33,
-                            "openAppointmentSlots": 33,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 40,
+                            "openAppointmentSlots": 40,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 66,
+                    "openTimeslots": 40,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 66,
+                    "openAppointmentSlots": 40,
                     "name": "W. W. White H-E-B",
                     "longitude": -98.40568,
                     "latitude": 29.41476,
                     "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "75119-4519",
@@ -8375,7 +7770,8 @@
                     "longitude": -96.63251,
                     "latitude": 32.32542,
                     "fluUrl": "",
-                    "city": "ENNIS"
+                    "city": "ENNIS",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78258-7587",
@@ -8386,30 +7782,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 53,
-                            "openAppointmentSlots": 53,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 49,
-                            "openAppointmentSlots": 49,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 55,
-                            "openAppointmentSlots": 55,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 310,
+                            "openAppointmentSlots": 310,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 157,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 157,
+                    "openTimeslots": 110,
+                    "openFluTimeslots": 200,
+                    "openFluAppointmentSlots": 200,
+                    "openAppointmentSlots": 110,
                     "name": "281 and Evans Road H-E-B plus!",
                     "longitude": -98.45756,
                     "latitude": 29.63886,
-                    "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4zQAE",
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77433-4288",
@@ -8420,35 +7811,28 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 120,
-                            "openAppointmentSlots": 120,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 331,
-                            "openAppointmentSlots": 331,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 328,
-                            "openAppointmentSlots": 328,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 84,
-                            "openAppointmentSlots": 84,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 840,
+                            "openAppointmentSlots": 840,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 863,
+                    "openTimeslots": 840,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 863,
+                    "openAppointmentSlots": 840,
                     "name": "Fairfield Market H-E-B",
                     "longitude": -95.74599,
                     "latitude": 29.9925,
                     "fluUrl": "",
-                    "city": "CYPRESS"
+                    "city": "CYPRESS",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77065-4814",
@@ -8459,30 +7843,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 12,
-                            "openAppointmentSlots": 12,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 16,
-                            "openAppointmentSlots": 16,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 824,
+                            "openAppointmentSlots": 824,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 38,
+                    "openTimeslots": 824,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 38,
+                    "openAppointmentSlots": 824,
                     "name": "Jones and West H-E-B",
                     "longitude": -95.5859,
                     "latitude": 29.91104,
                     "fluUrl": "",
-                    "city": "HOUSTON"
+                    "city": "HOUSTON",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer",
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer"
+                    ]
                 },
                 {
                     "zip": "78258-0",
@@ -8493,30 +7873,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 57,
-                            "openAppointmentSlots": 57,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 40,
-                            "openAppointmentSlots": 40,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 22,
-                            "openAppointmentSlots": 22,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 54,
+                            "openAppointmentSlots": 54,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 119,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 119,
+                    "openTimeslots": 25,
+                    "openFluTimeslots": 29,
+                    "openFluAppointmentSlots": 29,
+                    "openAppointmentSlots": 25,
                     "name": "The Market at Stone Oak",
                     "longitude": -98.50062,
                     "latitude": 29.662,
-                    "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4kQAE",
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78717-5992",
@@ -8527,20 +7902,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 16,
-                            "openAppointmentSlots": 16,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 9,
+                            "openAppointmentSlots": 9,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 16,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 16,
+                    "openTimeslots": 1,
+                    "openFluTimeslots": 8,
+                    "openFluAppointmentSlots": 8,
+                    "openAppointmentSlots": 1,
                     "name": "Lakeline H-E-B plus!",
                     "longitude": -97.8034,
                     "latitude": 30.47786,
-                    "fluUrl": "",
-                    "city": "AUSTIN"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4lQAE",
+                    "city": "AUSTIN",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77304-1837",
@@ -8551,25 +7930,35 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 347,
-                            "openAppointmentSlots": 347,
+                            "openTimeslots": 350,
+                            "openAppointmentSlots": 350,
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 387,
-                            "openAppointmentSlots": 387,
+                            "openTimeslots": 391,
+                            "openAppointmentSlots": 391,
                             "manufacturer": "Pfizer"
+                        },
+                        {
+                            "openTimeslots": 1028,
+                            "openAppointmentSlots": 1028,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 734,
+                    "openTimeslots": 1769,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 734,
+                    "openAppointmentSlots": 1769,
                     "name": "Conroe Market H-E-B",
                     "longitude": -95.49817,
                     "latitude": 30.32647,
                     "fluUrl": "",
-                    "city": "CONROE"
+                    "city": "CONROE",
+                    "availableImmunizations": [
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu"
+                    ]
                 },
                 {
                     "zip": "77590-6548",
@@ -8580,25 +7969,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 120,
-                            "openAppointmentSlots": 120,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 95,
-                            "openAppointmentSlots": 95,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 167,
+                            "openAppointmentSlots": 167,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 215,
+                    "openTimeslots": 167,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 215,
+                    "openAppointmentSlots": 167,
                     "name": "Texas City H-E-B",
                     "longitude": -94.94893,
                     "latitude": 29.39535,
                     "fluUrl": "",
-                    "city": "TEXAS CITY"
+                    "city": "TEXAS CITY",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer"
+                    ]
                 },
                 {
                     "zip": "78228-6308",
@@ -8616,7 +8006,8 @@
                     "longitude": -98.5407,
                     "latitude": 29.44655,
                     "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78209-5703",
@@ -8627,35 +8018,29 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 27,
-                            "openAppointmentSlots": 27,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 40,
-                            "openAppointmentSlots": 40,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 28,
-                            "openAppointmentSlots": 28,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 52,
-                            "openAppointmentSlots": 52,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 570,
+                            "openAppointmentSlots": 570,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 147,
+                    "openTimeslots": 570,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 147,
+                    "openAppointmentSlots": 570,
                     "name": "Broadway Central Market",
                     "longitude": -98.46408,
                     "latitude": 29.47069,
                     "fluUrl": "",
-                    "city": "SAN ANTONIO"
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": [
+                        "COVID-19 Moderna",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Janssen",
+                        "Flu",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "76522-2515",
@@ -8673,36 +8058,35 @@
                     "longitude": -97.86448,
                     "latitude": 31.11872,
                     "fluUrl": "",
-                    "city": "COPPERAS COVE"
+                    "city": "COPPERAS COVE",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78834-2028",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudsQAC",
+                    "url": null,
                     "type": "store",
                     "street": "2030 N. 1ST STREET",
                     "storeNumber": 671,
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 9,
-                            "openAppointmentSlots": 9,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 11,
-                            "openAppointmentSlots": 11,
-                            "manufacturer": "Pfizer"
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 20,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 20,
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 20,
+                    "openFluAppointmentSlots": 20,
+                    "openAppointmentSlots": 0,
                     "name": "Carrizo Springs H-E-B",
                     "longitude": -99.85102,
                     "latitude": 28.53642,
-                    "fluUrl": "",
-                    "city": "CARRIZO SPRINGS"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF53QAE",
+                    "city": "CARRIZO SPRINGS",
+                    "availableImmunizations": [
+                        "Flu"
+                    ]
                 },
                 {
                     "zip": "76711-2119",
@@ -8713,45 +8097,32 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
-                            "manufacturer": "Janssen"
-                        },
-                        {
-                            "openTimeslots": 88,
-                            "openAppointmentSlots": 88,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 25,
-                            "openAppointmentSlots": 25,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 86,
-                            "openAppointmentSlots": 86,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 56,
-                            "openAppointmentSlots": 56,
-                            "manufacturer": "Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 45,
-                            "openAppointmentSlots": 45,
-                            "manufacturer": "Ultra_Pediatric_Pfizer"
+                            "openTimeslots": 78,
+                            "openAppointmentSlots": 78,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 350,
+                    "openTimeslots": 78,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 350,
+                    "openAppointmentSlots": 78,
                     "name": "Valley Mills H-E-B plus!",
                     "longitude": -97.13916,
                     "latitude": 31.52508,
                     "fluUrl": "",
-                    "city": "WACO"
+                    "city": "WACO",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Novavax",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Janssen",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78665-1044",
@@ -8762,35 +8133,31 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 8,
-                            "openAppointmentSlots": 8,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 2,
-                            "openAppointmentSlots": 2,
-                            "manufacturer": "Pediatric_Moderna"
-                        },
-                        {
-                            "openTimeslots": 11,
-                            "openAppointmentSlots": 11,
-                            "manufacturer": "Ultra_Pediatric_Pfizer"
-                        },
-                        {
-                            "openTimeslots": 66,
-                            "openAppointmentSlots": 66,
+                            "openTimeslots": 84,
+                            "openAppointmentSlots": 84,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 87,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 87,
+                    "openTimeslots": 79,
+                    "openFluTimeslots": 5,
+                    "openFluAppointmentSlots": 5,
+                    "openAppointmentSlots": 79,
                     "name": "University Blvd H-E-B",
                     "longitude": -97.68859,
                     "latitude": 30.56107,
-                    "fluUrl": "",
-                    "city": "ROUND ROCK"
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF55QAE",
+                    "city": "ROUND ROCK",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Novavax",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78573-5070",
@@ -8801,30 +8168,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 14,
-                            "openAppointmentSlots": 14,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 28,
-                            "openAppointmentSlots": 28,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 13,
-                            "openAppointmentSlots": 13,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 36,
+                            "openAppointmentSlots": 36,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 55,
+                    "openTimeslots": 36,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 55,
+                    "openAppointmentSlots": 36,
                     "name": "Palmhurst H-E-B",
                     "longitude": -98.31816,
                     "latitude": 26.25684,
                     "fluUrl": "",
-                    "city": "PALMHURST"
+                    "city": "PALMHURST",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer"
+                    ]
                 },
                 {
                     "zip": "77581-5346",
@@ -8835,30 +8198,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 201,
-                            "openAppointmentSlots": 201,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 169,
-                            "openAppointmentSlots": 169,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 153,
-                            "openAppointmentSlots": 153,
-                            "manufacturer": "Pediatric_Pfizer"
+                            "openTimeslots": 340,
+                            "openAppointmentSlots": 340,
+                            "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 523,
+                    "openTimeslots": 340,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 523,
+                    "openAppointmentSlots": 340,
                     "name": "Pearland Market H-E-B",
                     "longitude": -95.26499,
                     "latitude": 29.55812,
                     "fluUrl": "",
-                    "city": "PEARLAND"
+                    "city": "PEARLAND",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "75206-2921",
@@ -8876,7 +8236,8 @@
                     "longitude": -96.76835,
                     "latitude": 32.85091,
                     "fluUrl": "",
-                    "city": "DALLAS"
+                    "city": "DALLAS",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "76092-6420",
@@ -8894,7 +8255,38 @@
                     "longitude": -97.12966,
                     "latitude": 32.94096,
                     "fluUrl": "",
-                    "city": "SOUTHLAKE"
+                    "city": "SOUTHLAKE",
+                    "availableImmunizations": null
+                },
+                {
+                    "zip": "75033-0",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h6P000000067cQAA",
+                    "type": "store",
+                    "street": "4800 MAIN STREET",
+                    "storeNumber": 789,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 164,
+                            "openAppointmentSlots": 164,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 164,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 164,
+                    "name": "Frisco H-E-B",
+                    "longitude": -96.84583,
+                    "latitude": 33.15458,
+                    "fluUrl": "",
+                    "city": "FRISCO",
+                    "availableImmunizations": [
+                        "COVID-19 Moderna",
+                        "COVID-19 Janssen",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Novavax"
+                    ]
                 }
             ]
         },
@@ -8902,15 +8294,15 @@
             "Content-Type",
             "binary/octet-stream",
             "Content-Length",
-            "178173",
+            "180218",
             "Connection",
             "close",
             "Date",
-            "Thu, 30 Jun 2022 02:27:47 GMT",
+            "Fri, 23 Sep 2022 01:57:11 GMT",
             "Last-Modified",
-            "Thu, 30 Jun 2022 02:26:08 GMT",
+            "Fri, 23 Sep 2022 01:56:21 GMT",
             "ETag",
-            "\"b14524c3f8c52a9e5f2b5ec8e958d43f\"",
+            "\"263e5e82603e9bd09b12d6a0a2c1149d\"",
             "Cache-Control",
             "max-age:0",
             "Accept-Ranges",
@@ -8920,11 +8312,11 @@
             "X-Cache",
             "Miss from cloudfront",
             "Via",
-            "1.1 42d3518040c55e24793897f7f5d5f342.cloudfront.net (CloudFront)",
+            "1.1 912d83c7c9b4676eb19f09c9bfabda24.cloudfront.net (CloudFront)",
             "X-Amz-Cf-Pop",
-            "EWR53-C1",
+            "SFO5-P2",
             "X-Amz-Cf-Id",
-            "M3mJVyrjZG6SXMaoB0I4NjpqaWogopf8aO_jH5RiPjczaiesaBeryw=="
+            "5H74alGnsTF52Qe5IIQpcYxFhO5OyF-XFxFA-K7tugjBkGx-2ncgIw=="
         ],
         "responseIsBinary": false
     }

--- a/loader/test/heb.test.js
+++ b/loader/test/heb.test.js
@@ -46,6 +46,11 @@ describe("H-E-B", () => {
       latitude: 29.47069,
       fluUrl: "",
       city: "SAN ANTONIO",
+      availableImmunizations: [
+        "COVID-19 Janssen",
+        "COVID-19 Moderna_Updated_Booster",
+        "COVID-19 Pfizer_Updated_Booster",
+      ],
     });
 
     expect(formatted).toEqual({
@@ -70,7 +75,7 @@ describe("H-E-B", () => {
         checked_at: expectDatetimeString(),
         is_public: true,
         available_count: 76,
-        products: ["jj", "moderna", "pfizer"],
+        products: ["jj", "moderna_ba4_ba5", "pfizer_ba4_ba5"],
       },
     });
   });


### PR DESCRIPTION
H-E-B added bivalent vaccine listings in an unenjoyably complex new way, and this adds support for it. Fixes https://sentry.io/organizations/usdr/issues/3613330687 and https://sentry.io/organizations/usdr/issues/3613330594.

Previously, each locations would have a `slotDetails` field with an array of objects representing the number of open slots for each vaccine type (identified by the `manufacturer` field [side note: this originally indicated just the manufacturer, until we had pediatric vaccines, at which point it became more of a product type]), like so:

```js
{
  "slotDetails": [
    {
      "openTimeslots": 23,
      "openAppointmentSlots": 23,
      "manufacturer": "Pfizer"
    },
    {
      "openTimeslots": 15,
      "openAppointmentSlots": 15,
      "manufacturer": "Ultra_Pediatric_Pfizer"
    },
    {
      "openTimeslots": 164,
      "openAppointmentSlots": 164,
      "manufacturer": "Multiple"
    }
  ]
  // ...other location fields...
}
```

(Sadly, we had to give up on identifying what was available for “Multiple” if it was listed alongside some other more specific slots.)

With bivalent boosters, they didn’t create a new `manufacturer` value, but instead added a new location-level `availableImmunizations` field that the `manufacter` field maps to (the actual concrete values don’t match, so I had to guess the mappings, but they are pretty obvious). This looks like:

```js
{
  "slotDetails": [
    {
      "openTimeslots": 23,
      "openAppointmentSlots": 23,
      // Notably, this is still just "Pfizer" in locations that only have
      // "Pfizer_Updated_Booster" listed under `availableImmunizations`.
      "manufacturer": "Pfizer"
    },
    {
      "openTimeslots": 15,
      "openAppointmentSlots": 15,
      "manufacturer": "Ultra_Pediatric_Pfizer"
    },
    {
      "openTimeslots": 164,
      "openAppointmentSlots": 164,
      "manufacturer": "Multiple"
    }
  ],
  "availableImmunizations": [
    "COVID-19 Pfizer",
    "COVID-19 Pfizer_Updated_Booster",
    "COVID-19 Ultra_Pediatric_Pfizer",
    "COVID-19 Moderna_Updated_Booster"
  ]
  // ...other location fields...
}
```

To add to the complexity, `availableImmunizations` is often `null`.

This attempts to map `manufacturer` to `availableImmunizations` when present, or to the list of known values for `availableImmunizations` when not. One upshot here is that we can often list the actual products in the `Multiple` case, which we could not do before. It’s definitely a lot more complicated, though.