### PR TITLE
Handle new Moderna vaccine name from Alaska

### DIFF
--- a/loader/src/sources/prepmod/index.js
+++ b/loader/src/sources/prepmod/index.js
@@ -302,7 +302,7 @@ function parseSchedule(schedule) {
         data.hasNonCovidProducts = true;
       } else {
         warn(
-          "Unparseable product extension",
+          `Unparseable product "${extension?.valueCoding?.display}"`,
           {
             scheduleId: schedule.id,
             extension,

--- a/loader/src/utils.js
+++ b/loader/src/utils.js
@@ -554,7 +554,7 @@ module.exports = {
     if (/astra\s*zeneca/.test(text)) {
       return isBa4Ba5 ? undefined : VaccineProduct.astraZeneca;
     } else if (text.includes("moderna")) {
-      if (/ages?\s+18( and up|\s*\+)/i.test(text)) {
+      if (/ages?\s+(12|18)( and up|\s*\+)/i.test(text)) {
         return isBa4Ba5 ? VaccineProduct.modernaBa4Ba5 : VaccineProduct.moderna;
       } else if (/ages?\s+6\s*(m|months)\b/i.test(text)) {
         return isBa4Ba5 ? undefined : VaccineProduct.modernaAge0_5;

--- a/loader/test/utils.test.js
+++ b/loader/test/utils.test.js
@@ -237,6 +237,7 @@ describe("matchVaccineProduct", () => {
     [v.moderna, "Moderna COVID-19 Vaccine"],
     [v.moderna, "Moderna Booster COVID-19 Vaccine"],
     [v.moderna, "Moderna COVID-19 Vaccine/Booster (Ages 18+)"],
+    [v.moderna, "Moderna COVID-19 Vaccine (Ages 12+)"],
 
     [v.modernaBa4Ba5, "Moderna COVID-19 Vaccine (Ages 12+)/Bivalent Booster (Ages 18+)"],
     [v.modernaBa4Ba5, "Moderna COVID-19, Bivalent Booster (Ages 18+)"],


### PR DESCRIPTION
Alaska's PrepMod instance is now showing "Moderna COVID-19 Vaccine (Ages 12+)" instead of "Moderna COVID-19 Vaccine (Ages 18+)" in a lot of cases now. They are the same product with the same authorization, so not much really needs to change here.

While I was at it, I added the display name to the error message, since this unhelpfully vague error in Sentry is always frustrating:

<img width="568" alt="Screen Shot 2022-09-23 at 12 24 16 PM" src="https://user-images.githubusercontent.com/74178/192043417-0c653156-0d80-45e9-9a67-0074856ab6c8.png">

Fixes https://sentry.io/organizations/usdr/issues/3382842420.