### PR TITLE
Handle "multi - vaccine" listings in Washington

### DIFF
--- a/loader/src/sources/prepmod/index.js
+++ b/loader/src/sources/prepmod/index.js
@@ -267,6 +267,10 @@ const nonCovidProductName = new RegExp(
     raw`\btdap\b`,
     raw`\bPCV(\d+)?\b`,
     raw`\bPPSV(\d+)?\b`,
+    // In all cases we've seen, this occurs on schedules that list other actual
+    // vaccine names as well. We'll pick up the true products from the other
+    // extensions in the schedule.
+    raw`multi\s*-\s*vaccine`,
   ].join("|"),
   "i"
 );


### PR DESCRIPTION
Washington's PrepMod instance just started listing `"multi - vaccine"` as a vaccine name on some schedules. This skips over it, which should be perfectly fine since we are only seeing it on schedules that list multiple other vaccines, and we'll pick up the COVID-ness and product names from those. Fixes https://sentry.io/organizations/usdr/issues/3629606210.