### PR TITLE
Stop trying to be so fancy with line breaks in PrepMod addresses

### DIFF
--- a/loader/src/sources/prepmod/index.js
+++ b/loader/src/sources/prepmod/index.js
@@ -6,7 +6,6 @@
  * contact at least one (and sometimes several) hosts in each state.
  */
 
-const { isDeepStrictEqual } = require("node:util");
 const { ApiClient } = require("../../api-client");
 const {
   EXTENSIONS,

--- a/loader/test/prepmod.test.js
+++ b/loader/test/prepmod.test.js
@@ -622,8 +622,7 @@ describe("PrepMod API", () => {
     );
     expect(result).toHaveProperty("address_lines", [
       "Some High School",
-      "123 Example Rd.",
-      "Ste. 313",
+      "123 Example Rd., Ste. 313",
     ]);
     expect(result).toHaveProperty("city", "Somewheresville");
     expect(result).toHaveProperty("state", "SC");


### PR DESCRIPTION
This is a competing proposal with #988.

Fixes #929 by ceasing to try to insert new line breaks in PrepMod addresses where they probably ought to be using all kinds of fussy logic. This is the simple approach and probably the smarter one. I’d be sad to lose all the nice address formatting, but I suspect it’s not worth the maintenance burden.