### PR TITLE
Upgrade cron job resources

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -124,7 +124,7 @@ services:
     schedule: "0/10 * * * *" # Every 10 minutes
     startCommand: |
       cd loader
-      bin/univaf-loader.js cvsSmart --send --compact --states "AL,AK,AZ,AR,CA,CO,CT,DE,DC,FL,GA,HI,ID,IL,IN,IA,KS,KY,LA,ME,MD,MA,MI,MN,MS,MO,MT,NE,NV,NH,NJ,NM,NY,NC,ND,OH,OK,OR,PA,RI,SC,SD,TN,TX,UT,VT,VA,WA,WV,WI,WY,MH,PR,VI"
+      bin/univaf-loader.js cvsSmart --send --compact
     # Common options used for all crons. (Other configs use `<<` to repeat this
     # cron job's configuration and override the above, non-common values.)
     plan: "starter plus"
@@ -178,56 +178,56 @@ services:
     schedule: "0/10 * * * *" # Every 10 minutes
     startCommand: |
       cd loader
-      bin/univaf-loader.js riteAidScraper --send --compact --states "CA,CO,CT,DE,ID,MA,MD,MI,NH,NJ,NV,NY,OH,OR,PA,VA,VT,WA"
+      bin/univaf-loader.js riteAidScraper --send --compact
 
   - <<: *loader-config
     name: "Loader: Walgreens SMART"
     schedule: "2/10 * * * *" # Every 10 minutes
     startCommand: |
       cd loader
-      bin/univaf-loader.js walgreensSmart --send --compact --states "AL,AK,AZ,AR,CA,CO,CT,DE,DC,FL,GA,HI,ID,IL,IN,IA,KS,KY,LA,ME,MD,MA,MI,MN,MS,MO,MT,NE,NV,NH,NJ,NM,NY,NC,ND,OH,OK,OR,PA,RI,SC,SD,TN,TX,UT,VT,VA,WA,WV,WI,WY,MH,PR,VI"
+      bin/univaf-loader.js walgreensSmart --send --compact
 
   - <<: *loader-config
     name: "Loader: Kroger SMART"
     schedule: "4/10 * * * *" # Every 10 minutes
     startCommand: |
       cd loader
-      bin/univaf-loader.js krogerSmart --send --compact --states "AL,AK,AZ,AR,CA,CO,CT,DE,DC,FL,GA,HI,ID,IL,IN,IA,KS,KY,LA,ME,MD,MA,MI,MN,MS,MO,MT,NE,NV,NH,NJ,NM,NY,NC,ND,OH,OK,OR,PA,RI,SC,SD,TN,TX,UT,VT,VA,WA,WV,WI,WY,MH,PR,VI"
+      bin/univaf-loader.js krogerSmart --send --compact
 
   - <<: *loader-config
     name: "Loader: Albertsons"
     schedule: "6/10 * * * *" # Every 10 minutes
     startCommand: |
       cd loader
-      bin/univaf-loader.js albertsons --send --compact --states "AL,AK,AZ,AR,CA,CO,CT,DE,DC,FL,GA,HI,ID,IL,IN,IA,KS,KY,LA,ME,MD,MA,MI,MN,MS,MO,MT,NE,NV,NH,NJ,NM,NY,NC,ND,OH,OK,OR,PA,RI,SC,SD,TN,TX,UT,VT,VA,WA,WV,WI,WY,MH,PR,VI"
+      bin/univaf-loader.js albertsons --send --compact
 
   - <<: *loader-config
     name: "Loader: HyVee"
     schedule: "8/10 * * * *" # Every 10 minutes
     startCommand: |
       cd loader
-      bin/univaf-loader.js hyvee --send --compact --states "AL,AK,AZ,AR,CA,CO,CT,DE,DC,FL,GA,HI,ID,IL,IN,IA,KS,KY,LA,ME,MD,MA,MI,MN,MS,MO,MT,NE,NV,NH,NJ,NM,NY,NC,ND,OH,OK,OR,PA,RI,SC,SD,TN,TX,UT,VT,VA,WA,WV,WI,WY,MH,PR,VI"
+      bin/univaf-loader.js hyvee --send --compact
 
   - <<: *loader-config
     name: "Loader: H-E-B"
     schedule: "1/10 * * * *" # Every 10 minutes
     startCommand: |
       cd loader
-      bin/univaf-loader.js heb --send --compact --states "AL,AK,AZ,AR,CA,CO,CT,DE,DC,FL,GA,HI,ID,IL,IN,IA,KS,KY,LA,ME,MD,MA,MI,MN,MS,MO,MT,NE,NV,NH,NJ,NM,NY,NC,ND,OH,OK,OR,PA,RI,SC,SD,TN,TX,UT,VT,VA,WA,WV,WI,WY,MH,PR,VI"
+      bin/univaf-loader.js heb --send --compact
 
   - <<: *loader-config
     name: "Loader: WA Dept. of Health"
     schedule: "3/5 * * * *" # Every 5 minutes
     startCommand: |
       cd loader
-      bin/univaf-loader.js waDoh --send --compact --states "AL,AK,AZ,AR,CA,CO,CT,DE,DC,FL,GA,HI,ID,IL,IN,IA,KS,KY,LA,ME,MD,MA,MI,MN,MS,MO,MT,NE,NV,NH,NJ,NM,NY,NC,ND,OH,OK,OR,PA,RI,SC,SD,TN,TX,UT,VT,VA,WA,WV,WI,WY,MH,PR,VI"
+      bin/univaf-loader.js waDoh --send --compact
 
   - <<: *loader-config
     name: "Loader: CDC Open Data API"
     schedule: "0 0,12 * * *" # Twice a day
     startCommand: |
       cd loader
-      bin/univaf-loader.js cdcApi --send --compact --states "AL,AK,AZ,AR,CA,CO,CT,DE,DC,FL,GA,HI,ID,IL,IN,IA,KS,KY,LA,ME,MD,MA,MI,MN,MS,MO,MT,NE,NV,NH,NJ,NM,NY,NC,ND,OH,OK,OR,PA,RI,SC,SD,TN,TX,UT,VT,VA,WA,WV,WI,WY,MH,PR,VI"
+      bin/univaf-loader.js cdcApi --send --compact
 
   - <<: *loader-config
     name: "Loader: PrepMod"

--- a/render.yaml
+++ b/render.yaml
@@ -127,7 +127,7 @@ services:
       bin/univaf-loader.js cvsSmart --send --compact --states "AL,AK,AZ,AR,CA,CO,CT,DE,DC,FL,GA,HI,ID,IL,IN,IA,KS,KY,LA,ME,MD,MA,MI,MN,MS,MO,MT,NE,NV,NH,NJ,NM,NY,NC,ND,OH,OK,OR,PA,RI,SC,SD,TN,TX,UT,VT,VA,WA,WV,WI,WY,MH,PR,VI"
     # Common options used for all crons. (Other configs use `<<` to repeat this
     # cron job's configuration and override the above, non-common values.)
-    plan: starter
+    plan: "starter plus"
     type: cron
     env: node
     region: oregon

--- a/terraform/deprecated/loaders.tf
+++ b/terraform/deprecated/loaders.tf
@@ -11,7 +11,6 @@ module "cvs_smart_loader" {
   name          = "cvs-smart-api"
   loader_image  = "${aws_ecr_repository.loader_repository.repository_url}:${var.loader_release_version}"
   loader_source = "cvsSmart"
-  command       = ["--states", "AL,AK,AZ,AR,CA,CO,CT,DE,DC,FL,GA,HI,ID,IL,IN,IA,KS,KY,LA,ME,MD,MA,MI,MN,MS,MO,MT,NE,NV,NH,NJ,NM,NY,NC,ND,OH,OK,OR,PA,RI,SC,SD,TN,TX,UT,VT,VA,WA,WV,WI,WY,MH,PR,VI"]
   api_url       = "http://${aws_alb.main.dns_name}"
   api_key       = var.api_key
   sentry_dsn    = var.loader_sentry_dsn
@@ -82,7 +81,6 @@ module "walgreens_loader" {
 
   name          = "walgreensSmart"
   loader_image  = "${aws_ecr_repository.loader_repository.repository_url}:${var.loader_release_version}"
-  command       = ["--states", "AL,AK,AZ,AR,CA,CO,CT,DE,DC,FL,GA,HI,ID,IL,IN,IA,KS,KY,LA,ME,MD,MA,MI,MN,MS,MO,MT,NE,NV,NH,NJ,NM,NY,NC,ND,OH,OK,OR,PA,RI,SC,SD,TN,TX,UT,VT,VA,WA,WV,WI,WY,MH,PR,VI"]
   loader_source = "walgreensSmart"
   api_url       = "http://${aws_alb.main.dns_name}"
   api_key       = var.api_key
@@ -98,7 +96,6 @@ module "kroger_loader" {
 
   name          = "krogerSmart"
   loader_image  = "${aws_ecr_repository.loader_repository.repository_url}:${var.loader_release_version}"
-  command       = ["--states", "AL,AK,AZ,AR,CA,CO,CT,DE,DC,FL,GA,HI,ID,IL,IN,IA,KS,KY,LA,ME,MD,MA,MI,MN,MS,MO,MT,NE,NV,NH,NJ,NM,NY,NC,ND,OH,OK,OR,PA,RI,SC,SD,TN,TX,UT,VT,VA,WA,WV,WI,WY,MH,PR,VI"]
   loader_source = "krogerSmart"
   api_url       = "http://${aws_alb.main.dns_name}"
   api_key       = var.api_key
@@ -114,7 +111,6 @@ module "albertsons_loader" {
 
   name          = "albertsons"
   loader_image  = "${aws_ecr_repository.loader_repository.repository_url}:${var.loader_release_version}"
-  command       = ["--states", "AL,AK,AZ,AR,CA,CO,CT,DE,DC,FL,GA,HI,ID,IL,IN,IA,KS,KY,LA,ME,MD,MA,MI,MN,MS,MO,MT,NE,NV,NH,NJ,NM,NY,NC,ND,OH,OK,OR,PA,RI,SC,SD,TN,TX,UT,VT,VA,WA,WV,WI,WY,MH,PR,VI"]
   loader_source = "albertsons"
   api_url       = "http://${aws_alb.main.dns_name}"
   api_key       = var.api_key
@@ -130,7 +126,6 @@ module "hyvee_loader" {
 
   name          = "hyvee"
   loader_image  = "${aws_ecr_repository.loader_repository.repository_url}:${var.loader_release_version}"
-  command       = ["--states", "AL,AK,AZ,AR,CA,CO,CT,DE,DC,FL,GA,HI,ID,IL,IN,IA,KS,KY,LA,ME,MD,MA,MI,MN,MS,MO,MT,NE,NV,NH,NJ,NM,NY,NC,ND,OH,OK,OR,PA,RI,SC,SD,TN,TX,UT,VT,VA,WA,WV,WI,WY,MH,PR,VI"]
   loader_source = "hyvee"
   api_url       = "http://${aws_alb.main.dns_name}"
   api_key       = var.api_key
@@ -146,7 +141,6 @@ module "heb_loader" {
 
   name          = "heb"
   loader_image  = "${aws_ecr_repository.loader_repository.repository_url}:${var.loader_release_version}"
-  command       = ["--states", "AL,AK,AZ,AR,CA,CO,CT,DE,DC,FL,GA,HI,ID,IL,IN,IA,KS,KY,LA,ME,MD,MA,MI,MN,MS,MO,MT,NE,NV,NH,NJ,NM,NY,NC,ND,OH,OK,OR,PA,RI,SC,SD,TN,TX,UT,VT,VA,WA,WV,WI,WY,MH,PR,VI"]
   loader_source = "heb"
   api_url       = "http://${aws_alb.main.dns_name}"
   api_key       = var.api_key
@@ -162,7 +156,6 @@ module "washington_doh_loader" {
 
   name          = "waDoh"
   loader_image  = "${aws_ecr_repository.loader_repository.repository_url}:${var.loader_release_version}"
-  command       = ["--states", "AL,AK,AZ,AR,CA,CO,CT,DE,DC,FL,GA,HI,ID,IL,IN,IA,KS,KY,LA,ME,MD,MA,MI,MN,MS,MO,MT,NE,NV,NH,NJ,NM,NY,NC,ND,OH,OK,OR,PA,RI,SC,SD,TN,TX,UT,VT,VA,WA,WV,WI,WY,MH,PR,VI"]
   loader_source = "waDoh"
   api_url       = "http://${aws_alb.main.dns_name}"
   api_key       = var.api_key
@@ -179,28 +172,10 @@ module "cdc_loader" {
   name          = "cdcApi"
   loader_image  = "${aws_ecr_repository.loader_repository.repository_url}:${var.loader_release_version}"
   loader_source = "cdcApi"
-  command       = ["--states", "AL,AK,AZ,AR,CA,CO,CT,DE,DC,FL,GA,HI,ID,IL,IN,IA,KS,KY,LA,ME,MD,MA,MI,MN,MS,MO,MT,NE,NV,NH,NJ,NM,NY,NC,ND,OH,OK,OR,PA,RI,SC,SD,TN,TX,UT,VT,VA,WA,WV,WI,WY,MH,PR,VI"]
   api_url       = "http://${aws_alb.main.dns_name}"
   api_key       = var.api_key
   sentry_dsn    = var.loader_sentry_dsn
   schedule      = "cron(0 0,12 * * ? *)"
-  cluster_arn   = aws_ecs_cluster.main.arn
-  role          = aws_iam_role.ecs_task_execution_role.arn
-  subnets       = aws_subnet.public.*.id
-}
-
-module "vts_geo_loader" {
-  source = "./modules/loader"
-
-  name          = "vtsGeo"
-  enabled       = false
-  loader_image  = "${aws_ecr_repository.loader_repository.repository_url}:${var.loader_release_version}"
-  loader_source = "vtsGeo"
-  command       = ["--states", "AL,AK,AZ,AR,CA,CO,CT,DE,DC,FL,GA,HI,ID,IL,IN,IA,KS,KY,LA,ME,MD,MA,MI,MN,MS,MO,MT,NE,NV,NH,NJ,NM,NY,NC,ND,OH,OK,OR,PA,RI,SC,SD,TN,TX,UT,VT,VA,WA,WV,WI,WY,MH,PR,VI"]
-  api_url       = "http://${aws_alb.main.dns_name}"
-  api_key       = var.api_key
-  sentry_dsn    = var.loader_sentry_dsn
-  schedule      = "cron(1 1 1 1 ? 1970)"
   cluster_arn   = aws_ecs_cluster.main.arn
   role          = aws_iam_role.ecs_task_execution_role.arn
   subnets       = aws_subnet.public.*.id


### PR DESCRIPTION
This week, a lot of our cron jobs on Render started failing due to some sort of scheduling issues in Render's orchestration (that is: the jobs are never actually starting and our scripts don't even get a chance to fail -- the orchestrator is scheduling a job, and then failing it several minutes later instead of running it).

This is a check to see if maybe committing more resources to these jobs can solve the problem.

I also dropped the `--states` option from `render.yaml` in places where it was redundant, and just specifying the default.