### PR TITLE
Fix unescaped tab characters in CVS JSON data

### DIFF
--- a/loader/src/utils.js
+++ b/loader/src/utils.js
@@ -485,6 +485,9 @@ module.exports = {
       .filter(Boolean)
       .map((line, index) => {
         try {
+          // Escape any unescaped tab characters. This fixes an issue with
+          // improperly encoded JSON from some sources.
+          line = line.replace(/\t/g, "\\t");
           return JSON.parse(line);
         } catch (error) {
           throw new SyntaxError(`Error parsing line ${index + 1}: ${line}`);


### PR DESCRIPTION
CVS is outputting invalid JSON (there are unescaped tab characters, which are not allowed in proper JSON) in their SMART Scheduling Links API. This escapes any unescaped tabs, which should solve the issue for now on our side. (I've also notified their lead dev about the issue via FHIR chat.)

Fixes https://sentry.io/organizations/usdr/issues/3638566125.