### PR TITLE
Handle bivalent pediatric Moderna from H-E-B

### DIFF
--- a/loader/src/model.js
+++ b/loader/src/model.js
@@ -35,6 +35,7 @@ const VaccineProduct = {
   moderna: "moderna",
   modernaBa4Ba5: "moderna_ba4_ba5",
   modernaAge6_11: "moderna_age_6_11",
+  modernaBa4Ba5Age6_11: "moderna_ba4_ba5_age_6_11",
   modernaAge0_5: "moderna_age_0_5",
   novavax: "novavax",
   pfizer: "pfizer",

--- a/loader/src/sources/heb/index.js
+++ b/loader/src/sources/heb/index.js
@@ -44,6 +44,10 @@ const IMMUNIZATION_TYPES = {
     manufacturer: "pfizer",
     product: VaccineProduct.pfizerBa4Ba5,
   },
+  "COVID-19 Pediatric_Pfizer_Updated_Booster": {
+    manufacturer: "pediatric_pfizer",
+    product: VaccineProduct.pfizerBa4Ba5Age5_11,
+  },
   "COVID-19 Moderna_Updated_Booster": {
     manufacturer: "moderna",
     product: VaccineProduct.modernaBa4Ba5,
@@ -55,6 +59,10 @@ const IMMUNIZATION_TYPES = {
   "COVID-19 Pediatric_Moderna": {
     manufacturer: "pediatric_moderna",
     product: VaccineProduct.modernaAge0_5,
+  },
+  "COVID-19 Pediatric_Moderna_Updated_Booster": {
+    manufacturer: "pediatric_moderna",
+    product: VaccineProduct.modernaBa4Ba5Age6_11,
   },
   "COVID-19 Novavax": {
     // We haven't seen a "manufacturer" field with this, so it's a guess.

--- a/loader/test/fixtures/nock/h-e-b_should_output_valid_data.json
+++ b/loader/test/fixtures/nock/h-e-b_should_output_valid_data.json
@@ -2,194 +2,89 @@
     {
         "scope": "https://heb-ecom-covid-vaccine.hebdigital-prd.com:443",
         "method": "GET",
-        "path": "/vaccine_locations.json?v=790016882856.6163",
+        "path": "/vaccine_locations.json?v=987093037967.7764",
         "body": "",
         "status": 200,
         "response": {
             "locations": [
                 {
-                    "zip": "78654",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h6P0000004EAwQAM",
+                    "zip": "79525",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h6P0000004EGLQA2",
                     "type": "offsite",
-                    "street": "177 Broadmoor",
+                    "street": "2233 Ivanhoe Ln",
                     "storeNumber": null,
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 162,
-                            "openAppointmentSlots": 162,
+                            "openTimeslots": 32,
+                            "openAppointmentSlots": 32,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 162,
+                    "openTimeslots": 32,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 162,
-                    "name": "H-E-B Hosted City of Meadowlakes-Totten Hall",
+                    "openAppointmentSlots": 32,
+                    "name": "2022-2023 Hawley ISD Faculty & Staff - Flu+ Clinic",
                     "longitude": null,
                     "latitude": null,
                     "fluUrl": "",
-                    "city": "Marble Falls",
-                    "availableImmunizations": [
-                        "Flu"
-                    ]
-                },
-                {
-                    "zip": "78654",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h6P0000004EAmQAM",
-                    "type": "offsite",
-                    "street": "1101 Bluebonnet Drive",
-                    "storeNumber": null,
-                    "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 89,
-                            "openAppointmentSlots": 89,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 89,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 89,
-                    "name": "H-E-B Hosted First United Methodist Church",
-                    "longitude": null,
-                    "latitude": null,
-                    "fluUrl": "",
-                    "city": "Marble Falls",
-                    "availableImmunizations": [
-                        "Flu"
-                    ]
-                },
-                {
-                    "zip": "78643",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h6P000000064xQAA",
-                    "type": "offsite",
-                    "street": "200 Sunrise Drive",
-                    "storeNumber": null,
-                    "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 43,
-                            "openAppointmentSlots": 43,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 43,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 43,
-                    "name": "H-E-B Hosted Vaccine Clinic at Sunrise Beach VFD",
-                    "longitude": null,
-                    "latitude": null,
-                    "fluUrl": "",
-                    "city": "Sunrise Beach",
+                    "city": "Hawley",
                     "availableImmunizations": [
                         "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Novavax",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
-                    "zip": "79602",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h6P0000004EGBQA2",
+                    "zip": "79525",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h6P0000004EGQQA2",
                     "type": "offsite",
-                    "street": "2758 Jeanette St.",
+                    "street": "2233 Ivanhoe Ln",
                     "storeNumber": null,
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 8,
-                            "openAppointmentSlots": 8,
+                            "openTimeslots": 24,
+                            "openAppointmentSlots": 24,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 8,
+                    "openTimeslots": 24,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 8,
-                    "name": "2022-2023 Hendrick Home for Children - Flu Clinic",
+                    "openAppointmentSlots": 24,
+                    "name": "2022-2023 Hawley ISD - Student Flu Clinic",
                     "longitude": null,
                     "latitude": null,
                     "fluUrl": "",
-                    "city": "Abilene",
+                    "city": "Hawley",
                     "availableImmunizations": [
                         "Flu"
-                    ]
-                },
-                {
-                    "zip": "",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h6P0000004EKmQAM",
-                    "type": "offsite",
-                    "street": "",
-                    "storeNumber": null,
-                    "state": "",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 4,
-                            "openAppointmentSlots": 4,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 4,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 4,
-                    "name": "2022 Groves Elementary",
-                    "longitude": null,
-                    "latitude": null,
-                    "fluUrl": "",
-                    "city": "",
-                    "availableImmunizations": [
-                        "Flu"
-                    ]
-                },
-                {
-                    "zip": "78639",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h6P0000004EO0QAM",
-                    "type": "offsite",
-                    "street": "1136 RM 1431",
-                    "storeNumber": null,
-                    "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 44,
-                            "openAppointmentSlots": 44,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 44,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 44,
-                    "name": "H-E-B Hosted Kingsland Community Church",
-                    "longitude": null,
-                    "latitude": null,
-                    "fluUrl": "",
-                    "city": "Kingsland",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "78654",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h6P0000004ENvQAM",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h6P0000004EPcQAM",
                     "type": "offsite",
-                    "street": "1803 Hwy 1431 West",
+                    "street": "901 Ventana Drive",
                     "storeNumber": null,
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 27,
-                            "openAppointmentSlots": 27,
+                            "openTimeslots": 38,
+                            "openAppointmentSlots": 38,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 27,
+                    "openTimeslots": 38,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 27,
-                    "name": "H-E-B Hosted St Peter's Lutheran Church",
+                    "openAppointmentSlots": 38,
+                    "name": "H-E-B Hosted First Baptist Church of Marble Falls",
                     "longitude": null,
                     "latitude": null,
                     "fluUrl": "",
@@ -208,15 +103,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 27,
-                            "openAppointmentSlots": 27,
+                            "openTimeslots": 113,
+                            "openAppointmentSlots": 113,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 27,
+                    "openTimeslots": 113,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 27,
+                    "openAppointmentSlots": 113,
                     "name": "Round Rock H-E-B plus!",
                     "longitude": -97.65978,
                     "latitude": 30.5177,
@@ -224,8 +119,10 @@
                     "city": "ROUND ROCK",
                     "availableImmunizations": [
                         "Flu",
+                        "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
@@ -238,24 +135,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 321,
-                            "openAppointmentSlots": 321,
+                            "openTimeslots": 163,
+                            "openAppointmentSlots": 163,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 283,
-                    "openFluTimeslots": 38,
-                    "openFluAppointmentSlots": 38,
-                    "openAppointmentSlots": 283,
+                    "openTimeslots": 163,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 163,
                     "name": "Taylor H-E-B",
                     "longitude": -97.4167,
                     "latitude": 30.6007,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3oQAE",
+                    "fluUrl": "",
                     "city": "TAYLOR",
                     "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer"
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu"
                     ]
                 },
                 {
@@ -267,24 +164,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 201,
-                            "openAppointmentSlots": 201,
+                            "openTimeslots": 16,
+                            "openAppointmentSlots": 16,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 190,
-                    "openFluTimeslots": 11,
-                    "openFluAppointmentSlots": 11,
-                    "openAppointmentSlots": 190,
+                    "openTimeslots": 16,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 16,
                     "name": "Marble Falls H-E-B",
                     "longitude": -98.27972,
                     "latitude": 30.58301,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF1mQAE",
+                    "fluUrl": "",
                     "city": "MARBLE FALLS",
                     "availableImmunizations": [
                         "COVID-19 Pfizer_Updated_Booster",
-                        "Flu",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "Flu"
                     ]
                 },
                 {
@@ -296,23 +192,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 1122,
-                            "openAppointmentSlots": 1122,
+                            "openTimeslots": 419,
+                            "openAppointmentSlots": 419,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 1122,
+                    "openTimeslots": 419,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 1122,
+                    "openAppointmentSlots": 419,
                     "name": "Wells Branch H-E-B",
                     "longitude": -97.66419,
                     "latitude": 30.44263,
                     "fluUrl": "",
                     "city": "PFLUGERVILLE",
                     "availableImmunizations": [
-                        "Flu",
                         "COVID-19 Pfizer",
+                        "Flu",
                         "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Moderna"
                     ]
@@ -326,23 +222,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 21,
-                            "openAppointmentSlots": 21,
+                            "openTimeslots": 120,
+                            "openAppointmentSlots": 120,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 21,
+                    "openTimeslots": 120,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 21,
+                    "openAppointmentSlots": 120,
                     "name": "Louis Henna Blvd H-E-B",
                     "longitude": -97.65938,
                     "latitude": 30.48179,
                     "fluUrl": "",
                     "city": "ROUND ROCK",
                     "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu"
                     ]
                 },
                 {
@@ -354,26 +251,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 96,
-                            "openAppointmentSlots": 96,
+                            "openTimeslots": 57,
+                            "openAppointmentSlots": 57,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 96,
+                    "openTimeslots": 57,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 96,
+                    "openAppointmentSlots": 57,
                     "name": "H-E-B at Ronald Reagan Blvd",
                     "longitude": -97.82446,
                     "latitude": 30.63307,
                     "fluUrl": "",
                     "city": "GEORGETOWN",
                     "availableImmunizations": [
-                        "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Novavax",
                         "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Novavax",
                         "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
@@ -386,15 +284,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 31,
-                            "openAppointmentSlots": 31,
+                            "openTimeslots": 89,
+                            "openAppointmentSlots": 89,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 31,
+                    "openTimeslots": 89,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 31,
+                    "openAppointmentSlots": 89,
                     "name": "El Dorado H-E-B",
                     "longitude": -95.14874,
                     "latitude": 29.55117,
@@ -433,6 +331,7 @@
                     "city": "LAREDO",
                     "availableImmunizations": [
                         "Flu",
+                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
@@ -445,27 +344,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 54,
-                            "openAppointmentSlots": 54,
+                            "openTimeslots": 168,
+                            "openAppointmentSlots": 168,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 27,
-                    "openFluTimeslots": 27,
-                    "openFluAppointmentSlots": 27,
-                    "openAppointmentSlots": 27,
+                    "openTimeslots": 168,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 168,
                     "name": "Falfurrias H-E-B",
                     "longitude": -98.14572,
                     "latitude": 27.22043,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF15QAE",
+                    "fluUrl": "",
                     "city": "FALFURRIAS",
                     "availableImmunizations": [
-                        "COVID-19 Pediatric_Pfizer",
+                        "Flu",
                         "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Novavax",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "Flu"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -477,15 +374,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 1,
-                            "openAppointmentSlots": 1,
+                            "openTimeslots": 3,
+                            "openAppointmentSlots": 3,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 1,
+                    "openTimeslots": 3,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 1,
+                    "openAppointmentSlots": 3,
                     "name": "Burnet Rd H-E-B",
                     "longitude": -97.74016,
                     "latitude": 30.33374,
@@ -504,24 +401,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 494,
-                            "openAppointmentSlots": 494,
+                            "openTimeslots": 406,
+                            "openAppointmentSlots": 406,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 494,
+                    "openTimeslots": 406,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 494,
+                    "openAppointmentSlots": 406,
                     "name": "Las Palmas H-E-B",
                     "longitude": -98.55132,
                     "latitude": 29.41734,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
+                        "COVID-19 Moderna_Updated_Booster",
                         "Flu",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer"
                     ]
                 },
                 {
@@ -533,57 +431,47 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
+                            "openTimeslots": 42,
+                            "openAppointmentSlots": 42,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 43,
-                    "openFluTimeslots": 7,
-                    "openFluAppointmentSlots": 7,
-                    "openAppointmentSlots": 43,
+                    "openTimeslots": 42,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 42,
                     "name": "Guadalupe and Stone H-E-B",
                     "longitude": -99.48344,
                     "latitude": 27.50656,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF18QAE",
+                    "fluUrl": "",
                     "city": "LAREDO",
                     "availableImmunizations": [
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "Flu",
+                        "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Moderna"
+                        "Flu",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "78412-2412",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubCQAS",
+                    "url": null,
                     "type": "store",
                     "street": "4320 S. ALAMEDA ST.",
                     "storeNumber": 210,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 95,
-                            "openAppointmentSlots": 95,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 95,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 95,
+                    "openAppointmentSlots": 0,
                     "name": "Alameda and Robert H-E-B",
                     "longitude": -97.37175,
                     "latitude": 27.73002,
                     "fluUrl": "",
                     "city": "CORPUS CHRISTI",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78202-3050",
@@ -632,15 +520,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 79,
-                            "openAppointmentSlots": 79,
+                            "openTimeslots": 22,
+                            "openAppointmentSlots": 22,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 79,
+                    "openTimeslots": 22,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 79,
+                    "openAppointmentSlots": 22,
                     "name": "Parmer and Mopac H-E-B",
                     "longitude": -97.70326,
                     "latitude": 30.41883,
@@ -649,8 +537,7 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
@@ -663,15 +550,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 289,
-                            "openAppointmentSlots": 289,
+                            "openTimeslots": 331,
+                            "openAppointmentSlots": 331,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 289,
+                    "openTimeslots": 331,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 289,
+                    "openAppointmentSlots": 331,
                     "name": "Pleasanton H-E-B",
                     "longitude": -98.48567,
                     "latitude": 28.95696,
@@ -679,10 +566,6 @@
                     "city": "PLEASANTON",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
@@ -703,7 +586,11 @@
                     "latitude": 28.40071,
                     "fluUrl": "",
                     "city": "BEEVILLE",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78404-2505",
@@ -714,24 +601,22 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 98,
-                            "openAppointmentSlots": 98,
+                            "openTimeslots": 26,
+                            "openAppointmentSlots": 26,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 98,
+                    "openTimeslots": 26,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 98,
+                    "openAppointmentSlots": 26,
                     "name": "Alameda / Texan Trail (Medical District)",
                     "longitude": -97.3912,
                     "latitude": 27.75745,
                     "fluUrl": "",
                     "city": "CORPUS CHRISTI",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -743,26 +628,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 1213,
-                            "openAppointmentSlots": 1213,
+                            "openTimeslots": 1248,
+                            "openAppointmentSlots": 1248,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 1213,
+                    "openTimeslots": 1248,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 1213,
+                    "openAppointmentSlots": 1248,
                     "name": "Brenham H-E-B",
                     "longitude": -96.39591,
                     "latitude": 30.14381,
                     "fluUrl": "",
                     "city": "BRENHAM",
                     "availableImmunizations": [
+                        "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer",
-                        "Flu"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -793,15 +678,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 180,
-                            "openAppointmentSlots": 180,
+                            "openTimeslots": 53,
+                            "openAppointmentSlots": 53,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 180,
+                    "openTimeslots": 53,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 180,
+                    "openAppointmentSlots": 53,
                     "name": "La Grange H-E-B",
                     "longitude": -96.87264,
                     "latitude": 29.9073,
@@ -817,32 +702,22 @@
                 },
                 {
                     "zip": "78840-4658",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Guc4QAC",
+                    "url": null,
                     "type": "store",
                     "street": "200 VETERAN'S BLVD",
                     "storeNumber": 418,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 17,
-                            "openAppointmentSlots": 17,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 17,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 17,
+                    "openAppointmentSlots": 0,
                     "name": "Avenue F and Gibbs H-E-B",
                     "longitude": -100.8998,
                     "latitude": 29.36632,
                     "fluUrl": "",
                     "city": "DEL RIO",
-                    "availableImmunizations": [
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Ultra_Pediatric_Pfizer"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78852-4718",
@@ -853,22 +728,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 6,
-                            "openAppointmentSlots": 6,
+                            "openTimeslots": 8,
+                            "openAppointmentSlots": 8,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 6,
+                    "openTimeslots": 8,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 6,
+                    "openAppointmentSlots": 8,
                     "name": "Eagle Pass H-E-B",
                     "longitude": -100.48583,
                     "latitude": 28.70894,
                     "fluUrl": "",
                     "city": "EAGLE PASS",
                     "availableImmunizations": [
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "Flu"
                     ]
                 },
                 {
@@ -918,15 +794,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 20,
-                            "openAppointmentSlots": 20,
+                            "openTimeslots": 58,
+                            "openAppointmentSlots": 58,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 20,
+                    "openTimeslots": 58,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 20,
+                    "openAppointmentSlots": 58,
                     "name": "Hondo H-E-B",
                     "longitude": -99.13501,
                     "latitude": 29.34784,
@@ -934,9 +810,6 @@
                     "city": "HONDO",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
@@ -949,28 +822,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 307,
-                            "openAppointmentSlots": 307,
+                            "openTimeslots": 225,
+                            "openAppointmentSlots": 225,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 307,
+                    "openTimeslots": 225,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 307,
+                    "openAppointmentSlots": 225,
                     "name": "Hancock Center H-E-B",
                     "longitude": -97.71973,
                     "latitude": 30.30057,
                     "fluUrl": "",
                     "city": "AUSTIN",
                     "availableImmunizations": [
+                        "COVID-19 Moderna_Updated_Booster",
                         "Flu",
                         "COVID-19 Moderna",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Janssen",
-                        "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pfizer",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Janssen",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -982,22 +854,21 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 176,
-                            "openAppointmentSlots": 176,
+                            "openTimeslots": 3,
+                            "openAppointmentSlots": 3,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 176,
+                    "openTimeslots": 3,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 176,
+                    "openAppointmentSlots": 3,
                     "name": "Waxahachie H-E-B",
                     "longitude": -96.83983,
                     "latitude": 32.41159,
                     "fluUrl": "",
                     "city": "WAXAHACHIE",
                     "availableImmunizations": [
-                        "COVID-19 Moderna_Updated_Booster",
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
@@ -1006,6 +877,7 @@
                         "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
                         "COVID-19 Novavax",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
@@ -1018,15 +890,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 95,
-                            "openAppointmentSlots": 95,
+                            "openTimeslots": 90,
+                            "openAppointmentSlots": 90,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 95,
+                    "openTimeslots": 90,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 95,
+                    "openAppointmentSlots": 90,
                     "name": "Military and Pleasanton H-E-B",
                     "longitude": -98.50277,
                     "latitude": 29.35666,
@@ -1034,6 +906,7 @@
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
                         "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer"
                     ]
@@ -1047,27 +920,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 745,
-                            "openAppointmentSlots": 745,
+                            "openTimeslots": 152,
+                            "openAppointmentSlots": 152,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 645,
-                    "openFluTimeslots": 100,
-                    "openFluAppointmentSlots": 100,
-                    "openAppointmentSlots": 645,
+                    "openTimeslots": 152,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 152,
                     "name": "Blanco and West Ave H-E-B",
                     "longitude": -98.51025,
                     "latitude": 29.54526,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF14QAE",
+                    "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
                         "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Moderna",
-                        "Flu",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -1079,27 +949,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 759,
-                            "openAppointmentSlots": 759,
+                            "openTimeslots": 581,
+                            "openAppointmentSlots": 581,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 564,
-                    "openFluTimeslots": 195,
-                    "openFluAppointmentSlots": 195,
-                    "openAppointmentSlots": 564,
+                    "openTimeslots": 581,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 581,
                     "name": "Pflugerville H-E-B",
                     "longitude": -97.6133,
                     "latitude": 30.4373,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF34QAE",
+                    "fluUrl": "",
                     "city": "PFLUGERVILLE",
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer"
                     ]
                 },
                 {
@@ -1111,15 +981,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 64,
-                            "openAppointmentSlots": 64,
+                            "openTimeslots": 98,
+                            "openAppointmentSlots": 98,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 64,
+                    "openTimeslots": 98,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 64,
+                    "openAppointmentSlots": 98,
                     "name": "I10 and Wurzbach H-E-B",
                     "longitude": -98.5595,
                     "latitude": 29.5336,
@@ -1127,40 +997,27 @@
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "78596-2700",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucaQAC",
+                    "url": null,
                     "type": "store",
                     "street": "310 N. WESTGATE DRIVE",
                     "storeNumber": 485,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 18,
-                            "openAppointmentSlots": 18,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 18,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 18,
+                    "openAppointmentSlots": 0,
                     "name": "83 and Westgate H-E-B",
                     "longitude": -97.98934,
                     "latitude": 26.17109,
                     "fluUrl": "",
                     "city": "WESLACO",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78628-0",
@@ -1171,15 +1028,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 66,
-                            "openAppointmentSlots": 66,
+                            "openTimeslots": 1,
+                            "openAppointmentSlots": 1,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 66,
+                    "openTimeslots": 1,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 66,
+                    "openAppointmentSlots": 1,
                     "name": "Williams Drive H-E-B",
                     "longitude": -97.71873,
                     "latitude": 30.68312,
@@ -1187,6 +1044,7 @@
                     "city": "GEORGETOWN",
                     "availableImmunizations": [
                         "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
@@ -1199,22 +1057,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 14,
-                            "openAppointmentSlots": 14,
+                            "openTimeslots": 46,
+                            "openAppointmentSlots": 46,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 14,
+                    "openTimeslots": 46,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 14,
+                    "openAppointmentSlots": 46,
                     "name": "Elsa H-E-B",
                     "longitude": -97.99272,
                     "latitude": 26.29384,
                     "fluUrl": "",
                     "city": "ELSA",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu"
                     ]
                 },
                 {
@@ -1226,49 +1085,58 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 933,
-                            "openAppointmentSlots": 933,
+                            "openTimeslots": 883,
+                            "openAppointmentSlots": 883,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 761,
-                    "openFluTimeslots": 172,
-                    "openFluAppointmentSlots": 172,
-                    "openAppointmentSlots": 761,
+                    "openTimeslots": 883,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 883,
                     "name": "Valley Hi H-E-B",
                     "longitude": -98.64021,
                     "latitude": 29.38099,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF59QAE",
+                    "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
-                        "COVID-19 Pediatric_Moderna",
                         "COVID-19 Moderna",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Novavax",
                         "COVID-19 Pfizer",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu"
                     ]
                 },
                 {
                     "zip": "76033-4830",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudzQAC",
                     "type": "store",
                     "street": "600 W HENDERSON",
                     "storeNumber": 679,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 61,
+                            "openAppointmentSlots": 61,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 61,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 61,
                     "name": "Cleburne H-E-B",
                     "longitude": -97.39485,
                     "latitude": 32.3478,
                     "fluUrl": "",
                     "city": "CLEBURNE",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77375-1478",
@@ -1279,26 +1147,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 101,
-                            "openAppointmentSlots": 101,
+                            "openTimeslots": 109,
+                            "openAppointmentSlots": 109,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 41,
-                    "openFluTimeslots": 60,
-                    "openFluAppointmentSlots": 60,
-                    "openAppointmentSlots": 41,
+                    "openTimeslots": 109,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 109,
                     "name": "Creekside Park H-E-B",
                     "longitude": -95.55072,
                     "latitude": 30.14362,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF5BQAU",
+                    "fluUrl": "",
                     "city": "TOMBALL",
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -1310,15 +1178,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 89,
-                            "openAppointmentSlots": 89,
+                            "openTimeslots": 390,
+                            "openAppointmentSlots": 390,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 89,
+                    "openTimeslots": 390,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 89,
+                    "openAppointmentSlots": 390,
                     "name": "San Felipe H-E-B",
                     "longitude": -95.48512,
                     "latitude": 29.74797,
@@ -1326,37 +1194,27 @@
                     "city": "HOUSTON",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "78332-5046",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubGQAS",
+                    "url": null,
                     "type": "store",
                     "street": "1115 E. MAIN",
                     "storeNumber": 223,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 46,
-                            "openAppointmentSlots": 46,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 46,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 46,
+                    "openAppointmentSlots": 0,
                     "name": "Alice H-E-B",
                     "longitude": -98.06425,
                     "latitude": 27.75141,
                     "fluUrl": "",
                     "city": "ALICE",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78250-3232",
@@ -1367,26 +1225,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 291,
-                            "openAppointmentSlots": 291,
+                            "openTimeslots": 81,
+                            "openAppointmentSlots": 81,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 291,
+                    "openTimeslots": 81,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 291,
+                    "openAppointmentSlots": 81,
                     "name": "Bandera and Guilbeau H-E-B",
                     "longitude": -98.64364,
                     "latitude": 29.51985,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
-                        "Flu",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer"
+                        "Flu"
                     ]
                 },
                 {
@@ -1398,15 +1254,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 11,
-                            "openAppointmentSlots": 11,
+                            "openTimeslots": 30,
+                            "openAppointmentSlots": 30,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 11,
+                    "openTimeslots": 30,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 11,
+                    "openAppointmentSlots": 30,
                     "name": "Oak Hill H-E-B",
                     "longitude": -97.88755,
                     "latitude": 30.22696,
@@ -1425,23 +1281,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 183,
-                            "openAppointmentSlots": 183,
+                            "openTimeslots": 291,
+                            "openAppointmentSlots": 291,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 129,
-                    "openFluTimeslots": 54,
-                    "openFluAppointmentSlots": 54,
-                    "openAppointmentSlots": 129,
+                    "openTimeslots": 291,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 291,
                     "name": "Burnet H-E-B",
                     "longitude": -98.22452,
                     "latitude": 30.7588,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2kQAE",
+                    "fluUrl": "",
                     "city": "BURNET",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna",
                         "COVID-19 Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster",
                         "Flu"
                     ]
                 },
@@ -1492,15 +1350,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 171,
-                            "openAppointmentSlots": 171,
+                            "openTimeslots": 72,
+                            "openAppointmentSlots": 72,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 171,
+                    "openTimeslots": 72,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 171,
+                    "openAppointmentSlots": 72,
                     "name": "Military and Goliad H-E-B",
                     "longitude": -98.4362,
                     "latitude": 29.35194,
@@ -1511,8 +1369,8 @@
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -1524,15 +1382,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 122,
-                            "openAppointmentSlots": 122,
+                            "openTimeslots": 164,
+                            "openAppointmentSlots": 164,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 122,
+                    "openTimeslots": 164,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 122,
+                    "openAppointmentSlots": 164,
                     "name": "Lockhart H-E-B",
                     "longitude": -97.66994,
                     "latitude": 29.88213,
@@ -1543,103 +1401,156 @@
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "78521-1609",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucJQAS",
                     "type": "store",
                     "street": "2155 PAREDES LINE RD",
                     "storeNumber": 446,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 17,
+                            "openAppointmentSlots": 17,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 17,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 17,
                     "name": "Paredes and Torres H-E-B plus!",
                     "longitude": -97.48904,
                     "latitude": 25.95015,
                     "fluUrl": "",
                     "city": "BROWNSVILLE",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Janssen",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78572-5362",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubJQAS",
                     "type": "store",
                     "street": "820 S. CONWAY",
                     "storeNumber": 226,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 26,
+                            "openAppointmentSlots": 26,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 26,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 26,
                     "name": "Conway and 9th St H-E-B",
                     "longitude": -98.3262,
                     "latitude": 26.21354,
                     "fluUrl": "",
                     "city": "MISSION",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78374-2816",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuccQAC",
                     "type": "store",
                     "street": "1600 WILDCAT DRIVE",
                     "storeNumber": 488,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 124,
+                            "openAppointmentSlots": 124,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 124,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 124,
                     "name": "Portland H-E-B",
                     "longitude": -97.31836,
                     "latitude": 27.88722,
                     "fluUrl": "",
                     "city": "PORTLAND",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78521-2216",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucdQAC",
                     "type": "store",
                     "street": "2250 BOCA CHICA",
                     "storeNumber": 489,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 28,
+                            "openAppointmentSlots": 28,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 28,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 28,
                     "name": "Boca Chica H-E-B",
                     "longitude": -97.48722,
                     "latitude": 25.92214,
                     "fluUrl": "",
                     "city": "BROWNSVILLE",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu"
+                    ]
                 },
                 {
                     "zip": "77084-5813",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuceQAC",
                     "type": "store",
                     "street": "1550 FRY RD",
                     "storeNumber": 492,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 168,
+                            "openAppointmentSlots": 168,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 168,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 168,
                     "name": "Fry Rd and I10 H-E-B",
                     "longitude": -95.7189,
                     "latitude": 29.7898,
                     "fluUrl": "",
                     "city": "HOUSTON",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu"
+                    ]
                 },
                 {
                     "zip": "78251-1320",
@@ -1650,23 +1561,21 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 636,
-                            "openAppointmentSlots": 636,
+                            "openTimeslots": 502,
+                            "openAppointmentSlots": 502,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 351,
-                    "openFluTimeslots": 285,
-                    "openFluAppointmentSlots": 285,
-                    "openAppointmentSlots": 351,
+                    "openTimeslots": 416,
+                    "openFluTimeslots": 86,
+                    "openFluAppointmentSlots": 86,
+                    "openAppointmentSlots": 416,
                     "name": "Culebra and 1604 H-E-B",
                     "longitude": -98.70445,
                     "latitude": 29.49292,
                     "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3BQAU",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
-                        "COVID-19 Novavax",
-                        "COVID-19 Moderna_Updated_Booster",
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
@@ -1674,7 +1583,9 @@
                         "COVID-19 Janssen",
                         "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Novavax",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -1686,25 +1597,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 162,
-                            "openAppointmentSlots": 162,
+                            "openTimeslots": 405,
+                            "openAppointmentSlots": 405,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 82,
-                    "openFluTimeslots": 80,
-                    "openFluAppointmentSlots": 80,
-                    "openAppointmentSlots": 82,
+                    "openTimeslots": 405,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 405,
                     "name": "Beaumont 6 H-E-B",
                     "longitude": -94.12834,
                     "latitude": 30.06853,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF0qQAE",
+                    "fluUrl": "",
                     "city": "BEAUMONT",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer"
                     ]
                 },
@@ -1717,23 +1628,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 41,
-                            "openAppointmentSlots": 41,
+                            "openTimeslots": 79,
+                            "openAppointmentSlots": 79,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 41,
+                    "openTimeslots": 79,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 41,
+                    "openAppointmentSlots": 79,
                     "name": "Kenedy H-E-B",
                     "longitude": -97.85797,
                     "latitude": 28.81419,
                     "fluUrl": "",
                     "city": "KENEDY",
                     "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster",
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer"
                     ]
                 },
                 {
@@ -1745,28 +1657,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 512,
-                            "openAppointmentSlots": 512,
+                            "openTimeslots": 128,
+                            "openAppointmentSlots": 128,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 512,
+                    "openTimeslots": 128,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 512,
+                    "openAppointmentSlots": 128,
                     "name": "New Braunfels H-E-B plus!",
                     "longitude": -98.0782,
                     "latitude": 29.731,
                     "fluUrl": "",
                     "city": "NEW BRAUNFELS",
                     "availableImmunizations": [
-                        "COVID-19 Pediatric_Moderna",
-                        "Flu",
                         "COVID-19 Ultra_Pediatric_Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Novavax",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna",
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Novavax"
                     ]
                 },
                 {
@@ -1778,26 +1688,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 687,
-                            "openAppointmentSlots": 687,
+                            "openTimeslots": 578,
+                            "openAppointmentSlots": 578,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 687,
+                    "openTimeslots": 578,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 687,
-                    "name": "Hutto 130 and Gattis School H-E-B plus!",
+                    "openAppointmentSlots": 578,
+                    "name": "Gattis School H-E-B plus! Hutto",
                     "longitude": -97.58284,
                     "latitude": 30.50112,
                     "fluUrl": "",
                     "city": "HUTTO",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -1809,15 +1717,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 643,
-                            "openAppointmentSlots": 643,
+                            "openTimeslots": 859,
+                            "openAppointmentSlots": 859,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 469,
-                    "openFluTimeslots": 174,
-                    "openFluAppointmentSlots": 174,
-                    "openAppointmentSlots": 469,
+                    "openTimeslots": 602,
+                    "openFluTimeslots": 257,
+                    "openFluAppointmentSlots": 257,
+                    "openAppointmentSlots": 602,
                     "name": "League City Market H-E-B",
                     "longitude": -95.04131,
                     "latitude": 29.50588,
@@ -1833,22 +1741,35 @@
                 },
                 {
                     "zip": "79764-7155",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueGQAS",
                     "type": "store",
                     "street": "2501 W UNIVERSITY BLVD",
                     "storeNumber": 711,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 87,
+                            "openAppointmentSlots": 87,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 87,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 87,
                     "name": "Odessa H-E-B University Blvd",
                     "longitude": -102.41008,
                     "latitude": 31.86213,
                     "fluUrl": "",
                     "city": "ODESSA",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Novavax",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77954-2126",
@@ -1878,24 +1799,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 77,
-                            "openAppointmentSlots": 77,
+                            "openTimeslots": 132,
+                            "openAppointmentSlots": 132,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 77,
+                    "openTimeslots": 132,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 77,
+                    "openAppointmentSlots": 132,
                     "name": "Clear Lake Marketplace H-E-B",
                     "longitude": -95.12473,
                     "latitude": 29.60563,
                     "fluUrl": "",
                     "city": "HOUSTON",
                     "availableImmunizations": [
-                        "Flu",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer"
+                        "Flu"
                     ]
                 },
                 {
@@ -1907,24 +1827,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 35,
-                            "openAppointmentSlots": 35,
+                            "openTimeslots": 25,
+                            "openAppointmentSlots": 25,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 35,
+                    "openTimeslots": 25,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 35,
+                    "openAppointmentSlots": 25,
                     "name": "Lakeway H-E-B",
                     "longitude": -97.96662,
                     "latitude": 30.34368,
                     "fluUrl": "",
                     "city": "LAKEWAY",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
                         "Flu",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -1948,22 +1867,31 @@
                 },
                 {
                     "zip": "78041-2205",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gud1QAC",
                     "type": "store",
                     "street": "210 WEST DEL MAR BOULEVARD",
                     "storeNumber": 570,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 2,
+                            "openAppointmentSlots": 2,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 2,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 2,
                     "name": "35 and Del Mar H-E-B",
                     "longitude": -99.49676,
                     "latitude": 27.56786,
                     "fluUrl": "",
                     "city": "LAREDO",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78572-2912",
@@ -1993,56 +1921,57 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 57,
-                            "openAppointmentSlots": 57,
+                            "openTimeslots": 65,
+                            "openAppointmentSlots": 65,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 57,
+                    "openTimeslots": 65,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 57,
+                    "openAppointmentSlots": 65,
                     "name": "Tomball Pkwy and Graham H-E-B",
                     "longitude": -95.63218,
                     "latitude": 30.08868,
                     "fluUrl": "",
                     "city": "TOMBALL",
                     "availableImmunizations": [
-                        "COVID-19 Novavax",
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Novavax",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer"
                     ]
                 },
                 {
                     "zip": "77379-7234",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gud4QAC",
                     "type": "store",
                     "street": "7310 LOUETTA",
                     "storeNumber": 576,
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 14,
-                            "openAppointmentSlots": 14,
+                            "openTimeslots": 90,
+                            "openAppointmentSlots": 90,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 0,
-                    "openFluTimeslots": 14,
-                    "openFluAppointmentSlots": 14,
-                    "openAppointmentSlots": 0,
+                    "openTimeslots": 90,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 90,
                     "name": "Louetta and Stuebner H-E-B",
                     "longitude": -95.5243,
                     "latitude": 30.0209,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3aQAE",
+                    "fluUrl": "",
                     "city": "SPRING",
                     "availableImmunizations": [
                         "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
@@ -2055,22 +1984,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 224,
-                            "openAppointmentSlots": 224,
+                            "openTimeslots": 80,
+                            "openAppointmentSlots": 80,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 224,
+                    "openTimeslots": 80,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 224,
+                    "openAppointmentSlots": 80,
                     "name": "Kempwood and Gessner H-E-B",
                     "longitude": -95.5468,
                     "latitude": 29.8226,
                     "fluUrl": "",
                     "city": "HOUSTON",
                     "availableImmunizations": [
-                        "Flu"
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -2082,15 +2015,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 25,
-                            "openAppointmentSlots": 25,
+                            "openTimeslots": 41,
+                            "openAppointmentSlots": 41,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 25,
+                    "openTimeslots": 41,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 25,
+                    "openAppointmentSlots": 41,
                     "name": "Woodlands Market H-E-B",
                     "longitude": -95.46575,
                     "latitude": 30.16409,
@@ -2100,7 +2033,7 @@
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
@@ -2113,15 +2046,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 20,
-                            "openAppointmentSlots": 20,
+                            "openTimeslots": 18,
+                            "openAppointmentSlots": 18,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 20,
+                    "openTimeslots": 18,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 20,
+                    "openAppointmentSlots": 18,
                     "name": "Parmer and Whitestone H-E-B",
                     "longitude": -97.78545,
                     "latitude": 30.5328,
@@ -2129,8 +2062,9 @@
                     "city": "CEDAR PARK",
                     "availableImmunizations": [
                         "Flu",
+                        "COVID-19 Pfizer",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pfizer"
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -2142,15 +2076,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 59,
-                            "openAppointmentSlots": 59,
+                            "openTimeslots": 76,
+                            "openAppointmentSlots": 76,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 59,
+                    "openTimeslots": 76,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 59,
+                    "openAppointmentSlots": 76,
                     "name": "Stephenville H-E-B",
                     "longitude": -98.22569,
                     "latitude": 32.20975,
@@ -2173,26 +2107,29 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 322,
-                            "openAppointmentSlots": 322,
+                            "openTimeslots": 206,
+                            "openAppointmentSlots": 206,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 322,
+                    "openTimeslots": 206,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 322,
+                    "openAppointmentSlots": 206,
                     "name": "Slaughter and Manchaca H-E-B",
                     "longitude": -97.82509,
                     "latitude": 30.17524,
                     "fluUrl": "",
                     "city": "AUSTIN",
                     "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Novavax",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pediatric_Moderna"
                     ]
                 },
@@ -2205,15 +2142,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 100,
-                            "openAppointmentSlots": 100,
+                            "openTimeslots": 40,
+                            "openAppointmentSlots": 40,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 100,
+                    "openTimeslots": 40,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 100,
+                    "openAppointmentSlots": 40,
                     "name": "I 35 and William Cannon H-E-B",
                     "longitude": -97.76922,
                     "latitude": 30.19107,
@@ -2233,15 +2170,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 693,
-                            "openAppointmentSlots": 693,
+                            "openTimeslots": 672,
+                            "openAppointmentSlots": 672,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 693,
+                    "openTimeslots": 672,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 693,
+                    "openAppointmentSlots": 672,
                     "name": "Nacogdoches and O'Connor H-E-B",
                     "longitude": -98.3856,
                     "latitude": 29.56937,
@@ -2249,71 +2186,46 @@
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "78596-4511",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubNQAS",
+                    "url": null,
                     "type": "store",
                     "street": "1004 N. TEXAS",
                     "storeNumber": 231,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 85,
-                            "openAppointmentSlots": 85,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 85,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 85,
+                    "openAppointmentSlots": 0,
                     "name": "83 and N Texas H-E-B",
                     "longitude": -97.99096,
                     "latitude": 26.17103,
                     "fluUrl": "",
                     "city": "WESLACO",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77488-3204",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubOQAS",
+                    "url": null,
                     "type": "store",
                     "street": "1616 N ALABAMA",
                     "storeNumber": 233,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 29,
-                            "openAppointmentSlots": 29,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 29,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 29,
+                    "openAppointmentSlots": 0,
                     "name": "Wharton H-E-B",
                     "longitude": -96.08492,
                     "latitude": 29.32162,
                     "fluUrl": "",
                     "city": "WHARTON",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77450-4564",
@@ -2324,15 +2236,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 46,
-                            "openAppointmentSlots": 46,
+                            "openTimeslots": 101,
+                            "openAppointmentSlots": 101,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 46,
+                    "openTimeslots": 101,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 46,
+                    "openAppointmentSlots": 101,
                     "name": "Mason Rd H-E-B",
                     "longitude": -95.75102,
                     "latitude": 29.75787,
@@ -2352,15 +2264,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 504,
-                            "openAppointmentSlots": 504,
+                            "openTimeslots": 694,
+                            "openAppointmentSlots": 694,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 385,
-                    "openFluTimeslots": 119,
-                    "openFluAppointmentSlots": 119,
-                    "openAppointmentSlots": 385,
+                    "openTimeslots": 480,
+                    "openFluTimeslots": 214,
+                    "openFluAppointmentSlots": 214,
+                    "openAppointmentSlots": 480,
                     "name": "Atascocita H-E-B",
                     "longitude": -95.1642,
                     "latitude": 29.9983,
@@ -2368,10 +2280,9 @@
                     "city": "HUMBLE",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Moderna"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -2383,15 +2294,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 70,
-                            "openAppointmentSlots": 70,
+                            "openTimeslots": 79,
+                            "openAppointmentSlots": 79,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 70,
+                    "openTimeslots": 79,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 70,
+                    "openAppointmentSlots": 79,
                     "name": "Gulfgate H-E-B",
                     "longitude": -95.2968,
                     "latitude": 29.6994,
@@ -2417,22 +2328,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 60,
-                            "openAppointmentSlots": 60,
+                            "openTimeslots": 119,
+                            "openAppointmentSlots": 119,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 60,
+                    "openTimeslots": 119,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 60,
+                    "openAppointmentSlots": 119,
                     "name": "Beechnut H-E-B",
                     "longitude": -95.5604,
                     "latitude": 29.6896,
                     "fluUrl": "",
                     "city": "HOUSTON",
                     "availableImmunizations": [
-                        "Flu"
+                        "Flu",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -2444,15 +2358,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 120,
-                            "openAppointmentSlots": 120,
+                            "openTimeslots": 240,
+                            "openAppointmentSlots": 240,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 120,
+                    "openTimeslots": 240,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 120,
+                    "openAppointmentSlots": 240,
                     "name": "Texas Avenue H-E-B",
                     "longitude": -96.3165,
                     "latitude": 30.6131,
@@ -2472,19 +2386,19 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 262,
-                            "openAppointmentSlots": 262,
+                            "openTimeslots": 187,
+                            "openAppointmentSlots": 187,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 189,
-                    "openFluTimeslots": 73,
-                    "openFluAppointmentSlots": 73,
-                    "openAppointmentSlots": 189,
+                    "openTimeslots": 187,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 187,
                     "name": "Grant and Spring Cypress H-E-B",
                     "longitude": -95.63698,
                     "latitude": 30.00365,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF0vQAE",
+                    "fluUrl": "",
                     "city": "CYPRESS",
                     "availableImmunizations": [
                         "Flu",
@@ -2503,15 +2417,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 408,
-                            "openAppointmentSlots": 408,
+                            "openTimeslots": 280,
+                            "openAppointmentSlots": 280,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 408,
+                    "openTimeslots": 280,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 408,
+                    "openAppointmentSlots": 280,
                     "name": "Nogalitos H-E-B",
                     "longitude": -98.51485,
                     "latitude": 29.39799,
@@ -2521,9 +2435,9 @@
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer"
                     ]
                 },
                 {
@@ -2592,15 +2506,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 113,
-                            "openAppointmentSlots": 113,
+                            "openTimeslots": 291,
+                            "openAppointmentSlots": 291,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 113,
+                    "openTimeslots": 291,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 113,
+                    "openAppointmentSlots": 291,
                     "name": "Spring Creek Market H-E-B",
                     "longitude": -95.38801,
                     "latitude": 30.11036,
@@ -2608,8 +2522,8 @@
                     "city": "SPRING",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -2640,43 +2554,53 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 45,
-                            "openAppointmentSlots": 45,
+                            "openTimeslots": 48,
+                            "openAppointmentSlots": 48,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 11,
-                    "openFluTimeslots": 34,
-                    "openFluAppointmentSlots": 34,
-                    "openAppointmentSlots": 11,
+                    "openTimeslots": 48,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 48,
                     "name": "Midland Loop 250 H-E-B",
                     "longitude": -102.15509,
                     "latitude": 31.99588,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF1MQAU",
+                    "fluUrl": "",
                     "city": "MIDLAND",
                     "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "Flu"
                     ]
                 },
                 {
                     "zip": "77345-2621",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueNQAS",
                     "type": "store",
                     "street": "4517 KINGWOOD DRIVE",
                     "storeNumber": 720,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 44,
+                            "openAppointmentSlots": 44,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 44,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 44,
                     "name": "Kingwood Market H-E-B",
                     "longitude": -95.18375,
                     "latitude": 30.05329,
                     "fluUrl": "",
                     "city": "KINGWOOD",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "76542-0",
@@ -2687,15 +2611,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
+                            "openTimeslots": 26,
+                            "openAppointmentSlots": 26,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 10,
+                    "openTimeslots": 26,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 10,
+                    "openAppointmentSlots": 26,
                     "name": "Fort Hood Stan Schlueter H-E-B",
                     "longitude": -97.75988,
                     "latitude": 31.07989,
@@ -2703,8 +2627,9 @@
                     "city": "KILLEEN",
                     "availableImmunizations": [
                         "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer"
                     ]
                 },
                 {
@@ -2716,15 +2641,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 43,
-                            "openAppointmentSlots": 43,
+                            "openTimeslots": 103,
+                            "openAppointmentSlots": 103,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 43,
+                    "openTimeslots": 103,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 43,
+                    "openAppointmentSlots": 103,
                     "name": "Magnolia Market H-E-B",
                     "longitude": -95.5837,
                     "latitude": 30.2217,
@@ -2747,15 +2672,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 99,
-                            "openAppointmentSlots": 99,
+                            "openTimeslots": 102,
+                            "openAppointmentSlots": 102,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 99,
+                    "openTimeslots": 102,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 99,
+                    "openAppointmentSlots": 102,
                     "name": "Aliana Market H-E-B",
                     "longitude": -95.7137,
                     "latitude": 29.6597,
@@ -2764,8 +2689,7 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer"
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -2777,15 +2701,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 101,
-                            "openAppointmentSlots": 101,
+                            "openTimeslots": 27,
+                            "openAppointmentSlots": 27,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 101,
+                    "openTimeslots": 27,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 101,
+                    "openAppointmentSlots": 27,
                     "name": "Palmview H-E-B",
                     "longitude": -98.38385,
                     "latitude": 26.23538,
@@ -2808,19 +2732,19 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 44,
-                            "openAppointmentSlots": 44,
+                            "openTimeslots": 36,
+                            "openAppointmentSlots": 36,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 21,
-                    "openFluTimeslots": 23,
-                    "openFluAppointmentSlots": 23,
-                    "openAppointmentSlots": 21,
+                    "openTimeslots": 36,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 36,
                     "name": "Four Points H-E-B",
                     "longitude": -97.85202,
                     "latitude": 30.40458,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2sQAE",
+                    "fluUrl": "",
                     "city": "AUSTIN",
                     "availableImmunizations": [
                         "Flu",
@@ -2874,30 +2798,30 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 1072,
-                            "openAppointmentSlots": 1072,
+                            "openTimeslots": 1321,
+                            "openAppointmentSlots": 1321,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 1072,
+                    "openTimeslots": 1321,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 1072,
+                    "openAppointmentSlots": 1321,
                     "name": "Loop 1604 and Blanco Rd H-E-B plus!",
                     "longitude": -98.50968,
                     "latitude": 29.60792,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer",
                         "Flu",
-                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Moderna",
                         "COVID-19 Pediatric_Moderna",
                         "COVID-19 Ultra_Pediatric_Pfizer",
-                        "COVID-19 Moderna",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Novavax"
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Novavax",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -2909,25 +2833,22 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 628,
-                            "openAppointmentSlots": 628,
+                            "openTimeslots": 673,
+                            "openAppointmentSlots": 673,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 628,
+                    "openTimeslots": 673,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 628,
+                    "openAppointmentSlots": 673,
                     "name": "7th Street H-E-B",
                     "longitude": -97.71143,
                     "latitude": 30.26046,
                     "fluUrl": "",
                     "city": "AUSTIN",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer",
                         "Flu",
-                        "COVID-19 Novavax",
-                        "COVID-19 Pediatric_Moderna",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
@@ -2978,15 +2899,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 249,
-                            "openAppointmentSlots": 249,
+                            "openTimeslots": 145,
+                            "openAppointmentSlots": 145,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 249,
+                    "openTimeslots": 145,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 249,
+                    "openAppointmentSlots": 145,
                     "name": "Fairmont Pkwy H-E-B",
                     "longitude": -95.14512,
                     "latitude": 29.6497,
@@ -2997,7 +2918,8 @@
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -3009,15 +2931,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 769,
-                            "openAppointmentSlots": 769,
+                            "openTimeslots": 1099,
+                            "openAppointmentSlots": 1099,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 769,
+                    "openTimeslots": 1099,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 769,
+                    "openAppointmentSlots": 1099,
                     "name": "Lake Colony H-E-B",
                     "longitude": -95.58244,
                     "latitude": 29.58032,
@@ -3028,7 +2950,8 @@
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -3040,25 +2963,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 308,
-                            "openAppointmentSlots": 308,
+                            "openTimeslots": 242,
+                            "openAppointmentSlots": 242,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 179,
-                    "openFluTimeslots": 129,
-                    "openFluAppointmentSlots": 129,
-                    "openAppointmentSlots": 179,
+                    "openTimeslots": 242,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 242,
                     "name": "Elgin H-E-B",
                     "longitude": -97.38258,
                     "latitude": 30.34701,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF31QAE",
+                    "fluUrl": "",
                     "city": "ELGIN",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
                         "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer"
                     ]
                 },
@@ -3071,15 +2993,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 74,
-                            "openAppointmentSlots": 74,
+                            "openTimeslots": 130,
+                            "openAppointmentSlots": 130,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 32,
-                    "openFluTimeslots": 42,
-                    "openFluAppointmentSlots": 42,
-                    "openAppointmentSlots": 32,
+                    "openTimeslots": 84,
+                    "openFluTimeslots": 46,
+                    "openFluAppointmentSlots": 46,
+                    "openAppointmentSlots": 84,
                     "name": "Tech Ridge H-E-B",
                     "longitude": -97.67201,
                     "latitude": 30.40443,
@@ -3087,9 +3009,6 @@
                     "city": "AUSTIN",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
                         "COVID-19 Novavax",
                         "COVID-19 Pfizer_Updated_Booster"
@@ -3104,15 +3023,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 169,
-                            "openAppointmentSlots": 169,
+                            "openTimeslots": 82,
+                            "openAppointmentSlots": 82,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 169,
+                    "openTimeslots": 82,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 169,
+                    "openAppointmentSlots": 82,
                     "name": "Buda H-E-B",
                     "longitude": -97.82074,
                     "latitude": 30.08769,
@@ -3120,57 +3039,55 @@
                     "city": "BUDA",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "78251-2805",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubPQAS",
+                    "url": null,
                     "type": "store",
                     "street": "9255 GRISSOM RD",
                     "storeNumber": 235,
-                    "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 263,
-                            "openAppointmentSlots": 263,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 263,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 263,
-                    "name": "Grissom and Tezel H-E-B",
-                    "longitude": -98.66574,
-                    "latitude": 29.48432,
-                    "fluUrl": "",
-                    "city": "SAN ANTONIO",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
-                },
-                {
-                    "zip": "78626-5400",
-                    "url": null,
-                    "type": "store",
-                    "street": "1100 SOUTH IH35",
-                    "storeNumber": 237,
                     "state": "TX",
                     "slotDetails": [],
                     "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
                     "openAppointmentSlots": 0,
+                    "name": "Grissom and Tezel H-E-B",
+                    "longitude": -98.66574,
+                    "latitude": 29.48432,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": null
+                },
+                {
+                    "zip": "78626-5400",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubRQAS",
+                    "type": "store",
+                    "street": "1100 SOUTH IH35",
+                    "storeNumber": 237,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 35,
+                            "openAppointmentSlots": 35,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 35,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 35,
                     "name": "35 and West University H-E-B",
                     "longitude": -97.69028,
                     "latitude": 30.63446,
                     "fluUrl": "",
                     "city": "GEORGETOWN",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "75110-5138",
@@ -3200,15 +3117,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 563,
-                            "openAppointmentSlots": 563,
+                            "openTimeslots": 261,
+                            "openAppointmentSlots": 261,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 563,
+                    "openTimeslots": 261,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 563,
+                    "openAppointmentSlots": 261,
                     "name": "East Hopkins H-E-B",
                     "longitude": -97.93132,
                     "latitude": 29.88489,
@@ -3216,37 +3133,40 @@
                     "city": "SAN MARCOS",
                     "availableImmunizations": [
                         "COVID-19 Moderna",
-                        "Flu",
                         "COVID-19 Pfizer_Updated_Booster",
+                        "Flu",
                         "COVID-19 Pfizer",
                         "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "78408-3204",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubUQAS",
                     "type": "store",
                     "street": "3500 LEOPARD",
                     "storeNumber": 253,
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 38,
-                            "openAppointmentSlots": 38,
+                            "openTimeslots": 69,
+                            "openAppointmentSlots": 69,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 0,
-                    "openFluTimeslots": 38,
-                    "openFluAppointmentSlots": 38,
-                    "openAppointmentSlots": 0,
+                    "openTimeslots": 69,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 69,
                     "name": "Leopard and Nueces Bay H-E-B",
                     "longitude": -97.42774,
                     "latitude": 27.79695,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF1gQAE",
+                    "fluUrl": "",
                     "city": "CORPUS CHRISTI",
                     "availableImmunizations": [
-                        "Flu"
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -3258,15 +3178,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 88,
-                            "openAppointmentSlots": 88,
+                            "openTimeslots": 30,
+                            "openAppointmentSlots": 30,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 88,
+                    "openTimeslots": 30,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 88,
+                    "openAppointmentSlots": 30,
                     "name": "Tejas Center H-E-B",
                     "longitude": -96.3513,
                     "latitude": 30.64506,
@@ -3276,8 +3196,8 @@
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer"
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -3289,23 +3209,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 97,
-                            "openAppointmentSlots": 97,
+                            "openTimeslots": 263,
+                            "openAppointmentSlots": 263,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 67,
-                    "openFluTimeslots": 30,
-                    "openFluAppointmentSlots": 30,
-                    "openAppointmentSlots": 67,
+                    "openTimeslots": 263,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 263,
                     "name": "Westheimer and Kirkwood H-E-B",
                     "longitude": -95.587,
                     "latitude": 29.7363,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3JQAU",
+                    "fluUrl": "",
                     "city": "HOUSTON",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "Flu"
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -3317,15 +3237,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 479,
-                            "openAppointmentSlots": 479,
+                            "openTimeslots": 537,
+                            "openAppointmentSlots": 537,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 45,
-                    "openFluTimeslots": 434,
-                    "openFluAppointmentSlots": 434,
-                    "openAppointmentSlots": 45,
+                    "openTimeslots": 416,
+                    "openFluTimeslots": 121,
+                    "openFluAppointmentSlots": 121,
+                    "openAppointmentSlots": 416,
                     "name": "Bear Creek H-E-B",
                     "longitude": -95.6457,
                     "latitude": 29.8487,
@@ -3333,7 +3253,10 @@
                     "city": "HOUSTON",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pediatric_Pfizer"
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -3357,31 +3280,22 @@
                 },
                 {
                     "zip": "78148-3806",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucqQAC",
+                    "url": null,
                     "type": "store",
                     "street": "910 KITTY HAWK ROAD",
                     "storeNumber": 555,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 4,
-                            "openAppointmentSlots": 4,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 4,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 4,
+                    "openAppointmentSlots": 0,
                     "name": "Kitty Hawk H-E-B",
                     "longitude": -98.31298,
                     "latitude": 29.54766,
                     "fluUrl": "",
                     "city": "UNIVERSAL CITY",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78201-4407",
@@ -3392,15 +3306,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 20,
-                            "openAppointmentSlots": 20,
+                            "openTimeslots": 87,
+                            "openAppointmentSlots": 87,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 20,
+                    "openTimeslots": 87,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 20,
+                    "openAppointmentSlots": 87,
                     "name": "Deco District H-E-B",
                     "longitude": -98.5261,
                     "latitude": 29.4646,
@@ -3419,22 +3333,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 30,
-                            "openAppointmentSlots": 30,
+                            "openTimeslots": 122,
+                            "openAppointmentSlots": 122,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 30,
+                    "openTimeslots": 122,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 30,
+                    "openAppointmentSlots": 122,
                     "name": "35 and 84 H-E-B plus!",
                     "longitude": -97.10723,
                     "latitude": 31.58764,
                     "fluUrl": "",
                     "city": "BELLMEAD",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -3446,23 +3361,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 247,
-                            "openAppointmentSlots": 247,
+                            "openTimeslots": 339,
+                            "openAppointmentSlots": 339,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 247,
+                    "openTimeslots": 339,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 247,
+                    "openAppointmentSlots": 339,
                     "name": "Friendswood H-E-B",
                     "longitude": -95.1912,
                     "latitude": 29.5066,
                     "fluUrl": "",
                     "city": "FRIENDSWOOD",
                     "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "Flu"
                     ]
                 },
                 {
@@ -3474,27 +3390,28 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 91,
-                            "openAppointmentSlots": 91,
+                            "openTimeslots": 123,
+                            "openAppointmentSlots": 123,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 91,
+                    "openTimeslots": 123,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 91,
+                    "openAppointmentSlots": 123,
                     "name": "Lake Jackson H-E-B",
                     "longitude": -95.44554,
                     "latitude": 29.04151,
                     "fluUrl": "",
                     "city": "LAKE JACKSON",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster",
                         "Flu",
                         "COVID-19 Moderna",
-                        "COVID-19 Pediatric_Moderna"
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -3506,15 +3423,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 29,
-                            "openAppointmentSlots": 29,
+                            "openTimeslots": 17,
+                            "openAppointmentSlots": 17,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 29,
+                    "openTimeslots": 17,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 29,
+                    "openAppointmentSlots": 17,
                     "name": "Wimberley H-E-B",
                     "longitude": -98.10174,
                     "latitude": 30.00144,
@@ -3523,8 +3440,8 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
@@ -3537,15 +3454,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 109,
-                            "openAppointmentSlots": 109,
+                            "openTimeslots": 287,
+                            "openAppointmentSlots": 287,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 109,
+                    "openTimeslots": 287,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 109,
+                    "openAppointmentSlots": 287,
                     "name": "H-E-B Market at Tuckerton",
                     "longitude": -95.72501,
                     "latitude": 29.92737,
@@ -3553,8 +3470,10 @@
                     "city": "CYPRESS",
                     "availableImmunizations": [
                         "Flu",
+                        "COVID-19 Novavax",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pediatric_Moderna"
                     ]
                 },
                 {
@@ -3566,15 +3485,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 95,
-                            "openAppointmentSlots": 95,
+                            "openTimeslots": 53,
+                            "openAppointmentSlots": 53,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 95,
+                    "openTimeslots": 53,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 95,
+                    "openAppointmentSlots": 53,
                     "name": "Champion Forest Market H-E-B",
                     "longitude": -95.57475,
                     "latitude": 30.0551,
@@ -3582,28 +3501,37 @@
                     "city": "SPRING",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "77469-2509",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueSQAS",
                     "type": "store",
                     "street": "23500 CIRCLE OAK PARKWAY",
                     "storeNumber": 727,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 155,
+                            "openAppointmentSlots": 155,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 155,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 155,
                     "name": "Richmond Market H-E-B",
                     "longitude": -95.74781,
                     "latitude": 29.55142,
                     "fluUrl": "",
                     "city": "RICHMOND",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer"
+                    ]
                 },
                 {
                     "zip": "77340-3723",
@@ -3614,26 +3542,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 64,
-                            "openAppointmentSlots": 64,
+                            "openTimeslots": 61,
+                            "openAppointmentSlots": 61,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 26,
-                    "openFluTimeslots": 38,
-                    "openFluAppointmentSlots": 38,
-                    "openAppointmentSlots": 26,
+                    "openTimeslots": 61,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 61,
                     "name": "Huntsville H-E-B",
                     "longitude": -95.56075,
                     "latitude": 30.72274,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF1TQAU",
+                    "fluUrl": "",
                     "city": "HUNTSVILLE",
                     "availableImmunizations": [
-                        "COVID-19 Moderna",
+                        "Flu",
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "Flu"
+                        "COVID-19 Moderna"
                     ]
                 },
                 {
@@ -3645,23 +3574,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 1106,
-                            "openAppointmentSlots": 1106,
+                            "openTimeslots": 335,
+                            "openAppointmentSlots": 335,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 938,
-                    "openFluTimeslots": 168,
-                    "openFluAppointmentSlots": 168,
-                    "openAppointmentSlots": 938,
+                    "openTimeslots": 300,
+                    "openFluTimeslots": 35,
+                    "openFluAppointmentSlots": 35,
+                    "openAppointmentSlots": 300,
                     "name": "Bulverde and 1604 H-E-B",
                     "longitude": -98.41746,
                     "latitude": 29.59497,
                     "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF1UQAU",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
-                        "Flu",
                         "COVID-19 Pfizer_Updated_Booster",
+                        "Flu",
                         "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
@@ -3674,23 +3603,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 3,
-                            "openAppointmentSlots": 3,
+                            "openTimeslots": 8,
+                            "openAppointmentSlots": 8,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 3,
+                    "openTimeslots": 8,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 3,
+                    "openAppointmentSlots": 8,
                     "name": "35 and Calton H-E-B",
                     "longitude": -99.50182,
                     "latitude": 27.54172,
                     "fluUrl": "",
                     "city": "LAREDO",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer",
-                        "COVID-19 Moderna"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Ultra_Pediatric_Pfizer"
                     ]
                 },
                 {
@@ -3721,27 +3651,29 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 48,
-                            "openAppointmentSlots": 48,
+                            "openTimeslots": 250,
+                            "openAppointmentSlots": 250,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 48,
+                    "openTimeslots": 250,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 48,
+                    "openAppointmentSlots": 250,
                     "name": "Central Blvd H-E-B",
                     "longitude": -97.51093,
                     "latitude": 25.92849,
                     "fluUrl": "",
                     "city": "BROWNSVILLE",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu",
                         "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Ultra_Pediatric_Pfizer",
-                        "COVID-19 Pediatric_Moderna"
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -3753,24 +3685,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 40,
-                            "openAppointmentSlots": 40,
+                            "openTimeslots": 67,
+                            "openAppointmentSlots": 67,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 40,
+                    "openTimeslots": 67,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 40,
+                    "openAppointmentSlots": 67,
                     "name": "Hwy 183 and Whitestone Blvd H-E-B",
                     "longitude": -97.82911,
                     "latitude": 30.5225,
                     "fluUrl": "",
                     "city": "CEDAR PARK",
                     "availableImmunizations": [
+                        "COVID-19 Moderna_Updated_Booster",
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -3782,25 +3714,22 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 131,
-                            "openAppointmentSlots": 131,
+                            "openTimeslots": 68,
+                            "openAppointmentSlots": 68,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 131,
+                    "openTimeslots": 68,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 131,
+                    "openAppointmentSlots": 68,
                     "name": "North Hills H-E-B",
                     "longitude": -97.74832,
                     "latitude": 30.39868,
                     "fluUrl": "",
                     "city": "AUSTIN",
                     "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "Flu"
                     ]
                 },
                 {
@@ -3812,51 +3741,42 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 39,
-                            "openAppointmentSlots": 39,
+                            "openTimeslots": 98,
+                            "openAppointmentSlots": 98,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 39,
+                    "openTimeslots": 98,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 39,
+                    "openAppointmentSlots": 98,
                     "name": "Moore Plaza H-E-B",
                     "longitude": -97.37238,
                     "latitude": 27.70605,
                     "fluUrl": "",
                     "city": "CORPUS CHRISTI",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
                         "Flu"
                     ]
                 },
                 {
                     "zip": "78624-4146",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucuQAC",
+                    "url": null,
                     "type": "store",
                     "street": "407 SOUTH ADAMS",
                     "storeNumber": 561,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 9,
-                            "openAppointmentSlots": 9,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 9,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 9,
+                    "openAppointmentSlots": 0,
                     "name": "Fredericksburg H-E-B",
                     "longitude": -98.87538,
                     "latitude": 30.27006,
                     "fluUrl": "",
                     "city": "FREDERICKSBURG",
-                    "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78382-3314",
@@ -3886,15 +3806,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 294,
-                            "openAppointmentSlots": 294,
+                            "openTimeslots": 137,
+                            "openAppointmentSlots": 137,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 294,
+                    "openTimeslots": 137,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 294,
+                    "openAppointmentSlots": 137,
                     "name": "Riverpark H-E-B",
                     "longitude": -95.6815,
                     "latitude": 29.5636,
@@ -3902,9 +3822,9 @@
                     "city": "SUGAR LAND",
                     "availableImmunizations": [
                         "COVID-19 Pfizer_Updated_Booster",
-                        "Flu",
                         "COVID-19 Novavax",
-                        "COVID-19 Pediatric_Pfizer"
+                        "Flu",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -3916,15 +3836,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 115,
-                            "openAppointmentSlots": 115,
+                            "openTimeslots": 41,
+                            "openAppointmentSlots": 41,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 115,
+                    "openTimeslots": 41,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 115,
+                    "openAppointmentSlots": 41,
                     "name": "Sawdust Rd and 45 H-E-B",
                     "longitude": -95.44512,
                     "latitude": 30.12684,
@@ -3945,15 +3865,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 402,
-                            "openAppointmentSlots": 402,
+                            "openTimeslots": 329,
+                            "openAppointmentSlots": 329,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 402,
+                    "openTimeslots": 329,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 402,
+                    "openAppointmentSlots": 329,
                     "name": "Leon Springs H-E-B",
                     "longitude": -98.63218,
                     "latitude": 29.6659,
@@ -3961,9 +3881,6 @@
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
@@ -3995,36 +3912,6 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 22,
-                            "openAppointmentSlots": 22,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 22,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 22,
-                    "name": "Perrin Beitel and Thousand Oaks H-E-B",
-                    "longitude": -98.4082,
-                    "latitude": 29.5491,
-                    "fluUrl": "",
-                    "city": "SAN ANTONIO",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
-                    ]
-                },
-                {
-                    "zip": "78582-4815",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaEQAS",
-                    "type": "store",
-                    "street": "4031 EAST HWY 83",
-                    "storeNumber": 13,
-                    "state": "TX",
-                    "slotDetails": [
-                        {
                             "openTimeslots": 45,
                             "openAppointmentSlots": 45,
                             "manufacturer": "Multiple"
@@ -4034,20 +3921,35 @@
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
                     "openAppointmentSlots": 45,
+                    "name": "Perrin Beitel and Thousand Oaks H-E-B",
+                    "longitude": -98.4082,
+                    "latitude": 29.5491,
+                    "fluUrl": "",
+                    "city": "SAN ANTONIO",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
+                },
+                {
+                    "zip": "78582-4815",
+                    "url": null,
+                    "type": "store",
+                    "street": "4031 EAST HWY 83",
+                    "storeNumber": 13,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
                     "name": "Rio Grande City H-E-B plus!",
                     "longitude": -98.80031,
                     "latitude": 26.37244,
                     "fluUrl": "",
                     "city": "RIO GRANDE CITY",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
-                        "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Moderna_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78550-5905",
@@ -4077,15 +3979,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 16,
-                            "openAppointmentSlots": 16,
+                            "openTimeslots": 24,
+                            "openAppointmentSlots": 24,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 16,
+                    "openTimeslots": 24,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 16,
+                    "openAppointmentSlots": 24,
                     "name": "Bay City H-E-B",
                     "longitude": -95.95804,
                     "latitude": 28.98306,
@@ -4098,22 +4000,30 @@
                 },
                 {
                     "zip": "78244-1300",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubdQAC",
                     "type": "store",
                     "street": "6580 F.M. 78",
                     "storeNumber": 294,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 27,
+                            "openAppointmentSlots": 27,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 27,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 27,
                     "name": "Foster Rd H-E-B",
                     "longitude": -98.3591,
                     "latitude": 29.48109,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu"
+                    ]
                 },
                 {
                     "zip": "78521-4787",
@@ -4136,59 +4046,41 @@
                 },
                 {
                     "zip": "78336-1919",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubfQAC",
+                    "url": null,
                     "type": "store",
                     "street": "101 E. GOODNIGHT",
                     "storeNumber": 333,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 240,
-                            "openAppointmentSlots": 240,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 240,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 240,
+                    "openAppointmentSlots": 0,
                     "name": "Aransas Pass H-E-B",
                     "longitude": -97.14616,
                     "latitude": 27.90255,
                     "fluUrl": "",
                     "city": "ARANSAS PASS",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78501-3512",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubgQAC",
+                    "url": null,
                     "type": "store",
                     "street": "3601 PECAN",
                     "storeNumber": 334,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 30,
-                            "openAppointmentSlots": 30,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 30,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 30,
+                    "openAppointmentSlots": 0,
                     "name": "Pecan and Ware H-E-B",
                     "longitude": -98.25799,
                     "latitude": 26.21925,
                     "fluUrl": "",
                     "city": "MCALLEN",
-                    "availableImmunizations": [
-                        "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78640-6038",
@@ -4199,15 +4091,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 17,
-                            "openAppointmentSlots": 17,
+                            "openTimeslots": 4,
+                            "openAppointmentSlots": 4,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 17,
+                    "openTimeslots": 4,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 17,
+                    "openAppointmentSlots": 4,
                     "name": "Kyle H-E-B plus!",
                     "longitude": -97.86258,
                     "latitude": 30.01533,
@@ -4215,9 +4107,13 @@
                     "city": "KYLE",
                     "availableImmunizations": [
                         "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Janssen",
                         "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Novavax",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
@@ -4230,26 +4126,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 155,
-                            "openAppointmentSlots": 155,
+                            "openTimeslots": 437,
+                            "openAppointmentSlots": 437,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 121,
-                    "openFluTimeslots": 34,
-                    "openFluAppointmentSlots": 34,
-                    "openAppointmentSlots": 121,
+                    "openTimeslots": 437,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 437,
                     "name": "Burleson H-E-B plus!",
                     "longitude": -97.34901,
                     "latitude": 32.52083,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3wQAE",
+                    "fluUrl": "",
                     "city": "BURLESON",
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -4261,25 +4157,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 285,
-                            "openAppointmentSlots": 285,
+                            "openTimeslots": 316,
+                            "openAppointmentSlots": 316,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 68,
-                    "openFluTimeslots": 217,
-                    "openFluAppointmentSlots": 217,
-                    "openAppointmentSlots": 68,
+                    "openTimeslots": 316,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 316,
                     "name": "Lytle H-E-B plus!",
                     "longitude": -98.78924,
                     "latitude": 29.23224,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3xQAE",
+                    "fluUrl": "",
                     "city": "LYTLE",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Moderna",
-                        "COVID-19 Pfizer"
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -4291,15 +4188,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 78,
-                            "openAppointmentSlots": 78,
+                            "openTimeslots": 242,
+                            "openAppointmentSlots": 242,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 78,
+                    "openTimeslots": 242,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 78,
+                    "openAppointmentSlots": 242,
                     "name": "Cypress Market H-E-B",
                     "longitude": -95.6765,
                     "latitude": 29.95569,
@@ -4308,7 +4205,6 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
@@ -4322,15 +4218,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 20,
-                            "openAppointmentSlots": 20,
+                            "openTimeslots": 30,
+                            "openAppointmentSlots": 30,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 20,
+                    "openTimeslots": 30,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 20,
+                    "openAppointmentSlots": 30,
                     "name": "Anderson Mill H-E-B plus!",
                     "longitude": -97.82626,
                     "latitude": 30.45495,
@@ -4338,9 +4234,8 @@
                     "city": "AUSTIN",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -4352,24 +4247,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 171,
-                            "openAppointmentSlots": 171,
+                            "openTimeslots": 116,
+                            "openAppointmentSlots": 116,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 78,
-                    "openFluTimeslots": 93,
-                    "openFluAppointmentSlots": 93,
-                    "openAppointmentSlots": 78,
+                    "openTimeslots": 116,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 116,
                     "name": "Trimmier H-E-B plus!",
                     "longitude": -97.7338,
                     "latitude": 31.0909,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3eQAE",
+                    "fluUrl": "",
                     "city": "KILLEEN",
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
+                        "COVID-19 Novavax",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer",
@@ -4386,15 +4282,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 5,
-                            "openAppointmentSlots": 5,
+                            "openTimeslots": 11,
+                            "openAppointmentSlots": 11,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 5,
+                    "openTimeslots": 11,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 5,
+                    "openAppointmentSlots": 11,
                     "name": "Bastrop H-E-B plus!",
                     "longitude": -97.33458,
                     "latitude": 30.10981,
@@ -4410,22 +4306,32 @@
                 },
                 {
                     "zip": "76712-3371",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudAQAS",
                     "type": "store",
                     "street": "9100 WOODWAY DRIVE",
                     "storeNumber": 583,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 5,
+                            "openAppointmentSlots": 5,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 5,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 5,
                     "name": "Woodway H-E-B plus!",
                     "longitude": -97.22132,
                     "latitude": 31.49664,
                     "fluUrl": "",
                     "city": "WOODWAY",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77437-4420",
@@ -4436,23 +4342,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 217,
-                            "openAppointmentSlots": 217,
+                            "openTimeslots": 43,
+                            "openAppointmentSlots": 43,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 217,
+                    "openTimeslots": 43,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 217,
+                    "openAppointmentSlots": 43,
                     "name": "El Campo H-E-B",
                     "longitude": -96.26988,
                     "latitude": 29.19683,
                     "fluUrl": "",
                     "city": "EL CAMPO",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "Flu"
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -4464,15 +4370,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 93,
-                            "openAppointmentSlots": 93,
+                            "openTimeslots": 157,
+                            "openAppointmentSlots": 157,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 93,
+                    "openTimeslots": 157,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 93,
+                    "openAppointmentSlots": 157,
                     "name": "Austin Highway H-E-B",
                     "longitude": -98.43132,
                     "latitude": 29.4937,
@@ -4480,7 +4386,6 @@
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer",
                         "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Moderna_Updated_Booster"
                     ]
@@ -4494,27 +4399,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 91,
-                            "openAppointmentSlots": 91,
+                            "openTimeslots": 72,
+                            "openAppointmentSlots": 72,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 91,
+                    "openTimeslots": 72,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 91,
+                    "openAppointmentSlots": 72,
                     "name": "Zapata Highway H-E-B",
                     "longitude": -99.47479,
                     "latitude": 27.47673,
                     "fluUrl": "",
                     "city": "LAREDO",
                     "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
                         "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "Flu"
                     ]
                 },
                 {
@@ -4538,22 +4440,33 @@
                 },
                 {
                     "zip": "76901-0",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueWQAS",
                     "type": "store",
                     "street": "5502 SHERWOOD WAY",
                     "storeNumber": 734,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 238,
+                            "openAppointmentSlots": 238,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 238,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 238,
                     "name": "Sherwood & FM 2288 H-E-B",
                     "longitude": -100.51103,
                     "latitude": 31.43158,
                     "fluUrl": "",
                     "city": "SAN ANGELO",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Janssen",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna"
+                    ]
                 },
                 {
                     "zip": "77494-5426",
@@ -4564,19 +4477,19 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 98,
-                            "openAppointmentSlots": 98,
+                            "openTimeslots": 77,
+                            "openAppointmentSlots": 77,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 50,
-                    "openFluTimeslots": 48,
-                    "openFluAppointmentSlots": 48,
-                    "openAppointmentSlots": 50,
+                    "openTimeslots": 77,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 77,
                     "name": "Cross Creek Ranch H-E-B",
                     "longitude": -95.84788,
                     "latitude": 29.71936,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF1nQAE",
+                    "fluUrl": "",
                     "city": "KATY",
                     "availableImmunizations": [
                         "Flu",
@@ -4593,15 +4506,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 257,
-                            "openAppointmentSlots": 257,
+                            "openTimeslots": 99,
+                            "openAppointmentSlots": 99,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 257,
+                    "openTimeslots": 99,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 257,
+                    "openAppointmentSlots": 99,
                     "name": "The Heights H-E-B",
                     "longitude": -95.40865,
                     "latitude": 29.80735,
@@ -4609,8 +4522,7 @@
                     "city": "HOUSTON",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Janssen"
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -4622,15 +4534,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 380,
-                            "openAppointmentSlots": 380,
+                            "openTimeslots": 178,
+                            "openAppointmentSlots": 178,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 182,
-                    "openFluTimeslots": 198,
-                    "openFluAppointmentSlots": 198,
-                    "openAppointmentSlots": 182,
+                    "openTimeslots": 149,
+                    "openFluTimeslots": 29,
+                    "openFluAppointmentSlots": 29,
+                    "openAppointmentSlots": 149,
                     "name": "Bellaire Market H-E-B",
                     "longitude": -95.46938,
                     "latitude": 29.70764,
@@ -4644,6 +4556,7 @@
                         "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
                         "COVID-19 Novavax",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
@@ -4656,15 +4569,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 154,
-                            "openAppointmentSlots": 154,
+                            "openTimeslots": 80,
+                            "openAppointmentSlots": 80,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 154,
+                    "openTimeslots": 80,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 154,
+                    "openAppointmentSlots": 80,
                     "name": "Mont Belvieu H-E-B",
                     "longitude": -94.84973,
                     "latitude": 29.82755,
@@ -4672,10 +4585,10 @@
                     "city": "MONT BELVIEU",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pediatric_Pfizer"
                     ]
                 },
                 {
@@ -4687,23 +4600,22 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 60,
-                            "openAppointmentSlots": 60,
+                            "openTimeslots": 7,
+                            "openAppointmentSlots": 7,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 60,
+                    "openTimeslots": 7,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 60,
+                    "openAppointmentSlots": 7,
                     "name": "Floresville H-E-B",
                     "longitude": -98.15681,
                     "latitude": 29.14284,
                     "fluUrl": "",
                     "city": "FLORESVILLE",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -4715,25 +4627,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 658,
-                            "openAppointmentSlots": 658,
+                            "openTimeslots": 962,
+                            "openAppointmentSlots": 962,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 551,
-                    "openFluTimeslots": 107,
-                    "openFluAppointmentSlots": 107,
-                    "openAppointmentSlots": 551,
+                    "openTimeslots": 812,
+                    "openFluTimeslots": 150,
+                    "openFluAppointmentSlots": 150,
+                    "openAppointmentSlots": 812,
                     "name": "McCreless Market H-E-B plus!",
                     "longitude": -98.46115,
                     "latitude": 29.37828,
                     "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF41QAE",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pediatric_Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna",
+                        "Flu",
+                        "COVID-19 Pediatric_Moderna",
                         "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Novavax"
@@ -4748,15 +4661,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 325,
-                            "openAppointmentSlots": 325,
+                            "openTimeslots": 116,
+                            "openAppointmentSlots": 116,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 325,
+                    "openTimeslots": 116,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 325,
+                    "openAppointmentSlots": 116,
                     "name": "Bay Colony H-E-B",
                     "longitude": -95.0926,
                     "latitude": 29.4677,
@@ -4764,6 +4677,8 @@
                     "city": "LEAGUE CITY",
                     "availableImmunizations": [
                         "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
@@ -4777,22 +4692,21 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 2,
-                            "openAppointmentSlots": 2,
+                            "openTimeslots": 18,
+                            "openAppointmentSlots": 18,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 2,
+                    "openTimeslots": 18,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 2,
+                    "openAppointmentSlots": 18,
                     "name": "Westlake H-E-B",
                     "longitude": -97.82813,
                     "latitude": 30.2928,
                     "fluUrl": "",
                     "city": "WEST LAKE HILLS",
                     "availableImmunizations": [
-                        "Flu",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
@@ -4805,15 +4719,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 363,
-                            "openAppointmentSlots": 363,
+                            "openTimeslots": 191,
+                            "openAppointmentSlots": 191,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 363,
+                    "openTimeslots": 191,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 363,
+                    "openAppointmentSlots": 191,
                     "name": "Spicewood Springs H-E-B",
                     "longitude": -97.7713,
                     "latitude": 30.43494,
@@ -4822,9 +4736,6 @@
                     "availableImmunizations": [
                         "COVID-19 Pfizer_Updated_Booster",
                         "Flu",
-                        "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Novavax"
                     ]
                 },
@@ -4837,16 +4748,16 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 1232,
-                            "openAppointmentSlots": 1232,
+                            "openTimeslots": 830,
+                            "openAppointmentSlots": 830,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 586,
-                    "openFluTimeslots": 646,
-                    "openFluAppointmentSlots": 646,
-                    "openAppointmentSlots": 586,
-                    "name": "Red Bud Lane and Gattis School H-E-B",
+                    "openTimeslots": 676,
+                    "openFluTimeslots": 154,
+                    "openFluAppointmentSlots": 154,
+                    "openAppointmentSlots": 676,
+                    "name": "Gattis School H-E-B Round Rock",
                     "longitude": -97.61475,
                     "latitude": 30.49721,
                     "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4IQAU",
@@ -4856,7 +4767,8 @@
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -4868,15 +4780,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 46,
-                            "openAppointmentSlots": 46,
+                            "openTimeslots": 21,
+                            "openAppointmentSlots": 21,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 46,
+                    "openTimeslots": 21,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 46,
+                    "openAppointmentSlots": 21,
                     "name": "Edna H-E-B",
                     "longitude": -96.64731,
                     "latitude": 28.97947,
@@ -4885,8 +4797,8 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer"
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -4898,23 +4810,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 206,
-                            "openAppointmentSlots": 206,
+                            "openTimeslots": 147,
+                            "openAppointmentSlots": 147,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 206,
+                    "openTimeslots": 147,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 206,
+                    "openAppointmentSlots": 147,
                     "name": "Oak Park H-E-B",
                     "longitude": -98.45759,
                     "latitude": 29.50774,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer"
                     ]
                 },
                 {
@@ -4926,28 +4842,28 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 1423,
-                            "openAppointmentSlots": 1423,
+                            "openTimeslots": 2407,
+                            "openAppointmentSlots": 2407,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 1054,
-                    "openFluTimeslots": 369,
-                    "openFluAppointmentSlots": 369,
-                    "openAppointmentSlots": 1054,
+                    "openTimeslots": 2407,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 2407,
                     "name": "620 and O'Connor H-E-B",
                     "longitude": -97.72218,
                     "latitude": 30.50028,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2AQAU",
+                    "fluUrl": "",
                     "city": "ROUND ROCK",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Janssen",
+                        "COVID-19 Novavax",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Novavax"
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -4959,15 +4875,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 284,
-                            "openAppointmentSlots": 284,
+                            "openTimeslots": 221,
+                            "openAppointmentSlots": 221,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 284,
+                    "openTimeslots": 221,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 284,
+                    "openAppointmentSlots": 221,
                     "name": "New Braunfels H-E-B at Walnut",
                     "longitude": -98.12631,
                     "latitude": 29.68903,
@@ -4979,7 +4895,8 @@
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Janssen",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -4991,26 +4908,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 263,
-                            "openAppointmentSlots": 263,
+                            "openTimeslots": 357,
+                            "openAppointmentSlots": 357,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 166,
-                    "openFluTimeslots": 97,
-                    "openFluAppointmentSlots": 97,
-                    "openAppointmentSlots": 166,
+                    "openTimeslots": 357,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 357,
                     "name": "Harker Heights H-E-B",
                     "longitude": -97.65511,
                     "latitude": 31.07905,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2CQAU",
+                    "fluUrl": "",
                     "city": "HARKER HEIGHTS",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "Flu",
                         "COVID-19 Pfizer",
                         "COVID-19 Moderna",
-                        "COVID-19 Pediatric_Pfizer"
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu"
                     ]
                 },
                 {
@@ -5022,27 +4939,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 240,
-                            "openAppointmentSlots": 240,
+                            "openTimeslots": 54,
+                            "openAppointmentSlots": 54,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 240,
+                    "openTimeslots": 54,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 240,
+                    "openAppointmentSlots": 54,
                     "name": "West Wadley H-E-B",
                     "longitude": -102.12562,
                     "latitude": 32.01955,
                     "fluUrl": "",
                     "city": "MIDLAND",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -5054,27 +4970,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 80,
-                            "openAppointmentSlots": 80,
+                            "openTimeslots": 285,
+                            "openAppointmentSlots": 285,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 80,
+                    "openTimeslots": 285,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 80,
+                    "openAppointmentSlots": 285,
                     "name": "Montgomery at Walzem",
                     "longitude": -98.37092,
                     "latitude": 29.5105,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
-                        "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu"
                     ]
                 },
                 {
@@ -5086,22 +5002,21 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 124,
-                            "openAppointmentSlots": 124,
+                            "openTimeslots": 18,
+                            "openAppointmentSlots": 18,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 124,
+                    "openTimeslots": 18,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 124,
+                    "openAppointmentSlots": 18,
                     "name": "Olmos Park H-E-B",
                     "longitude": -98.497,
                     "latitude": 29.4707,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
-                        "Flu",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
@@ -5133,15 +5048,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 105,
-                            "openAppointmentSlots": 105,
+                            "openTimeslots": 159,
+                            "openAppointmentSlots": 159,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 34,
-                    "openFluTimeslots": 71,
-                    "openFluAppointmentSlots": 71,
-                    "openAppointmentSlots": 34,
+                    "openTimeslots": 89,
+                    "openFluTimeslots": 70,
+                    "openFluAppointmentSlots": 70,
+                    "openAppointmentSlots": 89,
                     "name": "Parmer and McNeil H-E-B",
                     "longitude": -97.74278,
                     "latitude": 30.44181,
@@ -5152,8 +5067,10 @@
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Janssen",
                         "COVID-19 Ultra_Pediatric_Pfizer",
-                        "COVID-19 Pediatric_Moderna"
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -5165,15 +5082,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 196,
-                            "openAppointmentSlots": 196,
+                            "openTimeslots": 220,
+                            "openAppointmentSlots": 220,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 196,
+                    "openTimeslots": 220,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 196,
+                    "openAppointmentSlots": 220,
                     "name": "Mid County H-E-B",
                     "longitude": -93.9758,
                     "latitude": 29.966,
@@ -5186,8 +5103,8 @@
                         "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Novavax"
+                        "COVID-19 Novavax",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -5218,15 +5135,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 114,
-                            "openAppointmentSlots": 114,
+                            "openTimeslots": 42,
+                            "openAppointmentSlots": 42,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 114,
+                    "openTimeslots": 42,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 114,
+                    "openAppointmentSlots": 42,
                     "name": "Leander H-E-B plus!",
                     "longitude": -97.8582,
                     "latitude": 30.58369,
@@ -5247,15 +5164,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
+                            "openTimeslots": 140,
+                            "openAppointmentSlots": 140,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 50,
+                    "openTimeslots": 140,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 50,
+                    "openAppointmentSlots": 140,
                     "name": "Baytown H-E-B",
                     "longitude": -94.9788,
                     "latitude": 29.79503,
@@ -5265,6 +5182,7 @@
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
@@ -5277,26 +5195,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 233,
-                            "openAppointmentSlots": 233,
+                            "openTimeslots": 276,
+                            "openAppointmentSlots": 276,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 233,
+                    "openTimeslots": 276,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 233,
+                    "openAppointmentSlots": 276,
                     "name": "Buffalo Heights H-E-B On Washington Ave",
                     "longitude": -95.39658,
                     "latitude": 29.76901,
                     "fluUrl": "",
                     "city": "HOUSTON",
                     "availableImmunizations": [
-                        "Flu",
                         "COVID-19 Pfizer_Updated_Booster",
+                        "Flu",
+                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer"
+                        "COVID-19 Pfizer"
                     ]
                 },
                 {
@@ -5308,24 +5226,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 225,
-                            "openAppointmentSlots": 225,
+                            "openTimeslots": 88,
+                            "openAppointmentSlots": 88,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 225,
+                    "openTimeslots": 88,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 225,
+                    "openAppointmentSlots": 88,
                     "name": "Meyerland Market H-E-B",
                     "longitude": -95.46406,
                     "latitude": 29.68854,
                     "fluUrl": "",
                     "city": "HOUSTON",
                     "availableImmunizations": [
-                        "Flu",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pfizer"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "Flu"
                     ]
                 },
                 {
@@ -5337,15 +5255,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 14,
-                            "openAppointmentSlots": 14,
+                            "openTimeslots": 101,
+                            "openAppointmentSlots": 101,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 14,
+                    "openTimeslots": 101,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 14,
+                    "openAppointmentSlots": 101,
                     "name": "Jones Crossing H-E-B",
                     "longitude": -96.32324,
                     "latitude": 30.58444,
@@ -5379,34 +5297,22 @@
                 },
                 {
                     "zip": "76513-1519",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaRQAS",
+                    "url": null,
                     "type": "store",
                     "street": "2509 NORTH MAIN STREET",
                     "storeNumber": 39,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 46,
-                            "openAppointmentSlots": 46,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 46,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 46,
+                    "openAppointmentSlots": 0,
                     "name": "Belton H-E-B plus!",
                     "longitude": -97.45759,
                     "latitude": 31.0805,
                     "fluUrl": "",
                     "city": "BELTON",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78704-0",
@@ -5417,19 +5323,19 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 151,
-                            "openAppointmentSlots": 151,
+                            "openTimeslots": 223,
+                            "openAppointmentSlots": 223,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 70,
-                    "openFluTimeslots": 81,
-                    "openFluAppointmentSlots": 81,
-                    "openAppointmentSlots": 70,
+                    "openTimeslots": 223,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 223,
                     "name": "South Congress H-E-B",
                     "longitude": -97.7516,
                     "latitude": 30.23963,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4LQAU",
+                    "fluUrl": "",
                     "city": "AUSTIN",
                     "availableImmunizations": [
                         "Flu",
@@ -5445,15 +5351,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 191,
-                            "openAppointmentSlots": 191,
+                            "openTimeslots": 150,
+                            "openAppointmentSlots": 150,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 191,
+                    "openTimeslots": 150,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 191,
+                    "openAppointmentSlots": 150,
                     "name": "Beaumont H-E-B plus!",
                     "longitude": -94.1685,
                     "latitude": 30.10501,
@@ -5476,27 +5382,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 132,
-                            "openAppointmentSlots": 132,
+                            "openTimeslots": 85,
+                            "openAppointmentSlots": 85,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 121,
-                    "openFluTimeslots": 11,
-                    "openFluAppointmentSlots": 11,
-                    "openAppointmentSlots": 121,
+                    "openTimeslots": 85,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 85,
                     "name": "West Ave and Jackson Keller H-E-B",
                     "longitude": -98.52574,
                     "latitude": 29.51639,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2NQAU",
+                    "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
-                        "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Moderna",
                         "COVID-19 Pfizer_Updated_Booster",
+                        "Flu",
                         "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
@@ -5509,25 +5411,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 147,
-                            "openAppointmentSlots": 147,
+                            "openTimeslots": 144,
+                            "openAppointmentSlots": 144,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 79,
-                    "openFluTimeslots": 68,
-                    "openFluAppointmentSlots": 68,
-                    "openAppointmentSlots": 79,
+                    "openTimeslots": 144,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 144,
                     "name": "De Zavala H-E-B",
                     "longitude": -98.5889,
                     "latitude": 29.56222,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2OQAU",
+                    "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
+                        "COVID-19 Moderna_Updated_Booster",
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -5539,15 +5440,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 509,
-                            "openAppointmentSlots": 509,
+                            "openTimeslots": 396,
+                            "openAppointmentSlots": 396,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 509,
+                    "openTimeslots": 396,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 509,
+                    "openAppointmentSlots": 396,
                     "name": "281 and 1604 H-E-B",
                     "longitude": -98.46828,
                     "latitude": 29.60772,
@@ -5561,22 +5462,31 @@
                 },
                 {
                     "zip": "78247-3312",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubuQAC",
                     "type": "store",
                     "street": "2929 THOUSAND OAKS",
                     "storeNumber": 398,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 562,
+                            "openAppointmentSlots": 562,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 264,
+                    "openFluTimeslots": 298,
+                    "openFluAppointmentSlots": 298,
+                    "openAppointmentSlots": 264,
                     "name": "Thousand Oaks H-E-B",
                     "longitude": -98.44108,
                     "latitude": 29.57781,
-                    "fluUrl": "",
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2QQAU",
                     "city": "SAN ANTONIO",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78363-3872",
@@ -5587,15 +5497,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 111,
-                            "openAppointmentSlots": 111,
+                            "openTimeslots": 131,
+                            "openAppointmentSlots": 131,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 111,
+                    "openTimeslots": 131,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 111,
+                    "openAppointmentSlots": 131,
                     "name": "Kingsville H-E-B",
                     "longitude": -97.86453,
                     "latitude": 27.51658,
@@ -5606,7 +5516,8 @@
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -5618,22 +5529,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 35,
-                            "openAppointmentSlots": 35,
+                            "openTimeslots": 63,
+                            "openAppointmentSlots": 63,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 23,
-                    "openFluTimeslots": 12,
-                    "openFluAppointmentSlots": 12,
-                    "openAppointmentSlots": 23,
+                    "openTimeslots": 63,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 63,
                     "name": "Indian Springs H-E-B",
                     "longitude": -95.53672,
                     "latitude": 30.17791,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3pQAE",
+                    "fluUrl": "",
                     "city": "THE WOODLANDS",
                     "availableImmunizations": [
                         "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
@@ -5646,15 +5560,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 212,
-                            "openAppointmentSlots": 212,
+                            "openTimeslots": 279,
+                            "openAppointmentSlots": 279,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 212,
+                    "openTimeslots": 279,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 212,
+                    "openAppointmentSlots": 279,
                     "name": "N Frazier At Loop 336 H-E-B",
                     "longitude": -95.46548,
                     "latitude": 30.33593,
@@ -5677,15 +5591,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 54,
-                            "openAppointmentSlots": 54,
+                            "openTimeslots": 49,
+                            "openAppointmentSlots": 49,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 54,
+                    "openTimeslots": 49,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 54,
+                    "openAppointmentSlots": 49,
                     "name": "Grand Parkway H-E-B plus!",
                     "longitude": -95.7739,
                     "latitude": 29.7144,
@@ -5700,22 +5614,31 @@
                 },
                 {
                     "zip": "77005-4210",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudMQAS",
                     "type": "store",
                     "street": "5225 BUFFALO SPEEDWAY",
                     "storeNumber": 599,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 1,
+                            "openAppointmentSlots": 1,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 1,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 1,
                     "name": "Buffalo Market H-E-B On Buffalo Speedway",
                     "longitude": -95.4271,
                     "latitude": 29.7261,
                     "fluUrl": "",
                     "city": "HOUSTON",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77388-3412",
@@ -5726,23 +5649,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 249,
-                            "openAppointmentSlots": 249,
+                            "openTimeslots": 74,
+                            "openAppointmentSlots": 74,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 249,
+                    "openTimeslots": 74,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 249,
+                    "openAppointmentSlots": 74,
                     "name": "Spring Market H-E-B",
                     "longitude": -95.44894,
                     "latitude": 30.07042,
                     "fluUrl": "",
                     "city": "SPRING",
                     "availableImmunizations": [
-                        "Flu",
                         "COVID-19 Pfizer_Updated_Booster",
+                        "Flu",
                         "COVID-19 Pediatric_Pfizer"
                     ]
                 },
@@ -5755,15 +5678,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 151,
-                            "openAppointmentSlots": 151,
+                            "openTimeslots": 219,
+                            "openAppointmentSlots": 219,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 134,
-                    "openFluTimeslots": 17,
-                    "openFluAppointmentSlots": 17,
-                    "openAppointmentSlots": 134,
+                    "openTimeslots": 204,
+                    "openFluTimeslots": 15,
+                    "openFluAppointmentSlots": 15,
+                    "openAppointmentSlots": 204,
                     "name": "Dripping Springs H-E-B",
                     "longitude": -98.08146,
                     "latitude": 30.18968,
@@ -5771,7 +5694,8 @@
                     "city": "DRIPPING SPRINGS",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -5783,23 +5707,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 20,
-                            "openAppointmentSlots": 20,
+                            "openTimeslots": 36,
+                            "openAppointmentSlots": 36,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 20,
+                    "openTimeslots": 36,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 20,
+                    "openAppointmentSlots": 36,
                     "name": "La Vernia H-E-B",
                     "longitude": -98.13514,
                     "latitude": 29.35803,
                     "fluUrl": "",
                     "city": "LA VERNIA",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -5811,15 +5735,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 216,
-                            "openAppointmentSlots": 216,
+                            "openTimeslots": 60,
+                            "openAppointmentSlots": 60,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 216,
+                    "openTimeslots": 60,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 216,
+                    "openAppointmentSlots": 60,
                     "name": "H-E-B Market at Gosling",
                     "longitude": -95.50178,
                     "latitude": 30.07179,
@@ -5827,8 +5751,7 @@
                     "city": "SPRING",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -5878,15 +5801,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 123,
-                            "openAppointmentSlots": 123,
+                            "openTimeslots": 247,
+                            "openAppointmentSlots": 247,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 123,
+                    "openTimeslots": 247,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 123,
+                    "openAppointmentSlots": 247,
                     "name": "MacGregor Market H-E-B",
                     "longitude": -95.37644,
                     "latitude": 29.71432,
@@ -5894,7 +5817,8 @@
                     "city": "HOUSTON",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -5906,15 +5830,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 129,
-                            "openAppointmentSlots": 129,
+                            "openTimeslots": 273,
+                            "openAppointmentSlots": 273,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 129,
+                    "openTimeslots": 273,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 129,
+                    "openAppointmentSlots": 273,
                     "name": "Harper's Trace H-E-B",
                     "longitude": -95.42563,
                     "latitude": 30.20692,
@@ -5937,27 +5861,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 172,
-                            "openAppointmentSlots": 172,
+                            "openTimeslots": 220,
+                            "openAppointmentSlots": 220,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 172,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 172,
+                    "openTimeslots": 209,
+                    "openFluTimeslots": 11,
+                    "openFluAppointmentSlots": 11,
+                    "openAppointmentSlots": 209,
                     "name": "H-E-B Market at Northpark",
                     "longitude": -95.25033,
                     "latitude": 30.06864,
-                    "fluUrl": "",
+                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2FQAU",
                     "city": "KINGWOOD",
                     "availableImmunizations": [
+                        "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Janssen",
-                        "Flu"
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -5969,27 +5893,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 149,
-                            "openAppointmentSlots": 149,
+                            "openTimeslots": 21,
+                            "openAppointmentSlots": 21,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 129,
-                    "openFluTimeslots": 20,
-                    "openFluAppointmentSlots": 20,
-                    "openAppointmentSlots": 129,
+                    "openTimeslots": 21,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 21,
                     "name": "211 and Potranco H-E-B",
                     "longitude": -98.77966,
                     "latitude": 29.42367,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2GQAU",
+                    "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -6001,15 +5924,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 76,
-                            "openAppointmentSlots": 76,
+                            "openTimeslots": 318,
+                            "openAppointmentSlots": 318,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 76,
+                    "openTimeslots": 318,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 76,
+                    "openAppointmentSlots": 318,
                     "name": "Lubbock H-E-B",
                     "longitude": -101.90638,
                     "latitude": 33.48958,
@@ -6022,7 +5945,9 @@
                         "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Novavax"
+                        "COVID-19 Novavax",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -6034,15 +5959,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 116,
-                            "openAppointmentSlots": 116,
+                            "openTimeslots": 64,
+                            "openAppointmentSlots": 64,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 116,
+                    "openTimeslots": 64,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 116,
+                    "openAppointmentSlots": 64,
                     "name": "Big Spring H-E-B",
                     "longitude": -101.47211,
                     "latitude": 32.23493,
@@ -6065,15 +5990,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 179,
-                            "openAppointmentSlots": 179,
+                            "openTimeslots": 222,
+                            "openAppointmentSlots": 222,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 179,
+                    "openTimeslots": 222,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 179,
+                    "openAppointmentSlots": 222,
                     "name": "Sherwood Avenue N H-E-B",
                     "longitude": -100.47977,
                     "latitude": 31.44511,
@@ -6096,15 +6021,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 192,
-                            "openAppointmentSlots": 192,
+                            "openTimeslots": 187,
+                            "openAppointmentSlots": 187,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 192,
+                    "openTimeslots": 187,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 192,
+                    "openAppointmentSlots": 187,
                     "name": "Blackhawk H-E-B",
                     "longitude": -95.24868,
                     "latitude": 29.60234,
@@ -6112,7 +6037,9 @@
                     "city": "HOUSTON",
                     "availableImmunizations": [
                         "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pfizer",
                         "COVID-19 Moderna",
                         "COVID-19 Pediatric_Pfizer"
                     ]
@@ -6126,15 +6053,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 70,
-                            "openAppointmentSlots": 70,
+                            "openTimeslots": 54,
+                            "openAppointmentSlots": 54,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 70,
+                    "openTimeslots": 54,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 70,
+                    "openAppointmentSlots": 54,
                     "name": "Flour Bluff H-E-B plus!",
                     "longitude": -97.28288,
                     "latitude": 27.66767,
@@ -6142,7 +6069,8 @@
                     "city": "CORPUS CHRISTI",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -6154,22 +6082,21 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 91,
-                            "openAppointmentSlots": 91,
+                            "openTimeslots": 36,
+                            "openAppointmentSlots": 36,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 91,
+                    "openTimeslots": 36,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 91,
+                    "openAppointmentSlots": 36,
                     "name": "Pearland H-E-B plus!",
                     "longitude": -95.39002,
                     "latitude": 29.55932,
                     "fluUrl": "",
                     "city": "PEARLAND",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
@@ -6177,7 +6104,7 @@
                         "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
                         "COVID-19 Novavax",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -6189,15 +6116,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 182,
-                            "openAppointmentSlots": 182,
+                            "openTimeslots": 110,
+                            "openAppointmentSlots": 110,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 182,
+                    "openTimeslots": 110,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 182,
+                    "openAppointmentSlots": 110,
                     "name": "19th and Meridian H-E-B",
                     "longitude": -97.17255,
                     "latitude": 31.5804,
@@ -6207,8 +6134,8 @@
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -6220,23 +6147,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 48,
-                            "openAppointmentSlots": 48,
+                            "openTimeslots": 39,
+                            "openAppointmentSlots": 39,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 12,
-                    "openFluTimeslots": 36,
-                    "openFluAppointmentSlots": 36,
-                    "openAppointmentSlots": 12,
+                    "openTimeslots": 17,
+                    "openFluTimeslots": 22,
+                    "openFluAppointmentSlots": 22,
+                    "openAppointmentSlots": 17,
                     "name": "Slaughter and Escarpment H-E-B",
                     "longitude": -97.87642,
                     "latitude": 30.20247,
                     "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4TQAU",
                     "city": "AUSTIN",
                     "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster",
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -6286,24 +6214,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 58,
-                            "openAppointmentSlots": 58,
+                            "openTimeslots": 65,
+                            "openAppointmentSlots": 65,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 58,
+                    "openTimeslots": 65,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 58,
+                    "openAppointmentSlots": 65,
                     "name": "Bee Cave H-E-B",
                     "longitude": -97.93238,
                     "latitude": 30.30489,
                     "fluUrl": "",
                     "city": "BEE CAVE",
                     "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster",
                         "Flu",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Pediatric_Pfizer"
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -6315,24 +6245,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 252,
-                            "openAppointmentSlots": 252,
+                            "openTimeslots": 240,
+                            "openAppointmentSlots": 240,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 252,
+                    "openTimeslots": 240,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 252,
+                    "openAppointmentSlots": 240,
                     "name": "Marbach and 410 H-E-B plus!",
                     "longitude": -98.65227,
                     "latitude": 29.41837,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
-                        "Flu",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer"
+                        "Flu",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -6344,30 +6274,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 270,
-                            "openAppointmentSlots": 270,
+                            "openTimeslots": 340,
+                            "openAppointmentSlots": 340,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 252,
-                    "openFluTimeslots": 18,
-                    "openFluAppointmentSlots": 18,
-                    "openAppointmentSlots": 252,
+                    "openTimeslots": 340,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 340,
                     "name": "Summerwood Market H-E-B",
                     "longitude": -95.19697,
                     "latitude": 29.92325,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF49QAE",
+                    "fluUrl": "",
                     "city": "HOUSTON",
                     "availableImmunizations": [
+                        "COVID-19 Moderna_Updated_Booster",
                         "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
-                        "COVID-19 Pediatric_Moderna",
                         "COVID-19 Novavax",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -6379,19 +6304,19 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 853,
-                            "openAppointmentSlots": 853,
+                            "openTimeslots": 174,
+                            "openAppointmentSlots": 174,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 452,
-                    "openFluTimeslots": 401,
-                    "openFluAppointmentSlots": 401,
-                    "openAppointmentSlots": 452,
+                    "openTimeslots": 174,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 174,
                     "name": "Katy Market H-E-B",
                     "longitude": -95.82005,
                     "latitude": 29.77644,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4AQAU",
+                    "fluUrl": "",
                     "city": "KATY",
                     "availableImmunizations": [
                         "Flu",
@@ -6429,23 +6354,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 120,
-                            "openAppointmentSlots": 120,
+                            "openTimeslots": 215,
+                            "openAppointmentSlots": 215,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 11,
-                    "openFluTimeslots": 109,
-                    "openFluAppointmentSlots": 109,
-                    "openAppointmentSlots": 11,
+                    "openTimeslots": 137,
+                    "openFluTimeslots": 78,
+                    "openFluAppointmentSlots": 78,
+                    "openAppointmentSlots": 137,
                     "name": "Tower Point Market H-E-B",
                     "longitude": -96.26315,
                     "latitude": 30.55969,
                     "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4CQAU",
                     "city": "COLLEGE STATION",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "Flu"
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -6476,15 +6401,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 132,
-                            "openAppointmentSlots": 132,
+                            "openTimeslots": 47,
+                            "openAppointmentSlots": 47,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 132,
+                    "openTimeslots": 47,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 132,
+                    "openAppointmentSlots": 47,
                     "name": "H-E-B Pharmacy at the UTHTB",
                     "longitude": -97.73507,
                     "latitude": 30.27747,
@@ -6504,15 +6429,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 277,
-                            "openAppointmentSlots": 277,
+                            "openTimeslots": 89,
+                            "openAppointmentSlots": 89,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 277,
+                    "openTimeslots": 89,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 277,
+                    "openAppointmentSlots": 89,
                     "name": "Abilene H-E-B",
                     "longitude": -99.75934,
                     "latitude": 32.43348,
@@ -6520,34 +6445,44 @@
                     "city": "ABILENE",
                     "availableImmunizations": [
                         "Flu",
+                        "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna",
                         "COVID-19 Novavax",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Moderna"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "76504-2448",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuadQAC",
                     "type": "store",
                     "street": "1314 WEST ADAMS",
                     "storeNumber": 71,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 28,
+                            "openAppointmentSlots": 28,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 28,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 28,
                     "name": "Adams and 25th St H-E-B",
                     "longitude": -97.35378,
                     "latitude": 31.10153,
                     "fluUrl": "",
                     "city": "TEMPLE",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu"
+                    ]
                 },
                 {
                     "zip": "78006-2523",
@@ -6558,19 +6493,19 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 264,
-                            "openAppointmentSlots": 264,
+                            "openTimeslots": 123,
+                            "openAppointmentSlots": 123,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 139,
-                    "openFluTimeslots": 125,
-                    "openFluAppointmentSlots": 125,
-                    "openAppointmentSlots": 139,
+                    "openTimeslots": 123,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 123,
                     "name": "Boerne H-E-B plus!",
                     "longitude": -98.73481,
                     "latitude": 29.78173,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4EQAU",
+                    "fluUrl": "",
                     "city": "BOERNE",
                     "availableImmunizations": [
                         "Flu",
@@ -6587,15 +6522,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
+                            "openTimeslots": 199,
+                            "openAppointmentSlots": 199,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 10,
+                    "openTimeslots": 199,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 10,
+                    "openAppointmentSlots": 199,
                     "name": "Bulverde H-E-B plus!",
                     "longitude": -98.43022,
                     "latitude": 29.79882,
@@ -6604,10 +6539,13 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Novavax",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -6619,56 +6557,43 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 301,
-                            "openAppointmentSlots": 301,
+                            "openTimeslots": 214,
+                            "openAppointmentSlots": 214,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 145,
-                    "openFluTimeslots": 156,
-                    "openFluAppointmentSlots": 156,
-                    "openAppointmentSlots": 145,
+                    "openTimeslots": 214,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 214,
                     "name": "Bandera and 1604 H-E-B plus!",
                     "longitude": -98.66444,
                     "latitude": 29.55498,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4GQAU",
+                    "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu"
                     ]
                 },
                 {
                     "zip": "78586-4395",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudZQAS",
+                    "url": null,
                     "type": "store",
                     "street": "1095 WEST BUSINESS 77",
                     "storeNumber": 626,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 315,
-                            "openAppointmentSlots": 315,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 315,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 315,
+                    "openAppointmentSlots": 0,
                     "name": "San Benito H-E-B",
                     "longitude": -97.63395,
                     "latitude": 26.14392,
                     "fluUrl": "",
                     "city": "SAN BENITO",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77478-4947",
@@ -6679,22 +6604,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 21,
-                            "openAppointmentSlots": 21,
+                            "openTimeslots": 154,
+                            "openAppointmentSlots": 154,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 21,
+                    "openTimeslots": 154,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 21,
+                    "openAppointmentSlots": 154,
                     "name": "Sugar Land Market H-E-B",
                     "longitude": -95.64596,
                     "latitude": 29.60871,
                     "fluUrl": "",
                     "city": "SUGAR LAND",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -6725,15 +6651,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 22,
-                            "openAppointmentSlots": 22,
+                            "openTimeslots": 119,
+                            "openAppointmentSlots": 119,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 22,
+                    "openTimeslots": 119,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 22,
+                    "openAppointmentSlots": 119,
                     "name": "Spring Green Market H-E-B",
                     "longitude": -95.81427,
                     "latitude": 29.69558,
@@ -6744,7 +6670,8 @@
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -6756,23 +6683,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 91,
-                            "openAppointmentSlots": 91,
+                            "openTimeslots": 142,
+                            "openAppointmentSlots": 142,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 91,
+                    "openTimeslots": 142,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 91,
+                    "openAppointmentSlots": 142,
                     "name": "New Braunfels H-E-B at Hwy 46",
                     "longitude": -98.16041,
                     "latitude": 29.71309,
                     "fluUrl": "",
                     "city": "NEW BRAUNFELS",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -6784,15 +6712,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 762,
-                            "openAppointmentSlots": 762,
+                            "openTimeslots": 1276,
+                            "openAppointmentSlots": 1276,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 762,
+                    "openTimeslots": 1276,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 762,
+                    "openAppointmentSlots": 1276,
                     "name": "Zarzamora and Military H-E-B plus!",
                     "longitude": -98.5339,
                     "latitude": 29.35787,
@@ -6836,15 +6764,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 109,
-                            "openAppointmentSlots": 109,
+                            "openTimeslots": 57,
+                            "openAppointmentSlots": 57,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 109,
+                    "openTimeslots": 57,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 109,
+                    "openAppointmentSlots": 57,
                     "name": "Kerrville H-E-B On Main Street",
                     "longitude": -99.14287,
                     "latitude": 30.05056,
@@ -6863,46 +6791,59 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 282,
-                            "openAppointmentSlots": 282,
+                            "openTimeslots": 94,
+                            "openAppointmentSlots": 94,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 135,
-                    "openFluTimeslots": 147,
-                    "openFluAppointmentSlots": 147,
-                    "openAppointmentSlots": 135,
+                    "openTimeslots": 94,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 94,
                     "name": "Riverside H-E-B plus!",
                     "longitude": -97.72401,
                     "latitude": 30.23547,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4qQAE",
+                    "fluUrl": "",
                     "city": "AUSTIN",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "77904-1767",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuajQAC",
                     "type": "store",
                     "street": "6106 N. NAVARRO",
                     "storeNumber": 92,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 145,
+                            "openAppointmentSlots": 145,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 145,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 145,
                     "name": "Victoria H-E-B plus!",
                     "longitude": -96.99736,
                     "latitude": 28.85159,
                     "fluUrl": "",
                     "city": "VICTORIA",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Janssen",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Novavax",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77055-6209",
@@ -6913,15 +6854,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 456,
-                            "openAppointmentSlots": 456,
+                            "openTimeslots": 436,
+                            "openAppointmentSlots": 436,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 356,
-                    "openFluTimeslots": 100,
-                    "openFluAppointmentSlots": 100,
-                    "openAppointmentSlots": 356,
+                    "openTimeslots": 391,
+                    "openFluTimeslots": 45,
+                    "openFluAppointmentSlots": 45,
+                    "openAppointmentSlots": 391,
                     "name": "Bunker Hill H-E-B",
                     "longitude": -95.53206,
                     "latitude": 29.78485,
@@ -6929,13 +6870,15 @@
                     "city": "HOUSTON",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
                         "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pfizer",
-                        "COVID-19 Novavax",
                         "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Pediatric_Pfizer"
+                        "COVID-19 Novavax",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -6947,15 +6890,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 30,
-                            "openAppointmentSlots": 30,
+                            "openTimeslots": 107,
+                            "openAppointmentSlots": 107,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 30,
+                    "openTimeslots": 107,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 30,
+                    "openAppointmentSlots": 107,
                     "name": "Sienna Market H-E-B",
                     "longitude": -95.53497,
                     "latitude": 29.53928,
@@ -6963,39 +6906,28 @@
                     "city": "MISSOURI CITY",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "78550-7708",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuauQAC",
+                    "url": null,
                     "type": "store",
                     "street": "1213 S. COMMERCE",
                     "storeNumber": 136,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 14,
-                            "openAppointmentSlots": 14,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 14,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 14,
+                    "openAppointmentSlots": 0,
                     "name": "Southland and 12th St H-E-B",
                     "longitude": -97.68171,
                     "latitude": 26.18251,
                     "fluUrl": "",
                     "city": "HARLINGEN",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Janssen"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78413-3966",
@@ -7006,101 +6938,90 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 110,
-                            "openAppointmentSlots": 110,
+                            "openTimeslots": 44,
+                            "openAppointmentSlots": 44,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 91,
-                    "openFluTimeslots": 19,
-                    "openFluAppointmentSlots": 19,
-                    "openAppointmentSlots": 91,
+                    "openTimeslots": 44,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 44,
                     "name": "Weber and Holly H-E-B",
                     "longitude": -97.40529,
                     "latitude": 27.71118,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF0dQAE",
+                    "fluUrl": "",
                     "city": "CORPUS CHRISTI",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "Flu"
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "78723-2924",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuawQAC",
+                    "url": null,
                     "type": "store",
                     "street": "7112 ED BLUESTEIN_#125",
                     "storeNumber": 161,
-                    "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 69,
-                            "openAppointmentSlots": 69,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 69,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 69,
-                    "name": "Ed Bluestein H-E-B",
-                    "longitude": -97.66465,
-                    "latitude": 30.31211,
-                    "fluUrl": "",
-                    "city": "AUSTIN",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
-                },
-                {
-                    "zip": "78232-3714",
-                    "url": null,
-                    "type": "store",
-                    "street": "15000 SAN PEDRO",
-                    "storeNumber": 164,
                     "state": "TX",
                     "slotDetails": [],
                     "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
                     "openAppointmentSlots": 0,
+                    "name": "Ed Bluestein H-E-B",
+                    "longitude": -97.66465,
+                    "latitude": 30.31211,
+                    "fluUrl": "",
+                    "city": "AUSTIN",
+                    "availableImmunizations": null
+                },
+                {
+                    "zip": "78232-3714",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaxQAC",
+                    "type": "store",
+                    "street": "15000 SAN PEDRO",
+                    "storeNumber": 164,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 77,
+                            "openAppointmentSlots": 77,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 77,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 77,
                     "name": "Brook Hollow H-E-B",
                     "longitude": -98.47734,
                     "latitude": 29.5774,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78572-8354",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuakQAC",
+                    "url": null,
                     "type": "store",
                     "street": "2409 EAST EXPRESSWAY 83",
                     "storeNumber": 94,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 25,
-                            "openAppointmentSlots": 25,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 25,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 25,
+                    "openAppointmentSlots": 0,
                     "name": "Mission H-E-B plus!",
                     "longitude": -98.28628,
                     "latitude": 26.19755,
                     "fluUrl": "",
                     "city": "MISSION",
-                    "availableImmunizations": [
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Ultra_Pediatric_Pfizer"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78045-6596",
@@ -7111,15 +7032,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 35,
-                            "openAppointmentSlots": 35,
+                            "openTimeslots": 34,
+                            "openAppointmentSlots": 34,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 35,
+                    "openTimeslots": 34,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 35,
+                    "openAppointmentSlots": 34,
                     "name": "Laredo H-E-B plus!",
                     "longitude": -99.47435,
                     "latitude": 27.60863,
@@ -7130,40 +7051,28 @@
                         "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "78731-3023",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuamQAC",
+                    "url": null,
                     "type": "store",
                     "street": "7015 VILLAGE CTR DR.",
                     "storeNumber": 96,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 362,
-                            "openAppointmentSlots": 362,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 362,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 362,
+                    "openAppointmentSlots": 0,
                     "name": "Far West H-E-B",
                     "longitude": -97.75598,
                     "latitude": 30.35289,
                     "fluUrl": "",
                     "city": "AUSTIN",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77070-1667",
@@ -7174,15 +7083,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 216,
-                            "openAppointmentSlots": 216,
+                            "openTimeslots": 235,
+                            "openAppointmentSlots": 235,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 216,
+                    "openTimeslots": 235,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 216,
+                    "openAppointmentSlots": 235,
                     "name": "Vintage Park Market H-E-B",
                     "longitude": -95.57661,
                     "latitude": 29.9967,
@@ -7190,11 +7099,9 @@
                     "city": "HOUSTON",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pfizer"
                     ]
                 },
                 {
@@ -7206,15 +7113,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 710,
-                            "openAppointmentSlots": 710,
+                            "openTimeslots": 259,
+                            "openAppointmentSlots": 259,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 710,
+                    "openTimeslots": 259,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 710,
+                    "openAppointmentSlots": 259,
                     "name": "Alon Market H-E-B",
                     "longitude": -98.53463,
                     "latitude": 29.55254,
@@ -7235,19 +7142,19 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 24,
-                            "openAppointmentSlots": 24,
+                            "openTimeslots": 9,
+                            "openAppointmentSlots": 9,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 10,
-                    "openFluTimeslots": 14,
-                    "openFluAppointmentSlots": 14,
-                    "openAppointmentSlots": 10,
+                    "openTimeslots": 9,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 9,
                     "name": "Brodie Lane H-E-B",
                     "longitude": -97.83076,
                     "latitude": 30.21489,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2iQAE",
+                    "fluUrl": "",
                     "city": "AUSTIN",
                     "availableImmunizations": [
                         "Flu",
@@ -7282,15 +7189,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 29,
-                            "openAppointmentSlots": 29,
+                            "openTimeslots": 82,
+                            "openAppointmentSlots": 82,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 29,
+                    "openTimeslots": 82,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 29,
+                    "openAppointmentSlots": 82,
                     "name": "Montrose Market H-E-B",
                     "longitude": -95.40284,
                     "latitude": 29.7379,
@@ -7298,34 +7205,37 @@
                     "city": "HOUSTON",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Janssen"
                     ]
                 },
                 {
                     "zip": "76049-7428",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudcQAC",
                     "type": "store",
                     "street": "3804 US HWY 377",
                     "storeNumber": 631,
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 98,
-                            "openAppointmentSlots": 98,
+                            "openTimeslots": 124,
+                            "openAppointmentSlots": 124,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 0,
+                    "openTimeslots": 26,
                     "openFluTimeslots": 98,
                     "openFluAppointmentSlots": 98,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 26,
                     "name": "Granbury H-E-B",
                     "longitude": -97.73026,
                     "latitude": 32.45528,
                     "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4ZQAU",
                     "city": "GRANBURY",
                     "availableImmunizations": [
-                        "Flu"
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -7353,7 +7263,8 @@
                     "city": "THE WOODLANDS",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -7377,31 +7288,22 @@
                 },
                 {
                     "zip": "78629-2406",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudfQAC",
+                    "url": null,
                     "type": "store",
                     "street": "1841 CHURCH ST.",
                     "storeNumber": 641,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 32,
-                            "openAppointmentSlots": 32,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 32,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 32,
+                    "openAppointmentSlots": 0,
                     "name": "Gonzales H-E-B",
                     "longitude": -97.45202,
                     "latitude": 29.51832,
                     "fluUrl": "",
                     "city": "GONZALES",
-                    "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "Flu"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78577-6293",
@@ -7424,31 +7326,22 @@
                 },
                 {
                     "zip": "78415-5021",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudhQAC",
+                    "url": null,
                     "type": "store",
                     "street": "4444 KOSTORYZ",
                     "storeNumber": 643,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 10,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 10,
+                    "openAppointmentSlots": 0,
                     "name": "Kostoryz and Gollihar H-E-B",
                     "longitude": -97.40516,
                     "latitude": 27.73917,
                     "fluUrl": "",
                     "city": "CORPUS CHRISTI",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77803-1828",
@@ -7509,38 +7402,22 @@
                 },
                 {
                     "zip": "78550-5152",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuayQAC",
+                    "url": null,
                     "type": "store",
                     "street": "1103 MORGAN BLVD",
                     "storeNumber": 168,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 117,
-                            "openAppointmentSlots": 117,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 117,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 117,
+                    "openAppointmentSlots": 0,
                     "name": "Morgan and Grimes H-E-B",
                     "longitude": -97.67639,
                     "latitude": 26.20337,
                     "fluUrl": "",
                     "city": "HARLINGEN",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
-                        "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Novavax",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78539-5664",
@@ -7551,15 +7428,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 12,
-                            "openAppointmentSlots": 12,
+                            "openTimeslots": 18,
+                            "openAppointmentSlots": 18,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 12,
+                    "openTimeslots": 18,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 12,
+                    "openAppointmentSlots": 18,
                     "name": "Closner and Baker H-E-B",
                     "longitude": -98.1642,
                     "latitude": 26.29029,
@@ -7580,25 +7457,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 133,
-                            "openAppointmentSlots": 133,
+                            "openTimeslots": 63,
+                            "openAppointmentSlots": 63,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 133,
+                    "openTimeslots": 63,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 133,
+                    "openAppointmentSlots": 63,
                     "name": "San Pedro and Oblate H-E-B",
                     "longitude": -98.4995,
                     "latitude": 29.50282,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
-                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
@@ -7630,23 +7506,29 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 431,
-                            "openAppointmentSlots": 431,
+                            "openTimeslots": 807,
+                            "openAppointmentSlots": 807,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 214,
-                    "openFluTimeslots": 217,
-                    "openFluAppointmentSlots": 217,
-                    "openAppointmentSlots": 214,
+                    "openTimeslots": 807,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 807,
                     "name": "Lamar and Rundberg H-E-B",
                     "longitude": -97.69689,
                     "latitude": 30.36357,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF0kQAE",
+                    "fluUrl": "",
                     "city": "AUSTIN",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "Flu"
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Novavax",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -7658,23 +7540,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 23,
-                            "openAppointmentSlots": 23,
+                            "openTimeslots": 28,
+                            "openAppointmentSlots": 28,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 23,
+                    "openTimeslots": 28,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 23,
+                    "openAppointmentSlots": 28,
                     "name": "Leopard and Violet H-E-B",
                     "longitude": -97.58473,
                     "latitude": 27.84494,
                     "fluUrl": "",
                     "city": "CORPUS CHRISTI",
                     "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -7705,25 +7587,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 164,
-                            "openAppointmentSlots": 164,
+                            "openTimeslots": 191,
+                            "openAppointmentSlots": 191,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 69,
-                    "openFluTimeslots": 95,
-                    "openFluAppointmentSlots": 95,
-                    "openAppointmentSlots": 69,
+                    "openTimeslots": 191,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 191,
                     "name": "Slaughter and South Congress H-E-B",
                     "longitude": -97.78723,
                     "latitude": 30.16862,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF5CQAU",
+                    "fluUrl": "",
                     "city": "AUSTIN",
                     "availableImmunizations": [
+                        "COVID-19 Moderna",
                         "Flu",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer"
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer"
                     ]
                 },
                 {
@@ -7735,43 +7618,58 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 40,
-                            "openAppointmentSlots": 40,
+                            "openTimeslots": 282,
+                            "openAppointmentSlots": 282,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 40,
+                    "openTimeslots": 282,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 40,
+                    "openAppointmentSlots": 282,
                     "name": "W. W. White H-E-B",
                     "longitude": -98.40568,
                     "latitude": 29.41476,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
+                        "COVID-19 Moderna_Updated_Booster",
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pfizer"
                     ]
                 },
                 {
                     "zip": "75119-4519",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaqQAC",
                     "type": "store",
                     "street": "101 S. CLAY ST",
                     "storeNumber": 107,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 98,
+                            "openAppointmentSlots": 98,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 98,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 98,
                     "name": "Ennis H-E-B",
                     "longitude": -96.63251,
                     "latitude": 32.32542,
                     "fluUrl": "",
                     "city": "ENNIS",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Janssen",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78258-7587",
@@ -7782,24 +7680,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 310,
-                            "openAppointmentSlots": 310,
+                            "openTimeslots": 99,
+                            "openAppointmentSlots": 99,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 110,
-                    "openFluTimeslots": 200,
-                    "openFluAppointmentSlots": 200,
-                    "openAppointmentSlots": 110,
+                    "openTimeslots": 99,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 99,
                     "name": "281 and Evans Road H-E-B plus!",
                     "longitude": -98.45756,
                     "latitude": 29.63886,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4zQAE",
+                    "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
                         "Flu",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -7811,27 +7708,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 840,
-                            "openAppointmentSlots": 840,
+                            "openTimeslots": 2748,
+                            "openAppointmentSlots": 2748,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 840,
+                    "openTimeslots": 2748,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 840,
+                    "openAppointmentSlots": 2748,
                     "name": "Fairfield Market H-E-B",
                     "longitude": -95.74599,
                     "latitude": 29.9925,
                     "fluUrl": "",
                     "city": "CYPRESS",
                     "availableImmunizations": [
+                        "COVID-19 Moderna_Updated_Booster",
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -7843,25 +7739,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 824,
-                            "openAppointmentSlots": 824,
+                            "openTimeslots": 257,
+                            "openAppointmentSlots": 257,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 824,
+                    "openTimeslots": 257,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 824,
+                    "openAppointmentSlots": 257,
                     "name": "Jones and West H-E-B",
                     "longitude": -95.5859,
                     "latitude": 29.91104,
                     "fluUrl": "",
                     "city": "HOUSTON",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer",
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer"
+                        "COVID-19 Moderna"
                     ]
                 },
                 {
@@ -7873,24 +7767,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 54,
-                            "openAppointmentSlots": 54,
+                            "openTimeslots": 78,
+                            "openAppointmentSlots": 78,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 25,
-                    "openFluTimeslots": 29,
-                    "openFluAppointmentSlots": 29,
-                    "openAppointmentSlots": 25,
+                    "openTimeslots": 78,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 78,
                     "name": "The Market at Stone Oak",
                     "longitude": -98.50062,
                     "latitude": 29.662,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4kQAE",
+                    "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster",
                         "Flu",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -7902,23 +7796,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 9,
-                            "openAppointmentSlots": 9,
+                            "openTimeslots": 10,
+                            "openAppointmentSlots": 10,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 1,
-                    "openFluTimeslots": 8,
-                    "openFluAppointmentSlots": 8,
-                    "openAppointmentSlots": 1,
+                    "openTimeslots": 4,
+                    "openFluTimeslots": 6,
+                    "openFluAppointmentSlots": 6,
+                    "openAppointmentSlots": 4,
                     "name": "Lakeline H-E-B plus!",
                     "longitude": -97.8034,
                     "latitude": 30.47786,
                     "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4lQAE",
                     "city": "AUSTIN",
                     "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu"
                     ]
                 },
                 {
@@ -7935,28 +7829,30 @@
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 391,
-                            "openAppointmentSlots": 391,
+                            "openTimeslots": 392,
+                            "openAppointmentSlots": 392,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 1028,
-                            "openAppointmentSlots": 1028,
+                            "openTimeslots": 1026,
+                            "openAppointmentSlots": 1026,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 1769,
+                    "openTimeslots": 1768,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 1769,
+                    "openAppointmentSlots": 1768,
                     "name": "Conroe Market H-E-B",
                     "longitude": -95.49817,
                     "latitude": 30.32647,
                     "fluUrl": "",
                     "city": "CONROE",
                     "availableImmunizations": [
+                        "COVID-19 Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna",
                         "Flu"
                     ]
                 },
@@ -7969,15 +7865,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 167,
-                            "openAppointmentSlots": 167,
+                            "openTimeslots": 489,
+                            "openAppointmentSlots": 489,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 167,
+                    "openTimeslots": 489,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 167,
+                    "openAppointmentSlots": 489,
                     "name": "Texas City H-E-B",
                     "longitude": -94.94893,
                     "latitude": 29.39535,
@@ -7987,7 +7883,8 @@
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer"
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -8018,15 +7915,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 570,
-                            "openAppointmentSlots": 570,
+                            "openTimeslots": 196,
+                            "openAppointmentSlots": 196,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 570,
+                    "openTimeslots": 196,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 570,
+                    "openAppointmentSlots": 196,
                     "name": "Broadway Central Market",
                     "longitude": -98.46408,
                     "latitude": 29.47069,
@@ -8034,12 +7931,11 @@
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
                         "COVID-19 Moderna",
-                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Janssen",
                         "Flu",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Janssen"
                     ]
                 },
                 {
@@ -8068,25 +7964,17 @@
                     "street": "2030 N. 1ST STREET",
                     "storeNumber": 671,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 20,
-                            "openAppointmentSlots": 20,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
+                    "slotDetails": [],
                     "openTimeslots": 0,
-                    "openFluTimeslots": 20,
-                    "openFluAppointmentSlots": 20,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
                     "openAppointmentSlots": 0,
                     "name": "Carrizo Springs H-E-B",
                     "longitude": -99.85102,
                     "latitude": 28.53642,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF53QAE",
+                    "fluUrl": "",
                     "city": "CARRIZO SPRINGS",
-                    "availableImmunizations": [
-                        "Flu"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "76711-2119",
@@ -8097,15 +7985,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 78,
-                            "openAppointmentSlots": 78,
+                            "openTimeslots": 85,
+                            "openAppointmentSlots": 85,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 78,
+                    "openTimeslots": 85,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 78,
+                    "openAppointmentSlots": 85,
                     "name": "Valley Mills H-E-B plus!",
                     "longitude": -97.13916,
                     "latitude": 31.52508,
@@ -8115,13 +8003,12 @@
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Janssen",
                         "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
                         "COVID-19 Novavax",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Janssen",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -8133,25 +8020,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 84,
-                            "openAppointmentSlots": 84,
+                            "openTimeslots": 7,
+                            "openAppointmentSlots": 7,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 79,
-                    "openFluTimeslots": 5,
-                    "openFluAppointmentSlots": 5,
-                    "openAppointmentSlots": 79,
+                    "openTimeslots": 7,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 7,
                     "name": "University Blvd H-E-B",
                     "longitude": -97.68859,
                     "latitude": 30.56107,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF55QAE",
+                    "fluUrl": "",
                     "city": "ROUND ROCK",
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
                         "COVID-19 Novavax",
@@ -8168,15 +8053,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 36,
-                            "openAppointmentSlots": 36,
+                            "openTimeslots": 44,
+                            "openAppointmentSlots": 44,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 36,
+                    "openTimeslots": 44,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 36,
+                    "openAppointmentSlots": 44,
                     "name": "Palmhurst H-E-B",
                     "longitude": -98.31816,
                     "latitude": 26.25684,
@@ -8184,9 +8069,8 @@
                     "city": "PALMHURST",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer"
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -8198,15 +8082,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 340,
-                            "openAppointmentSlots": 340,
+                            "openTimeslots": 337,
+                            "openAppointmentSlots": 337,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 340,
+                    "openTimeslots": 337,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 340,
+                    "openAppointmentSlots": 337,
                     "name": "Pearland Market H-E-B",
                     "longitude": -95.26499,
                     "latitude": 29.55812,
@@ -8215,8 +8099,8 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
@@ -8267,25 +8151,30 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 164,
-                            "openAppointmentSlots": 164,
+                            "openTimeslots": 162,
+                            "openAppointmentSlots": 162,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 164,
+                    "openTimeslots": 162,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 164,
+                    "openAppointmentSlots": 162,
                     "name": "Frisco H-E-B",
                     "longitude": -96.84583,
                     "latitude": 33.15458,
                     "fluUrl": "",
                     "city": "FRISCO",
                     "availableImmunizations": [
+                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
                         "COVID-19 Janssen",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Novavax"
+                        "COVID-19 Novavax",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 }
             ]
@@ -8294,15 +8183,15 @@
             "Content-Type",
             "binary/octet-stream",
             "Content-Length",
-            "180218",
+            "175054",
             "Connection",
             "close",
             "Date",
-            "Fri, 23 Sep 2022 01:57:11 GMT",
+            "Wed, 05 Oct 2022 22:47:32 GMT",
             "Last-Modified",
-            "Fri, 23 Sep 2022 01:56:21 GMT",
+            "Wed, 05 Oct 2022 22:47:19 GMT",
             "ETag",
-            "\"263e5e82603e9bd09b12d6a0a2c1149d\"",
+            "\"307b0a3d351db28f64060f105a537870\"",
             "Cache-Control",
             "max-age:0",
             "Accept-Ranges",
@@ -8312,11 +8201,11 @@
             "X-Cache",
             "Miss from cloudfront",
             "Via",
-            "1.1 912d83c7c9b4676eb19f09c9bfabda24.cloudfront.net (CloudFront)",
+            "1.1 5e3db235184770510999a272e515dfbc.cloudfront.net (CloudFront)",
             "X-Amz-Cf-Pop",
-            "SFO5-P2",
+            "SFO5-P1",
             "X-Amz-Cf-Id",
-            "5H74alGnsTF52Qe5IIQpcYxFhO5OyF-XFxFA-K7tugjBkGx-2ncgIw=="
+            "YUy2f7PdC4LyMEnXEd_vUetSx4_F-bWzr0V-A7DEvp3kmp_rCjHvYQ=="
         ],
         "responseIsBinary": false
     }

--- a/server/public/docs/openapi.yaml
+++ b/server/public/docs/openapi.yaml
@@ -550,9 +550,9 @@ components:
           description: |
             List of vaccine products available on this date. Not present if not
             known. Current possible values include: `moderna`, `moderna_ba4_ba5`,
-            `moderna_age_6_11`, `moderna_age_0_5`, `pfizer`, `pfizer_ba4_ba5`,
-            `pfizer_age_5_11`, `pfizer_ba4_ba5_age_5_11`, `pfizer_age_0_4`,
-            `jj`, `sanofi`.
+            `moderna_age_6_11`, `moderna_ba4_ba5_age_6_11`, `moderna_age_0_5`,
+            `pfizer`, `pfizer_ba4_ba5`, `pfizer_age_5_11`,
+            `pfizer_ba4_ba5_age_5_11`, `pfizer_age_0_4`, `jj`, `sanofi`.
         dose:
           type: string
           description: |
@@ -603,9 +603,9 @@ components:
           description: |
             List of vaccine products available for this slot. Not present if not
             known. Current possible values include: `moderna`, `moderna_ba4_ba5`,
-            `moderna_age_6_11`, `moderna_age_0_5`, `pfizer`, `pfizer_ba4_ba5`,
-            `pfizer_age_5_11`, `pfizer_ba4_ba5_age_5_11`, `pfizer_age_0_4`,
-            `jj`, `sanofi`.
+            `moderna_age_6_11`, `moderna_ba4_ba5_age_6_11`, `moderna_age_0_5`,
+            `pfizer`, `pfizer_ba4_ba5`, `pfizer_age_5_11`,
+            `pfizer_ba4_ba5_age_5_11`, `pfizer_age_0_4`, `jj`, `sanofi`.
         dose:
           type: string
           description: |
@@ -668,9 +668,9 @@ components:
           description: |
             List of vaccine products available. Not present if not known.
             Current possible values include: `moderna`, `moderna_ba4_ba5`,
-            `moderna_age_6_11`, `moderna_age_0_5`, `pfizer`, `pfizer_ba4_ba5`,
-            `pfizer_age_5_11`, `pfizer_ba4_ba5_age_5_11`, `pfizer_age_0_4`,
-            `jj`, `sanofi`.
+            `moderna_age_6_11`, `moderna_ba4_ba5_age_6_11`, `moderna_age_0_5`,
+            `pfizer`, `pfizer_ba4_ba5`, `pfizer_age_5_11`,
+            `pfizer_ba4_ba5_age_5_11`, `pfizer_age_0_4`, `jj`, `sanofi`.
         doses:
           type: array
           items:

--- a/server/src/vaccines.ts
+++ b/server/src/vaccines.ts
@@ -4,6 +4,7 @@ export type VaccineCode =
   | "moderna"
   | "moderna_ba4_ba5"
   | "moderna_age_6_11"
+  | "moderna_ba4_ba5_age_6_11"
   | "moderna_age_0_5"
   | "novavax"
   | "pfizer"
@@ -20,6 +21,7 @@ export const CVX_CODES: { [code in VaccineCode]: number } = {
   moderna: 207,
   moderna_ba4_ba5: 229,
   moderna_age_6_11: 227,
+  moderna_ba4_ba5_age_6_11: 229,
   moderna_age_0_5: 228,
   novavax: 211,
   pfizer: 208,
@@ -36,6 +38,8 @@ export const PRODUCT_NAMES: { [code in VaccineCode]: string } = {
   moderna: "Moderna",
   moderna_ba4_ba5: "Moderna (for Omicron BA.4/BA.5)",
   moderna_age_6_11: "Moderna Pediatric (Ages 6-11)",
+  moderna_ba4_ba5_age_6_11:
+    "Moderna Pediatric (Ages 6-11, for Omicron BA.4/BA.5)",
   moderna_age_0_5: "Moderna Pediatric (Ages 0-5)",
   novavax: "NovaVax",
   pfizer: "Pfizer",
@@ -55,6 +59,7 @@ export const MINIMUM_PRODUCT_AGES: { [code in VaccineCode]: number } = {
   // only authorized for 18+.
   moderna_ba4_ba5: 18 * 12,
   moderna_age_6_11: 6 * 12,
+  moderna_ba4_ba5_age_6_11: 6 * 12,
   moderna_age_0_5: 6,
   novavax: 18 * 12,
   pfizer: 12 * 12,


### PR DESCRIPTION
H-E-B has started listing bivalent pediatric vaccines from Pfizer and Moderna (the CDC still shows the Moderna one as pre-EUA authorization, but maybe the site is out of date?) and this adds support. It's a little more complex than it might otherwise be since it is also adding a whole new vaccine type.

Fixes https://sentry.io/organizations/usdr/issues/3647682660 and https://sentry.io/organizations/usdr/issues/3647764297.