### PR TITLE
Handle MMR vaccines listed in PrepMod

### DIFF
--- a/loader/src/sources/prepmod/index.js
+++ b/loader/src/sources/prepmod/index.js
@@ -265,8 +265,12 @@ const nonCovidProductName = new RegExp(
     raw`monkeypox`,
     raw`jynneos`,
     raw`\btdap\b`,
+    // Pneumococcal Conjugate Vaccine
     raw`\bPCV(\d+)?\b`,
+    // Pneumococcal Polysaccharide Vaccine
     raw`\bPPSV(\d+)?\b`,
+    // Measles, Mumps, Rubella Vaccine
+    raw`\bMMRV??\b`,
     // In all cases we've seen, this occurs on schedules that list other actual
     // vaccine names as well. We'll pick up the true products from the other
     // extensions in the schedule.


### PR DESCRIPTION
Washington is now listing MMR vaccines in PrepMod, and we need to ignore those since they are unrelated to COVID.

Fixes https://sentry.io/organizations/usdr/issues/3653923079.