### PR TITLE
AWS again: Reinstate networks and bastion

### DIFF
--- a/terraform/bastion.tf
+++ b/terraform/bastion.tf
@@ -1,0 +1,28 @@
+# Bastion Server
+#
+# To access to services running on a private subnet, you can SSH into the
+# "bastion" server (which is in one of the public subnets and can see into the
+# private ones) and do your work from that SSH session.
+#
+# The bastion server itself is manually created, and uses this security group.
+resource "aws_security_group" "bastion_security_group" {
+
+  name        = "bastion-security"
+  description = "Allows SSH access to bastion server"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description = ""
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/terraform/networks.tf
+++ b/terraform/networks.tf
@@ -1,0 +1,78 @@
+# Network Configuration
+#
+# This creates one VPC for all services, with one public and one private subnet
+# in each availability zone (how many zones comes from the `az_count` variable).
+# Services that don't need to be reachable from the public internet (database,
+# loaders, etc.) run in the private networks.
+
+# Fetch AZs in the current region
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc" "main" {
+  cidr_block = "172.17.0.0/16"
+}
+
+
+# Public Network --------------------------------------------------------------
+
+resource "aws_subnet" "public" {
+  count                   = var.az_count
+  cidr_block              = cidrsubnet(aws_vpc.main.cidr_block, 8, var.az_count + count.index)
+  availability_zone       = data.aws_availability_zones.available.names[count.index]
+  vpc_id                  = aws_vpc.main.id
+  map_public_ip_on_launch = true
+}
+
+resource "aws_internet_gateway" "gw" {
+  vpc_id = aws_vpc.main.id
+}
+
+# Route the public subnet traffic through the internet gateway above.
+resource "aws_route" "internet_access" {
+  route_table_id         = aws_vpc.main.main_route_table_id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.gw.id
+}
+
+
+# Private Network -------------------------------------------------------------
+
+resource "aws_subnet" "private" {
+  count             = var.az_count
+  cidr_block        = cidrsubnet(aws_vpc.main.cidr_block, 8, count.index)
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  vpc_id            = aws_vpc.main.id
+}
+
+# Each subnet needs a NAT gateway with an elastic IP so services get internet
+# connectivity.
+resource "aws_eip" "gw" {
+  count      = var.az_count
+  vpc        = true
+  depends_on = [aws_internet_gateway.gw]
+}
+
+resource "aws_nat_gateway" "gw" {
+  count         = var.az_count
+  subnet_id     = element(aws_subnet.public.*.id, count.index)
+  allocation_id = element(aws_eip.gw.*.id, count.index)
+}
+
+# Route non-local traffic through the NAT gateway to the internet
+resource "aws_route_table" "private" {
+  count  = var.az_count
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = element(aws_nat_gateway.gw.*.id, count.index)
+  }
+}
+
+# Explicitly associate the newly created route tables to the private subnets.
+# (Otherwise they't default to the main route table.)
+resource "aws_route_table_association" "private" {
+  count          = var.az_count
+  subnet_id      = element(aws_subnet.private.*.id, count.index)
+  route_table_id = element(aws_route_table.private.*.id, count.index)
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -3,6 +3,11 @@ variable "aws_region" {
   default     = "us-west-2"
 }
 
+variable "az_count" {
+  description = "Number of AZs to cover (within the chosen region)"
+  default     = 2
+}
+
 variable "ssl_certificate_arn" {
   description = "To enable HTTPS, the ARN of an SSL certificate created with ACM in us-east-1"
   default     = ""


### PR DESCRIPTION
This re-instates the old public/private network setup and bastion security group on AWS. I combined all network configuration into a single file this time (makes more sense to me) and tried to add more clearly explanatory comments. I'm not sure I got the network stuff 100% right (this is the part of AWS I have the most trouble with, TBH), but this matches what I understand from the previous comments.