### PR TITLE
Upgrade Terraform from v1.2.8 to v1.3.2

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.2.8"
+  required_version = "~> 1.3.2"
 
   required_providers {
     aws = {


### PR DESCRIPTION
Noticed we are behind while updating AWS stuff. I figured our Dependabot configuration would make this automatic, but apparently not.