### PR TITLE
AWS again: reinstate database

### DIFF
--- a/terraform/db.tf
+++ b/terraform/db.tf
@@ -1,0 +1,23 @@
+
+module "db" {
+  source = "./modules/rds"
+
+  name     = "univaf-db"
+  database = "univaf" # RDS does not allow hyphens
+  password = var.db_password
+  username = var.db_user
+
+  allocated_storage            = var.db_size
+  instance_class               = var.db_instance
+  engine                       = "postgres"
+  engine_version               = "14"
+  performance_insights_enabled = true
+
+  vpc_id     = aws_vpc.main.id
+  subnet_ids = aws_subnet.private[*].id
+  ingress_allow_security_groups = compact([
+    # TODO: allow access from ECS once we've set it up again.
+    # aws_security_group.ecs_tasks.id,
+    aws_security_group.bastion_security_group.id
+  ])
+}

--- a/terraform/modules/rds/main.tf
+++ b/terraform/modules/rds/main.tf
@@ -1,0 +1,89 @@
+
+resource "aws_security_group" "main" {
+  name        = "${var.name}-rds"
+  description = "Allows traffic to RDS from other security groups"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port       = var.port
+    to_port         = var.port
+    protocol        = "TCP"
+    security_groups = var.ingress_allow_security_groups
+  }
+
+  ingress {
+    from_port   = var.port
+    to_port     = var.port
+    protocol    = "TCP"
+    cidr_blocks = var.ingress_allow_cidr_blocks
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = -1
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "RDS (${var.name})"
+  }
+}
+
+resource "aws_db_subnet_group" "main" {
+  name        = var.name
+  description = "RDS subnet group"
+  subnet_ids  = var.subnet_ids
+}
+
+resource "aws_db_instance" "main" {
+  identifier = var.name
+
+  # Database
+  engine                       = var.engine
+  engine_version               = var.engine_version
+  allow_major_version_upgrade  = var.allow_major_version_upgrade
+  username                     = coalesce(var.username, var.name)
+  password                     = var.password
+  multi_az                     = var.multi_az
+  db_name                      = coalesce(var.database, var.name)
+  performance_insights_enabled = var.performance_insights_enabled
+
+  # Backups / maintenance
+  backup_retention_period   = var.backup_retention_period
+  backup_window             = var.backup_window
+  maintenance_window        = var.maintenance_window
+  monitoring_interval       = var.monitoring_interval
+  monitoring_role_arn       = var.monitoring_role_arn
+  apply_immediately         = var.apply_immediately
+  final_snapshot_identifier = "${var.name}-finalsnapshot"
+
+  # Hardware
+  instance_class    = var.instance_class
+  storage_type      = var.storage_type
+  allocated_storage = var.allocated_storage
+
+  # Network / security
+  db_subnet_group_name   = aws_db_subnet_group.main.id
+  vpc_security_group_ids = [aws_security_group.main.id]
+  publicly_accessible    = var.publicly_accessible
+}
+
+# Monitor critical metrics and send anomalies to SNS topic
+module "aws_db_instance_alarms" {
+  source            = "lorenzoaiello/rds-alarms/aws"
+  version           = "2.2.0"
+  db_instance_id    = aws_db_instance.main.id
+  db_instance_class = aws_db_instance.main.instance_class
+  actions_alarm     = [aws_sns_topic.alarms_sns.arn]
+  actions_ok        = [aws_sns_topic.alarms_sns.arn]
+
+  # Our basic behavior is bursty -- we send hundreds or thousands of updates
+  # in rapid succession every few minutes, so we expect to regularly go below
+  # 100% burst balance, but not *way* below.
+  disk_burst_balance_too_low_threshold = "80"
+}
+
+resource "aws_sns_topic" "alarms_sns" {
+  name = "aws-db-instance-alarms-topic"
+}

--- a/terraform/modules/rds/outputs.tf
+++ b/terraform/modules/rds/outputs.tf
@@ -1,0 +1,7 @@
+output "host" {
+  value = aws_db_instance.main.address
+}
+
+output "db_name" {
+  value = aws_db_instance.main.db_name
+}

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -1,0 +1,118 @@
+variable "name" {
+  description = "RDS instance name"
+}
+
+variable "engine" {
+  description = "Database engine: mysql, postgres, etc."
+  default     = "postgres"
+}
+
+variable "engine_version" {
+  description = "Database version"
+  default     = "13.1"
+}
+
+variable "port" {
+  description = "Port for database to listen on"
+  default     = 5432
+}
+
+variable "database" {
+  description = "The database name for the RDS instance (if not specified, `var.name` will be used)"
+  default     = ""
+}
+
+variable "username" {
+  description = "The username for the RDS instance (if not specified, `var.name` will be used)"
+  default     = ""
+}
+
+variable "password" {
+  description = "Postgres user password"
+}
+
+variable "multi_az" {
+  description = "If true, database will be placed in multiple AZs for HA"
+  default     = false
+}
+
+variable "backup_retention_period" {
+  description = "Backup retention, in days"
+  default     = 5
+}
+
+variable "backup_window" {
+  description = "Time window for backups."
+  default     = "00:00-01:00"
+}
+
+variable "maintenance_window" {
+  description = "Time window for maintenance."
+  default     = "Mon:01:00-Mon:02:00"
+}
+
+variable "monitoring_interval" {
+  description = "Seconds between enhanced monitoring metric collection. 0 disables enhanced monitoring."
+  default     = "0"
+}
+
+variable "monitoring_role_arn" {
+  description = "The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Required if monitoring_interval > 0."
+  default     = ""
+}
+
+variable "apply_immediately" {
+  description = "If false, apply changes during maintenance window"
+  default     = true
+}
+
+variable "allow_major_version_upgrade" {
+  description = "If true, major version upgrades are allowed"
+  default     = false
+}
+
+variable "instance_class" {
+  description = "Underlying instance type"
+  default     = "db.t2.micro"
+}
+
+variable "storage_type" {
+  description = "Storage type: standard, gp2, or io1"
+  default     = "gp2"
+}
+
+variable "allocated_storage" {
+  description = "Disk size, in GB"
+  default     = 10
+}
+
+variable "publicly_accessible" {
+  description = "If true, the RDS instance will be open to the internet"
+  default     = false
+}
+
+variable "vpc_id" {
+  description = "The VPC ID to use"
+}
+
+variable "ingress_allow_security_groups" {
+  description = "A list of security group IDs to allow traffic from"
+  type        = list(string)
+  default     = []
+}
+
+variable "ingress_allow_cidr_blocks" {
+  description = "A list of CIDR blocks to allow traffic from"
+  type        = list(string)
+  default     = []
+}
+
+variable "subnet_ids" {
+  description = "A list of subnet IDs"
+  type        = list(string)
+}
+
+variable "performance_insights_enabled" {
+  description = "Enable RDS performance insights"
+  default     = false
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -28,6 +28,26 @@ variable "data_snapshot_s3_bucket" {
   default     = "univaf-data-snapshots"
 }
 
+variable "db_user" {
+  description = "The database user"
+  default     = "univaf"
+}
+
+variable "db_password" {
+  description = "The password for the database instance, filled via Terraform"
+  sensitive   = true
+}
+
+variable "db_instance" {
+  description = "The instance type for the DB. Reference: https://aws.amazon.com/rds/instance-types/"
+  default     = "db.t4g.small"
+}
+
+variable "db_size" {
+  description = "The storage size for the DB (in Gigabytes)"
+  default     = 30
+}
+
 # These AWS variables are present to clean up warnings in terraform
 variable "AWS_SECRET_ACCESS_KEY" {
   default = ""


### PR DESCRIPTION
Recreate the database on AWS. This uses smaller default instance and disk size than we used to have, and is in-line with what we were using on Render (which seemed to work just fine). Should save a little on costs.