### PR TITLE
AWS again: reinstate API service on ECS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,9 +182,10 @@ jobs:
       - name: Build ${{ matrix.repository }}
         run: |
           IMAGE_NAME="dev/${ECR_REPOSITORY}:${IMAGE_TAG}"
-          docker build \
-            -t "${IMAGE_NAME}" \
-            -f ${{ matrix.dockerfile }} \
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --tag "${IMAGE_NAME}" \
+            --file "${{ matrix.dockerfile }}" \
             --build-arg RELEASE="${IMAGE_TAG}" \
             ${{ matrix.build_path }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,6 @@ jobs:
         run: |
           IMAGE_NAME="dev/${ECR_REPOSITORY}:${IMAGE_TAG}"
           docker buildx build \
-            --platform linux/amd64,linux/arm64 \
             --tag "${IMAGE_NAME}" \
             --file "${{ matrix.dockerfile }}" \
             --build-arg RELEASE="${IMAGE_TAG}" \

--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -44,6 +44,98 @@ resource "aws_cloudwatch_log_stream" "data_snapshot_log_stream" {
   log_group_name = aws_cloudwatch_log_group.data_snapshot_log_group.name
 }
 
+# API Service -----------------------------------------------------------------
+
+resource "aws_alb" "main" {
+  name                       = "api-load-balancer"
+  subnets                    = aws_subnet.public.*.id
+  security_groups            = [aws_security_group.lb.id]
+  drop_invalid_header_fields = true
+}
+
+resource "aws_alb_target_group" "api" {
+  name        = "api-target-group"
+  port        = var.api_port
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.main.id
+  target_type = "ip"
+
+  health_check {
+    healthy_threshold   = "3"
+    interval            = "30"
+    protocol            = "HTTP"
+    matcher             = "200"
+    timeout             = "3"
+    path                = var.api_health_check_path
+    unhealthy_threshold = "2"
+  }
+}
+
+# Redirect all traffic from the ALB to the target group
+resource "aws_alb_listener" "front_end" {
+  load_balancer_arn = aws_alb.main.id
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    target_group_arn = aws_alb_target_group.api.arn
+    type             = "forward"
+  }
+}
+
+resource "aws_alb_listener_rule" "redirect_www" {
+  listener_arn = aws_alb_listener.front_end.arn
+
+  condition {
+    host_header {
+      values = ["www.${var.domain_name}"]
+    }
+  }
+
+  action {
+    type = "redirect"
+
+    redirect {
+      host        = var.domain_name
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+module "api_task" {
+  source = "./modules/task"
+
+  name  = "api"
+  image = "${aws_ecr_repository.server_repository.repository_url}:${var.api_release_version}"
+  # FIXME: it's possible this isn't required (it's *technically* not)
+  # role = aws_iam_role.ecs_task_execution_role.arn
+  # Only certain CPU/Memory combinations are allowed. See:
+  # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html#fargate-tasks-size
+  cpu    = var.api_cpu
+  memory = var.api_memory
+  port   = var.api_port
+
+  # Enable Datadog
+  datadog_enabled = true
+  datadog_api_key = var.datadog_api_key
+
+  env_vars = {
+    RELEASE                   = var.api_release_version
+    DB_HOST                   = module.db.host
+    DB_NAME                   = module.db.db_name
+    DB_USERNAME               = var.db_user
+    DB_PASSWORD               = var.db_password
+    API_KEYS                  = join(",", var.api_keys)
+    SENTRY_DSN                = var.api_sentry_dsn
+    SENTRY_TRACES_SAMPLE_RATE = format("%.2f", var.api_sentry_traces_sample_rate)
+    PRIMARY_HOST              = var.domain_name
+  }
+
+  depends_on = [aws_alb_listener.front_end, aws_iam_role_policy_attachment.ecs_task_execution_role]
+}
+
 resource "aws_cloudwatch_log_group" "api_log_group" {
   name              = "/ecs/api"
   retention_in_days = 30
@@ -58,6 +150,33 @@ resource "aws_cloudwatch_log_stream" "api_log_stream" {
   log_group_name = aws_cloudwatch_log_group.api_log_group.name
 }
 
+resource "aws_ecs_service" "api_service" {
+  name            = "api"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = module.api_task.arn
+  desired_count   = 1 # This will get adjusted by autoscaling rules
+  launch_type     = "FARGATE"
+
+  lifecycle {
+    # Autoscaling rules will tweak this dynamically. Ignore it so Terraform
+    # doesn't reset things on every run.
+    ignore_changes = [desired_count]
+  }
+
+  network_configuration {
+    security_groups  = [aws_security_group.ecs_tasks.id]
+    subnets          = aws_subnet.private.*.id
+    assign_public_ip = true
+  }
+
+  load_balancer {
+    target_group_arn = aws_alb_target_group.api.id
+    container_name   = "api"
+    container_port   = var.api_port
+  }
+
+  depends_on = [aws_alb_listener.front_end, aws_iam_role_policy_attachment.ecs_task_execution_role, module.api_task]
+}
 
 # Use CloudFront as a caching layer in front of the API server (Render does not
 # provide a built-in one). Enabled only if var.domain, var.api_remote_domain and

--- a/terraform/auto_scaling.tf
+++ b/terraform/auto_scaling.tf
@@ -1,0 +1,90 @@
+# Scale the API service up and down depending on usage.
+#
+# The target defines the resource to be scaled and its limits, while the
+# policies do the actual scaling (and define how much and how often to do so),
+# and the alarms ultimately define the conditions under which to scale and call
+# the policies when those conditions are met.
+
+resource "aws_appautoscaling_target" "target" {
+  service_namespace  = "ecs"
+  resource_id        = "service/${aws_ecs_cluster.main.name}/${aws_ecs_service.api_service.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  min_capacity       = 1
+  max_capacity       = 4
+}
+
+# Automatically scale capacity up by one
+resource "aws_appautoscaling_policy" "up" {
+  name               = "api_scale_up"
+  service_namespace  = aws_appautoscaling_target.target.service_namespace
+  resource_id        = aws_appautoscaling_target.target.resource_id
+  scalable_dimension = aws_appautoscaling_target.target.scalable_dimension
+
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = 60
+    metric_aggregation_type = "Maximum"
+
+    step_adjustment {
+      metric_interval_upper_bound = 0
+      scaling_adjustment          = 1
+    }
+  }
+}
+
+# Automatically scale capacity down by one
+resource "aws_appautoscaling_policy" "down" {
+  name               = "api_scale_down"
+  service_namespace  = aws_appautoscaling_target.target.service_namespace
+  resource_id        = aws_appautoscaling_target.target.resource_id
+  scalable_dimension = aws_appautoscaling_target.target.scalable_dimension
+
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = 60
+    metric_aggregation_type = "Maximum"
+
+    step_adjustment {
+      metric_interval_lower_bound = 0
+      scaling_adjustment          = -1
+    }
+  }
+}
+
+# CloudWatch alarm that triggers the autoscaling up policy
+resource "aws_cloudwatch_metric_alarm" "service_cpu_high" {
+  alarm_name          = "api_cpu_utilization_high"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "85"
+
+  dimensions = {
+    ClusterName = aws_ecs_cluster.main.name
+    ServiceName = aws_ecs_service.api_service.name
+  }
+
+  alarm_actions = [aws_appautoscaling_policy.up.arn]
+}
+
+# CloudWatch alarm that triggers the autoscaling down policy
+resource "aws_cloudwatch_metric_alarm" "service_cpu_low" {
+  alarm_name          = "api_cpu_utilization_low"
+  comparison_operator = "LessThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "25"
+
+  dimensions = {
+    ClusterName = aws_ecs_cluster.main.name
+    ServiceName = aws_ecs_service.api_service.name
+  }
+
+  alarm_actions = [aws_appautoscaling_policy.down.arn]
+}

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -1,0 +1,6 @@
+# Most UNIVAF code is deployed as tasks that run on this cluster, either as
+# scheduled cron-like scheduled tasks that run to completion, or as services
+# that the cluster will keep running.
+resource "aws_ecs_cluster" "main" {
+  name = "univaf-cluster"
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,0 +1,59 @@
+# ECS task execution role data
+
+# Use this role for things that need to execute tasks in the ECS cluster.
+resource "aws_iam_role" "ecs_task_execution_role" {
+  # TODO: clean this up if it turns out we don't really need a variable here
+  # TODO: consider using jsonencode and/or `inline_policy` blocks to put policy
+  #       definitions inline: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role
+  # name               = var.ecs_task_execution_role_name
+  name               = "univaf-ecs-task-execution"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_execution_role.json
+}
+
+# Gives the role access to things needed to execute tasks. The policy referenced
+# here is predefined by Amazon.
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_role" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# Gives the role the ability to run actual tasks.
+resource "aws_iam_role_policy_attachment" "ecs_runtask_policy" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = aws_iam_policy.ecs_runtask_policy.arn
+}
+
+# Policies used in the role/attachments above ---------------------------------
+
+# Defines what resources are allowed to assume a given role.
+data "aws_iam_policy_document" "ecs_task_execution_role" {
+  version = "2012-10-17"
+  statement {
+    sid     = "1"
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com", "events.amazonaws.com"]
+    }
+  }
+}
+
+# Defines the ability to run a task in ECS.
+data "aws_iam_policy_document" "ecs_task_additional_permissions" {
+  version = "2012-10-17"
+  statement {
+    sid     = "1"
+    effect  = "Allow"
+    actions = ["ecs:RunTask", "iam:PassRole"]
+    resources = [
+      "*" # TODO: lock this down
+    ]
+  }
+}
+resource "aws_iam_policy" "ecs_runtask_policy" {
+  name   = "runtask_policy"
+  path   = "/"
+  policy = data.aws_iam_policy_document.ecs_task_additional_permissions.json
+}

--- a/terraform/modules/task/main.tf
+++ b/terraform/modules/task/main.tf
@@ -95,6 +95,8 @@ resource "aws_ecs_task_definition" "main" {
   # TODO: see about running on ARM for less power consumption. I *think* we
   # need to build the images with:
   #   docker buildx build --platform linux/amd64,linux/arm64 ...other-args...
+  # See also some tips in:
+  #   https://blog.thesparktree.com/docker-multi-arch-github-actions
   # runtime_platform {
   #   operating_system_family = "LINUX"
   #   cpu_architecture        = "ARM64"

--- a/terraform/modules/task/main.tf
+++ b/terraform/modules/task/main.tf
@@ -91,4 +91,12 @@ resource "aws_ecs_task_definition" "main" {
   cpu                      = var.cpu
   memory                   = var.memory
   container_definitions    = local.encoded_containers
+
+  # TODO: see about running on ARM for less power consumption. I *think* we
+  # need to build the images with:
+  #   docker buildx build --platform linux/amd64,linux/arm64 ...other-args...
+  # runtime_platform {
+  #   operating_system_family = "LINUX"
+  #   cpu_architecture        = "ARM64"
+  # }
 }

--- a/terraform/modules/task/main.tf
+++ b/terraform/modules/task/main.tf
@@ -1,0 +1,94 @@
+
+/**
+ * The task module creates an ECS task definition.
+ *
+ * Usage:
+ *
+ *     module "nginx" {
+ *       source = "./modules/task"
+ *       name   = "nginx"
+ *       image  = "nginx"
+ *     }
+ *
+ */
+
+/**
+ * Define the two container definitions and the ultimate list we want to use
+ */
+locals {
+  env_vars = merge(
+    { ENV = "production", NODE_ENV = "production" },
+    var.env_vars
+  )
+
+  datadog_container_def = {
+    name  = "datadog-agent"
+    image = "datadog/agent:latest"
+    environment = [
+      {
+        name  = "DD_API_KEY"
+        value = var.datadog_api_key
+      },
+      {
+        name  = "ECS_FARGATE",
+        value = "true"
+      }
+    ]
+  }
+
+  container_definition = {
+    cpu    = var.cpu
+    memory = var.memory
+
+    name  = var.name
+    image = var.image
+
+    environment = [for key, val in local.env_vars : { name = key, value = val }]
+    entryPoint  = var.entry_point
+    command     = var.command
+
+    essential   = true
+    networkMode = "awsvpc"
+    mountPoints = []
+    portMappings = [
+      {
+        containerPort = var.port
+        hostPort      = var.port
+      }
+    ]
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        "awslogs-group"         = "/ecs/${var.name}"
+        "awslogs-region"        = var.aws_region
+        "awslogs-stream-prefix" = "ecs"
+      }
+    }
+  }
+
+  encoded_containers = (
+    var.datadog_enabled
+    ? jsonencode([local.container_definition, local.datadog_container_def])
+    : jsonencode([local.container_definition])
+  )
+}
+
+/**
+ * Resources.
+ */
+
+# The ECS task definition.
+resource "aws_ecs_task_definition" "main" {
+  family             = var.name
+  execution_role_arn = var.role
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.cpu
+  memory                   = var.memory
+  container_definitions    = local.encoded_containers
+}

--- a/terraform/modules/task/outputs.tf
+++ b/terraform/modules/task/outputs.tf
@@ -1,0 +1,18 @@
+/**
+ * Outputs.
+ */
+
+// The created task definition name
+output "name" {
+  value = aws_ecs_task_definition.main.family
+}
+
+// The created task definition ARN
+output "arn" {
+  value = aws_ecs_task_definition.main.arn
+}
+
+// The revision number of the task definition
+output "revision" {
+  value = aws_ecs_task_definition.main.revision
+}

--- a/terraform/modules/task/variables.tf
+++ b/terraform/modules/task/variables.tf
@@ -1,0 +1,74 @@
+/**
+ * Required Variables.
+ */
+
+variable "image" {
+  description = "The docker image name, e.g nginx"
+}
+
+variable "name" {
+  description = "The worker name, if empty the service name is defaulted to the image name"
+}
+
+variable "port" {
+  description = "The docker container port"
+  default     = 3000
+}
+
+/**
+ * Optional Variables.
+ */
+
+variable "cpu" {
+  description = "The number of cpu units to reserve for the container"
+  default     = 1024
+}
+
+variable "env_vars" {
+  description = "The raw json of the task env vars"
+  default     = {}
+}
+
+variable "command" {
+  description = "Command and arguments to run"
+  default     = []
+} # ["--state","NJ","vaccinespotter"]
+
+variable "entry_point" {
+  description = "The docker container entry point"
+  default     = []
+}
+
+variable "image_version" {
+  description = "The docker image version"
+  default     = "latest"
+}
+
+variable "memory" {
+  description = "The number of MiB of memory to reserve for the container"
+  default     = 2048
+}
+
+variable "log_driver" {
+  description = "The log driver to use use for the container"
+  default     = "awslogs"
+}
+
+variable "role" {
+  description = "The IAM Role to assign to the Container"
+  default     = ""
+}
+
+variable "aws_region" {
+  default = "us-west-2"
+}
+
+variable "datadog_enabled" {
+  description = "Should datadog be enabled for this task"
+  default     = false
+}
+
+variable "datadog_api_key" {
+  description = "The datadog api key to be used for this container"
+  default = ""
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,5 +1,9 @@
 # outputs.tf
 
+output "alb_hostname" {
+  value = aws_alb.main.dns_name
+}
+
 output "cloudfront_hostname" {
   value = aws_cloudfront_distribution.univaf_api[0].domain_name
 }

--- a/terraform/security.tf
+++ b/terraform/security.tf
@@ -1,0 +1,50 @@
+# security.tf
+
+# ALB Security Group: Edit to restrict access to the application
+resource "aws_security_group" "lb" {
+  name        = "cb-load-balancer-security-group"
+  description = "controls access to the ALB"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    protocol    = "tcp"
+    from_port   = 80
+    to_port     = 80
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    protocol    = "tcp"
+    from_port   = 443
+    to_port     = 443
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# Traffic to the ECS cluster should only come from the ALB
+resource "aws_security_group" "ecs_tasks" {
+  name        = "cb-ecs-tasks-security-group"
+  description = "allow inbound access from the ALB only"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    protocol        = "tcp"
+    from_port       = var.api_port
+    to_port         = var.api_port
+    security_groups = [aws_security_group.lb.id]
+  }
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -48,6 +48,52 @@ variable "db_size" {
   default     = 30
 }
 
+variable "api_keys" {
+  description = "List of valid API keys for posting data to the API service"
+  type        = list(string)
+}
+
+variable "api_port" {
+  description = "Port to send HTTP traffic to in API service"
+  default     = 3000
+}
+
+variable "api_health_check_path" {
+  default = "/health"
+}
+
+variable "api_cpu" {
+  description = "CPU units to provision for each API service instance (1 vCPU = 1024 CPU units) - Allowed values: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html#fargate-tasks-size"
+  default     = 1024
+}
+
+variable "api_memory" {
+  description = "Memory to provision for each API service instance (in MiB) - Allowed values: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html#fargate-tasks-size"
+  default     = 2048
+}
+
+variable "api_sentry_dsn" {
+  description = "The Sentry.io DSN to use for the API service"
+  default     = ""
+  sensitive   = true
+}
+
+variable "api_sentry_traces_sample_rate" {
+  description = "The sample rate for Sentry performance monitoring in the API service"
+  type        = number
+  default     = 0.01
+
+  validation {
+    condition     = var.api_sentry_traces_sample_rate >= 0.0 && var.api_sentry_traces_sample_rate <= 1.0
+    error_message = "The api_sentry_traces_sample_rate variable must be between 0 and 1."
+  }
+}
+
+variable "datadog_api_key" {
+  description = "API key for sending metrics to Datadog"
+  sensitive   = true
+}
+
 # These AWS variables are present to clean up warnings in terraform
 variable "AWS_SECRET_ACCESS_KEY" {
   default = ""


### PR DESCRIPTION
Rebuilds the API service on ECS. This involves a lot of fiddly bits with security groups and policies that I modified *slightly* to see how necessary they are (it may break). There's also a *lot* of room for streamlining and refactoring to clean these up, but I'll leave that for a follow-on change once things are working again.