### PR TITLE
AWS again: reinstate daily data snapshot

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -28,6 +28,16 @@ variable "data_snapshot_s3_bucket" {
   default     = "univaf-data-snapshots"
 }
 
+variable "data_snapshot_aws_key_id" {
+  description = "AWS access key ID for writing to the data snapshot S3 bucket"
+  sensitive   = true
+}
+
+variable "data_snapshot_aws_secret_key" {
+  description = "AWS secret key for writing to the data snapshot S3 bucket"
+  sensitive   = true
+}
+
 variable "db_user" {
   description = "The database user"
   default     = "univaf"


### PR DESCRIPTION
**Depends on #1019, which should land and get tested first.**

This is the last component of a functioning deployment on AWS (besides DNS & CloudFront, which aren't strictly required for things to work).

Once this is in, we should wait for a day and make sure we feel good before switching DNS and CloudFront back over to AWS and turning off Render. This also gives us time to a little messy refactoring on the Terraform code before things are in production, and changes need to be made more carefully.