### PR TITLE
Differentiate Render vs. ECS in Sentry

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -253,7 +253,7 @@ envVarGroups:
       - key: SENTRY_TRACES_SAMPLE_RATE
         value: "0.01"
       - key: SENTRY_ENVIRONMENT
-        value: production
+        value: render
       - key: DB_POOL_SIZE_AVAILABILITY
         value: "5"
 
@@ -272,4 +272,4 @@ envVarGroups:
       - key: SENTRY_TRACES_SAMPLE_RATE
         value: "0.01"
       - key: SENTRY_ENVIRONMENT
-        value: production
+        value: render

--- a/terraform/modules/task/main.tf
+++ b/terraform/modules/task/main.tf
@@ -17,7 +17,7 @@
  */
 locals {
   env_vars = merge(
-    { ENV = "production", NODE_ENV = "production" },
+    { ENV = "production", NODE_ENV = "production", SENTRY_ENVIRONMENT = "ecs" },
     var.env_vars
   )
 


### PR DESCRIPTION
Mark the Sentry environment as either Render or ECS for clarity about where errors are coming from. We did this just for Render when doing the initial switchover, and I'm realizing this is probably just as useful long term anytime we make changes or big shifts.