### PR TITLE
AWS again: set up CloudFront for ECS deploy

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -245,8 +245,8 @@ resource "aws_cloudfront_distribution" "univaf_api" {
   price_class = "PriceClass_100" # North America
   aliases = compact([
     var.domain_name,
-    length(aws_route53_record.api_www_domain_record) > 0 ? aws_route53_record.api_www_domain_record[0].fqdn : "",
-    length(aws_route53_record.api_render_domain_record) > 0 ? aws_route53_record.api_render_domain_record[0].fqdn : ""
+    "www.${var.domain_name}",
+    "render.${var.domain_name}"
   ])
   http_version = "http2and3"
 

--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -243,11 +243,11 @@ resource "aws_cloudfront_distribution" "univaf_api" {
   )
   enabled     = true
   price_class = "PriceClass_100" # North America
-  aliases = [
+  aliases = compact([
     var.domain_name,
-    aws_route53_record.api_www_domain_record.fqdn,
-    aws_route53_record.api_render_domain_record.fqdn
-  ]
+    length(aws_route53_record.api_www_domain_record) > 0 ? aws_route53_record.api_www_domain_record[0].fqdn : "",
+    length(aws_route53_record.api_render_domain_record) > 0 ? aws_route53_record.api_render_domain_record[0].fqdn : ""
+  ])
   http_version = "http2and3"
 
   origin {
@@ -301,11 +301,11 @@ resource "aws_cloudfront_distribution" "univaf_api_ecs" {
   )
   enabled     = true
   price_class = "PriceClass_100" # North America
-  aliases = [
+  aliases = compact([
     var.domain_name,
-    aws_route53_record.api_www_domain_record.fqdn,
-    aws_route53_record.api_render_domain_record.fqdn
-  ]
+    length(aws_route53_record.api_www_domain_record) > 0 ? aws_route53_record.api_www_domain_record[0].fqdn : "",
+    length(aws_route53_record.api_ecs_domain_record) > 0 ? aws_route53_record.api_ecs_domain_record[0].fqdn : ""
+  ])
   http_version = "http2and3"
 
   origin {

--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -27,6 +27,28 @@ resource "aws_route53_record" "api_www_domain_record" {
   ttl     = 300
 }
 
+# Specifically points to the deployment on Render
+resource "aws_route53_record" "api_render_domain_record" {
+  count = (
+    var.domain_name != ""
+    && var.api_remote_domain_name != "" ? 1 : 0
+  )
+  zone_id = data.aws_route53_zone.domain_zone[0].zone_id
+  name    = "render"
+  type    = "CNAME"
+  records = [var.domain_name]
+  ttl     = 300
+}
+
+# Specifically points to the deployment on ECS
+resource "aws_route53_record" "api_ecs_domain_record" {
+  count   = var.domain_name != "" ? 1 : 0
+  zone_id = data.aws_route53_zone.domain_zone[0].zone_id
+  name    = "ecs"
+  type    = "CNAME"
+  records = [var.domain_name]
+  ttl     = 300
+}
 
 # Daily Data Snapshot ---------------------------------------------------------
 
@@ -219,9 +241,13 @@ resource "aws_cloudfront_distribution" "univaf_api" {
     && var.ssl_certificate_arn != ""
     && var.api_remote_domain_name != "" ? 1 : 0
   )
-  enabled      = true
-  price_class  = "PriceClass_100" # North America
-  aliases      = [var.domain_name, "www.${var.domain_name}"]
+  enabled     = true
+  price_class = "PriceClass_100" # North America
+  aliases = [
+    var.domain_name,
+    aws_route53_record.api_www_domain_record.fqdn,
+    aws_route53_record.api_render_domain_record.fqdn
+  ]
   http_version = "http2and3"
 
   origin {
@@ -233,6 +259,64 @@ resource "aws_cloudfront_distribution" "univaf_api" {
       https_port             = 443
       origin_ssl_protocols   = ["SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2"]
       origin_protocol_policy = var.api_remote_domain_name != "" ? "https-only" : "http-only"
+    }
+  }
+
+  default_cache_behavior {
+    allowed_methods        = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = var.domain_name
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    max_ttl                = 3600
+
+    forwarded_values {
+      headers      = ["Host", "Origin"]
+      query_string = true
+
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn = var.ssl_certificate_arn
+    ssl_support_method  = "sni-only"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+}
+
+# Use CloudFront as a caching layer in front of the API server that's running
+# in ECS. Enabled only if var.domain, and var.ssl_certificate_arn are provided.
+resource "aws_cloudfront_distribution" "univaf_api_ecs" {
+  count = (
+    var.domain_name != ""
+    && var.ssl_certificate_arn != "" ? 1 : 0
+  )
+  enabled     = true
+  price_class = "PriceClass_100" # North America
+  aliases = [
+    var.domain_name,
+    aws_route53_record.api_www_domain_record.fqdn,
+    aws_route53_record.api_render_domain_record.fqdn
+  ]
+  http_version = "http2and3"
+
+  origin {
+    origin_id   = var.domain_name
+    domain_name = aws_alb.main.dns_name
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_ssl_protocols   = ["SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2"]
+      origin_protocol_policy = "http-only"
     }
   }
 

--- a/terraform/loaders.tf
+++ b/terraform/loaders.tf
@@ -50,11 +50,12 @@ module "source_loader" {
   schedule      = each.value.schedule
   loader_source = each.key
   command       = lookup(each.value, "command", [])
-  api_url       = "http://${aws_alb.main.dns_name}"
-  api_key       = var.api_keys[0]
-  sentry_dsn    = var.loader_sentry_dsn
-  env_vars      = lookup(each.value, "env_vars", {})
-  loader_image  = "${aws_ecr_repository.loader_repository.repository_url}:${var.loader_release_version}"
+  # NOTE: loaders go directly to the API service load balancer, not CloudFront.
+  api_url      = "http://${aws_alb.main.dns_name}"
+  api_key      = var.api_keys[0]
+  sentry_dsn   = var.loader_sentry_dsn
+  env_vars     = lookup(each.value, "env_vars", {})
+  loader_image = "${aws_ecr_repository.loader_repository.repository_url}:${var.loader_release_version}"
 
   cluster_arn = aws_ecs_cluster.main.arn
   role        = aws_iam_role.ecs_task_execution_role.arn


### PR DESCRIPTION
Set up https://ecs.getmyvax.org to point to a CloudFront distribution that gives public access to the new old AWS ECS deployment.