### PR TITLE
Handle Moderna for "ages 6+" in Prepmod

### DIFF
--- a/loader/src/utils.js
+++ b/loader/src/utils.js
@@ -557,7 +557,7 @@ module.exports = {
     if (/astra\s*zeneca/.test(text)) {
       return isBa4Ba5 ? undefined : VaccineProduct.astraZeneca;
     } else if (text.includes("moderna")) {
-      if (/ages?\s+(12|18)( (years )?and up|\s*\+)/i.test(text)) {
+      if (/ages?\s+(6|12|18)( (years )?and up|\s*\+)/i.test(text)) {
         return isBa4Ba5 ? VaccineProduct.modernaBa4Ba5 : VaccineProduct.moderna;
       } else if (/ages?\s+6\s*(m|months)\b/i.test(text)) {
         return isBa4Ba5 ? undefined : VaccineProduct.modernaAge0_5;

--- a/loader/test/utils.test.js
+++ b/loader/test/utils.test.js
@@ -239,10 +239,12 @@ describe("matchVaccineProduct", () => {
     [v.moderna, "Moderna COVID-19 Vaccine/Booster (Ages 18+)"],
     [v.moderna, "Moderna COVID-19 Vaccine (Ages 12+)"],
     [v.moderna, "Moderna (Spikevax), ages 12 years and up"],
+    [v.moderna, "Moderna COVID-19 Vaccine (Ages 6+)"],
 
     [v.modernaBa4Ba5, "Moderna COVID-19 Vaccine (Ages 12+)/Bivalent Booster (Ages 18+)"],
     [v.modernaBa4Ba5, "Moderna COVID-19, Bivalent Booster (Ages 18+)"],
     [v.modernaBa4Ba5, "Moderna bivalent booster, ages 12 years and up"],
+    [v.modernaBa4Ba5, "Moderna COVID-19 Bivalent Booster (Ages 6+)"],
 
     [v.modernaAge6_11, "Moderna COVID-19 Vaccine (ages 6-11 Primary, 18+ Booster)"],
     [v.modernaAge6_11, "Moderna Pediatric COVID-19 Vaccine (Ages 6 through 11)"],


### PR DESCRIPTION
Moderna's new bivalent vaccine has just been approved for for ages 6-11, and is the same product as the one for ages 12+ (just a half dose). Accordingly, some Alaska Prepmod locations are now listing Moderna for "ages 6+", where they previously always differentiated listings for ages 6-11 and 12+ or 18+. This handles "6+" the same as "12+", and separately from ranges starting at 6 (e.g. "6-11").

Fixes https://sentry.io/organizations/usdr/issues/3666320109.