### PR TITLE
Change names for metrics that were distributions

### DIFF
--- a/loader/src/cli.js
+++ b/loader/src/cli.js
@@ -107,9 +107,9 @@ async function run(options) {
         }
       }
 
-      metrics.gauge("loader.jobs.send_total", results.length);
-      metrics.gauge("loader.jobs.send_stale", sendStale);
-      metrics.gauge("loader.jobs.send_errors", sendErrors);
+      metrics.increment("loader.jobs.send.total", results.length);
+      metrics.increment("loader.jobs.send.stale", sendStale);
+      metrics.increment("loader.jobs.send.errors", sendErrors);
     }
 
     let successCount = 0;
@@ -132,7 +132,7 @@ async function run(options) {
   } finally {
     const duration = (Date.now() - startTime) / 1000;
     console.error(`Completed in ${duration} seconds.`);
-    metrics.gauge("loader.jobs.duration", duration);
+    metrics.gauge("loader.jobs.duration_seconds", duration);
 
     await new Promise((resolve, reject) => {
       metrics.flush(resolve, reject);


### PR DESCRIPTION
In #1028, I changed the loader to use the Datadog API instead of the agent. However, the API client we're using doesn't support distributions (yet) and I foolishly used distributions for some of the metrics. I changed their types when switching to the API, but it turns out that while you can change the type of counts/gauges/rates, you can't change between those and distributions. This gives the things that were distributions new names so we can actually see them in Datadog.