### PR TITLE
A little light AWS tuning

### DIFF
--- a/terraform/api-autoscaling.tf
+++ b/terraform/api-autoscaling.tf
@@ -60,7 +60,7 @@ resource "aws_cloudwatch_metric_alarm" "service_cpu_high" {
   namespace           = "AWS/ECS"
   period              = "60"
   statistic           = "Average"
-  threshold           = "85"
+  threshold           = "75"
 
   dimensions = {
     ClusterName = aws_ecs_cluster.main.name
@@ -79,7 +79,7 @@ resource "aws_cloudwatch_metric_alarm" "service_cpu_low" {
   namespace           = "AWS/ECS"
   period              = "60"
   statistic           = "Average"
-  threshold           = "25"
+  threshold           = "30"
 
   dimensions = {
     ClusterName = aws_ecs_cluster.main.name

--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -150,6 +150,7 @@ module "daily_data_snapshot_task" {
     DB_NAME                 = module.db.db_name
     DB_USERNAME             = var.db_user
     DB_PASSWORD             = var.db_password
+    DB_POOL_SIZE_DATA       = 15
     SENTRY_DSN              = var.api_sentry_dsn
     DATA_SNAPSHOT_S3_BUCKET = var.data_snapshot_s3_bucket
     AWS_ACCESS_KEY_ID       = var.data_snapshot_aws_key_id

--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -150,7 +150,7 @@ module "daily_data_snapshot_task" {
     DB_NAME                 = module.db.db_name
     DB_USERNAME             = var.db_user
     DB_PASSWORD             = var.db_password
-    DB_POOL_SIZE_DATA       = 15
+    DB_POOL_SIZE_DATA       = "15"
     SENTRY_DSN              = var.api_sentry_dsn
     DATA_SNAPSHOT_S3_BUCKET = var.data_snapshot_s3_bucket
     AWS_ACCESS_KEY_ID       = var.data_snapshot_aws_key_id

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -55,7 +55,7 @@ variable "db_instance" {
 
 variable "db_size" {
   description = "The storage size for the DB (in Gigabytes)"
-  default     = 30
+  default     = 48
 }
 
 variable "api_keys" {


### PR DESCRIPTION
Pushing this to GitHub before I’m done for the evening. Probably won’t merge tonight.

This does a little fine tuning on the AWS deployment, based on things I noticed while comparing to Render and doing cleanup before cutting production back over to AWS:

- Ups the database’s disk size to 48 GB. We don’t need remotely that much space, but AWS throttles our disk I/O performance based on disk size, and is going to lock up our maximum performance soon. This increase in disk size *should* give us enough baseline performance to match our workload. *(On the flip-side, we don’t have to do this. We can also live with throttled performance. But this is cheap — it should cost us ~$2 extra per month.)*

- Adjust API scaling thresholds and increase the number of DB connections per API server instance. We are currently not bottlenecked on the API server’s CPU performance or memory (the system isn’t even scaling us up!), so we should be safe to take more connections per server instance. This also lowers the scale-up threshold. (On the flip-side, this might increase our disk I/O usage, and change the equation for ideal disk size. 🙃 )