### PR TITLE
Move production traffic back to AWS

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -4,6 +4,10 @@ output "alb_hostname" {
   value = aws_alb.main.dns_name
 }
 
-output "cloudfront_hostname" {
-  value = aws_cloudfront_distribution.univaf_api[0].domain_name
+output "cloudfront_hostname_ecs" {
+  value = aws_cloudfront_distribution.univaf_api_ecs[0].domain_name
+}
+
+output "cloudfront_hostname_render" {
+  value = aws_cloudfront_distribution.univaf_api_render[0].domain_name
 }


### PR DESCRIPTION
The deployment on AWS ECS has been working pretty well for the last week, and is more than ready to have production traffic again. Meanwhile, Render has continued to have various problems, and support has continued to be extremely slow.