### PR TITLE
Remove completed Terraform `move` block

### DIFF
--- a/terraform/api-domains.tf
+++ b/terraform/api-domains.tf
@@ -139,11 +139,6 @@ resource "aws_cloudfront_distribution" "univaf_api_render" {
   }
 }
 
-moved {
-  from = aws_cloudfront_distribution.univaf_api
-  to   = aws_cloudfront_distribution.univaf_api_render
-}
-
 # Use CloudFront as a caching layer in front of the API server that's running
 # in ECS. Enabled only if var.domain, and var.ssl_certificate_arn are provided.
 resource "aws_cloudfront_distribution" "univaf_api_ecs" {


### PR DESCRIPTION
This is cleanup from #1033, and just removes the Terraform `move` blocks that have done their job and are no longer necessary.