### PR TITLE
Use more smaller API server instances

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -42,13 +42,13 @@ services:
   - name: API Server
     region: oregon
     type: web
-    plan: standard
+    plan: starter plus
     env: node
     repo: "https://github.com/usdigitalresponse/univaf.git"
     branch: main
     scaling:
       minInstances: 1
-      maxInstances: 4
+      maxInstances: 2
       targetMemoryPercent: 60 # optional if targetCPUPercent is set
       targetCPUPercent: 70 # optional if targetMemory is set
     buildFilter:

--- a/terraform/api-autoscaling.tf
+++ b/terraform/api-autoscaling.tf
@@ -9,7 +9,7 @@ resource "aws_appautoscaling_target" "target" {
   service_namespace  = "ecs"
   resource_id        = "service/${aws_ecs_cluster.main.name}/${aws_ecs_service.api_service.name}"
   scalable_dimension = "ecs:service:DesiredCount"
-  min_capacity       = 1
+  min_capacity       = 2
   max_capacity       = 4
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -74,12 +74,12 @@ variable "api_health_check_path" {
 
 variable "api_cpu" {
   description = "CPU units to provision for each API service instance (1 vCPU = 1024 CPU units) - Allowed values: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html#fargate-tasks-size"
-  default     = 1024
+  default     = 512
 }
 
 variable "api_memory" {
   description = "Memory to provision for each API service instance (in MiB) - Allowed values: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html#fargate-tasks-size"
-  default     = 2048
+  default     = 1024
 }
 
 variable "api_sentry_dsn" {


### PR DESCRIPTION
One lesson from rebuilding things on AWS is that we just don't use much memory in the API server. We can't reduce RAM without also cutting the CPU in half, but my working theory is that we can just double the instances and it should be fine. We'll follow the charts and see how this goes (honestly I think a baseline of more instances might make the whole thing more stable anyway).