### PR TITLE
Go back to higher CPU instances for API server

### DIFF
--- a/loader/src/api-client.js
+++ b/loader/src/api-client.js
@@ -1,5 +1,6 @@
 const Queue = require("queue");
 const config = require("./config");
+const metrics = require("./metrics");
 const { httpClient } = require("./utils");
 
 const DEFAULT_CONCURRENCY = 10;
@@ -77,6 +78,8 @@ class ApiClient {
       body.sent = data;
       body.statusCode = response.statusCode;
     }
+
+    metrics.increment("loader.jobs.send.retries", response.retryCount);
 
     return body;
   }

--- a/terraform/api-autoscaling.tf
+++ b/terraform/api-autoscaling.tf
@@ -9,7 +9,7 @@ resource "aws_appautoscaling_target" "target" {
   service_namespace  = "ecs"
   resource_id        = "service/${aws_ecs_cluster.main.name}/${aws_ecs_service.api_service.name}"
   scalable_dimension = "ecs:service:DesiredCount"
-  min_capacity       = 2
+  min_capacity       = 1
   max_capacity       = 4
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -74,12 +74,12 @@ variable "api_health_check_path" {
 
 variable "api_cpu" {
   description = "CPU units to provision for each API service instance (1 vCPU = 1024 CPU units) - Allowed values: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html#fargate-tasks-size"
-  default     = 512
+  default     = 1024
 }
 
 variable "api_memory" {
   description = "Memory to provision for each API service instance (in MiB) - Allowed values: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html#fargate-tasks-size"
-  default     = 1024
+  default     = 2048
 }
 
 variable "api_sentry_dsn" {


### PR DESCRIPTION
We don’t need more than a quarter of this memory, but when we use the CPU, we are really using it. Switching to smaller instances appears to have doubled our response latency, so it was probably not a good move.

Also add telemetry for how much the loader is retrying failed requests.