### PR TITLE
H-E-B: Handle slots for "multiple" in all cases

### DIFF
--- a/loader/src/sources/heb/index.js
+++ b/loader/src/sources/heb/index.js
@@ -181,7 +181,7 @@ function formatAvailableProducts(slots, availableImmunizations) {
         // "other" denotes non-COVID vaccines, like the flu.
         return [];
       } else if (manufacturer === "multiple") {
-        return availableTypes.map((type) => type.product);
+        return availableTypes?.map((type) => type.product) || [];
       } else {
         const types = availableTypes || Object.values(IMMUNIZATION_TYPES);
         const formatted = types

--- a/loader/test/heb.test.js
+++ b/loader/test/heb.test.js
@@ -6,6 +6,46 @@ const { locationSchema } = require("./support/schemas");
 // Mock utils so we can track logs.
 jest.mock("../src/utils");
 
+const baseLocation = {
+  zip: "78209-5703",
+  url: "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gub6QAC",
+  type: "store",
+  street: "4821 BROADWAY",
+  storeNumber: 191,
+  state: "TX",
+  slotDetails: [
+    {
+      openTimeslots: 1,
+      openAppointmentSlots: 1,
+      manufacturer: "Janssen",
+    },
+    {
+      openTimeslots: 36,
+      openAppointmentSlots: 36,
+      manufacturer: "Moderna",
+    },
+    {
+      openTimeslots: 39,
+      openAppointmentSlots: 39,
+      manufacturer: "Pfizer",
+    },
+  ],
+  openTimeslots: 76,
+  openFluTimeslots: 0,
+  openFluAppointmentSlots: 0,
+  openAppointmentSlots: 76,
+  name: "Broadway Central Market",
+  longitude: -98.46408,
+  latitude: 29.47069,
+  fluUrl: "",
+  city: "SAN ANTONIO",
+  availableImmunizations: [
+    "COVID-19 Janssen",
+    "COVID-19 Moderna_Updated_Booster",
+    "COVID-19 Pfizer_Updated_Booster",
+  ],
+};
+
 describe("H-E-B", () => {
   it.nock("should output valid data", { ignoreQuery: ["v"] }, async () => {
     const result = await checkAvailability(() => {}, { states: ["TX"] });
@@ -13,45 +53,7 @@ describe("H-E-B", () => {
   });
 
   it("should format correct output for a store", () => {
-    const formatted = formatLocation({
-      zip: "78209-5703",
-      url: "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gub6QAC",
-      type: "store",
-      street: "4821 BROADWAY",
-      storeNumber: 191,
-      state: "TX",
-      slotDetails: [
-        {
-          openTimeslots: 1,
-          openAppointmentSlots: 1,
-          manufacturer: "Janssen",
-        },
-        {
-          openTimeslots: 36,
-          openAppointmentSlots: 36,
-          manufacturer: "Moderna",
-        },
-        {
-          openTimeslots: 39,
-          openAppointmentSlots: 39,
-          manufacturer: "Pfizer",
-        },
-      ],
-      openTimeslots: 76,
-      openFluTimeslots: 0,
-      openFluAppointmentSlots: 0,
-      openAppointmentSlots: 76,
-      name: "Broadway Central Market",
-      longitude: -98.46408,
-      latitude: 29.47069,
-      fluUrl: "",
-      city: "SAN ANTONIO",
-      availableImmunizations: [
-        "COVID-19 Janssen",
-        "COVID-19 Moderna_Updated_Booster",
-        "COVID-19 Pfizer_Updated_Booster",
-      ],
-    });
+    const formatted = formatLocation({ ...baseLocation });
 
     expect(formatted).toEqual({
       name: "Broadway Central Market",
@@ -78,5 +80,49 @@ describe("H-E-B", () => {
         products: ["jj", "moderna_ba4_ba5", "pfizer_ba4_ba5"],
       },
     });
+  });
+
+  it("should handle slots with 'multiple' by checking available types", () => {
+    const formatted = formatLocation({
+      ...baseLocation,
+      openTimeslots: 1,
+      openAppointmentSlots: 1,
+      slotDetails: [
+        {
+          openTimeslots: 1,
+          openAppointmentSlots: 1,
+          manufacturer: "Multiple",
+        },
+      ],
+      availableImmunizations: [
+        "COVID-19 Janssen",
+        "COVID-19 Moderna_Updated_Booster",
+        "COVID-19 Pfizer_Updated_Booster",
+      ],
+    });
+
+    expect(formatted).toHaveProperty("availability.products", [
+      "jj",
+      "moderna_ba4_ba5",
+      "pfizer_ba4_ba5",
+    ]);
+  });
+
+  it("should handle slots with 'multiple' and no available types", () => {
+    const formatted = formatLocation({
+      ...baseLocation,
+      openTimeslots: 1,
+      openAppointmentSlots: 1,
+      slotDetails: [
+        {
+          openTimeslots: 1,
+          openAppointmentSlots: 1,
+          manufacturer: "Multiple",
+        },
+      ],
+      availableImmunizations: [],
+    });
+
+    expect(formatted).toHaveProperty("availability.products", undefined);
   });
 });


### PR DESCRIPTION
This fixes an exception we recently saw in production caused by not accounting for a logical branch where the list of available vaccines might not be set (it's rare to see in practice). Also adds a test for this case.

Fixes https://sentry.io/organizations/usdr/issues/3684116765