### PR TITLE
Try not setting `throwHttpErrors: false` for Got

### DIFF
--- a/loader/src/api-client.js
+++ b/loader/src/api-client.js
@@ -63,15 +63,22 @@ class ApiClient {
       throw new TypeError("`options` must be an object");
     }
 
-    const response = await this._request({
-      method: "POST",
-      url: "/api/edge/update",
-      searchParams: options,
-      json: data,
-      throwHttpErrors: false,
-    });
+    // FIXME: determine if this is actually needed!
+    // Wrap this call in a try/catch; it seems like retries are not not
+    // happening when setting the `throwHttpErrors` to false.
+    let response;
+    try {
+      response = await this._request({
+        method: "POST",
+        url: "/api/edge/update",
+        searchParams: options,
+        json: data,
+      });
+    } catch (error) {
+      response = error.response;
+    }
 
-    const body = response.body;
+    const body = response?.body ?? {};
     // TODO: should probably always include success in response on API side?
     if (body.error || body.success === false) {
       body.success = false;


### PR DESCRIPTION
I added metrics about retries to the API client a couple days ago (#1056), and while we have seen errors that *should* have been retried (e.g. ECONNRESET, ETIMEDOUT), we've never gotten > 0 retries in our metrics. It's possible that when we've seen these errors, they have always occurred for all 3 tries, but that seems unlikely. My quick thought here is that setting `throwHttpErrors: false` is short-circuiting the retry logic (internally, it might be part of the throw-an-exception logic). This might be wrong! It's an experiment.