### PR TITLE
Support "Senior_Flu" immunization type at H-E-B

### DIFF
--- a/loader/src/sources/heb/index.js
+++ b/loader/src/sources/heb/index.js
@@ -32,6 +32,10 @@ const IMMUNIZATION_TYPES = {
     manufacturer: null,
     product: null,
   },
+  Senior_Flu: {
+    manufacturer: null,
+    product: null,
+  },
   "COVID-19 Pfizer": {
     manufacturer: "pfizer",
     product: VaccineProduct.pfizer,

--- a/loader/test/fixtures/nock/h-e-b_should_output_valid_data.json
+++ b/loader/test/fixtures/nock/h-e-b_should_output_valid_data.json
@@ -2,96 +2,64 @@
     {
         "scope": "https://heb-ecom-covid-vaccine.hebdigital-prd.com:443",
         "method": "GET",
-        "path": "/vaccine_locations.json?v=987093037967.7764",
+        "path": "/vaccine_locations.json?v=314803397183.5125",
         "body": "",
         "status": 200,
         "response": {
             "locations": [
                 {
-                    "zip": "79525",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h6P0000004EGLQA2",
-                    "type": "offsite",
-                    "street": "2233 Ivanhoe Ln",
-                    "storeNumber": null,
-                    "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 32,
-                            "openAppointmentSlots": 32,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 32,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 32,
-                    "name": "2022-2023 Hawley ISD Faculty & Staff - Flu+ Clinic",
-                    "longitude": null,
-                    "latitude": null,
-                    "fluUrl": "",
-                    "city": "Hawley",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Novavax",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
-                },
-                {
-                    "zip": "79525",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h6P0000004EGQQA2",
-                    "type": "offsite",
-                    "street": "2233 Ivanhoe Ln",
-                    "storeNumber": null,
-                    "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 24,
-                            "openAppointmentSlots": 24,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 24,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 24,
-                    "name": "2022-2023 Hawley ISD - Student Flu Clinic",
-                    "longitude": null,
-                    "latitude": null,
-                    "fluUrl": "",
-                    "city": "Hawley",
-                    "availableImmunizations": [
-                        "Flu"
-                    ]
-                },
-                {
                     "zip": "78654",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h6P0000004EPcQAM",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h6P0000004EAwQAM",
                     "type": "offsite",
-                    "street": "901 Ventana Drive",
+                    "street": "177 Broadmoor",
                     "storeNumber": null,
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 38,
-                            "openAppointmentSlots": 38,
+                            "openTimeslots": 6,
+                            "openAppointmentSlots": 6,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 38,
+                    "openTimeslots": 6,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 38,
-                    "name": "H-E-B Hosted First Baptist Church of Marble Falls",
+                    "openAppointmentSlots": 6,
+                    "name": "H-E-B Hosted City of Meadowlakes-Totten Hall",
                     "longitude": null,
                     "latitude": null,
                     "fluUrl": "",
                     "city": "Marble Falls",
                     "availableImmunizations": [
-                        "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster"
+                    ]
+                },
+                {
+                    "zip": "78654",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h6P0000004EufQAE",
+                    "type": "offsite",
+                    "street": "700 Avenue N",
+                    "storeNumber": null,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 86,
+                            "openAppointmentSlots": 86,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 86,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 86,
+                    "name": "H-E-B Hosted Marble Falls Fire Station",
+                    "longitude": null,
+                    "latitude": null,
+                    "fluUrl": "",
+                    "city": "Marble Falls",
+                    "availableImmunizations": [
+                        "Flu"
                     ]
                 },
                 {
@@ -103,57 +71,46 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 113,
-                            "openAppointmentSlots": 113,
+                            "openTimeslots": 162,
+                            "openAppointmentSlots": 162,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 113,
+                    "openTimeslots": 162,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 113,
+                    "openAppointmentSlots": 162,
                     "name": "Round Rock H-E-B plus!",
                     "longitude": -97.65978,
                     "latitude": 30.5177,
                     "fluUrl": "",
                     "city": "ROUND ROCK",
                     "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer"
                     ]
                 },
                 {
                     "zip": "76574-7059",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudIQAS",
+                    "url": null,
                     "type": "store",
                     "street": "100 N.W.CARLOS G.PARKER BL#101",
                     "storeNumber": 593,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 163,
-                            "openAppointmentSlots": 163,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 163,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 163,
+                    "openAppointmentSlots": 0,
                     "name": "Taylor H-E-B",
                     "longitude": -97.4167,
                     "latitude": 30.6007,
                     "fluUrl": "",
                     "city": "TAYLOR",
-                    "availableImmunizations": [
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "Flu"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78654-4902",
@@ -164,23 +121,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 16,
-                            "openAppointmentSlots": 16,
+                            "openTimeslots": 64,
+                            "openAppointmentSlots": 64,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 16,
+                    "openTimeslots": 64,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 16,
+                    "openAppointmentSlots": 64,
                     "name": "Marble Falls H-E-B",
                     "longitude": -98.27972,
                     "latitude": 30.58301,
                     "fluUrl": "",
                     "city": "MARBLE FALLS",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "Flu"
+                        "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -192,25 +150,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 419,
-                            "openAppointmentSlots": 419,
+                            "openTimeslots": 643,
+                            "openAppointmentSlots": 643,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 419,
+                    "openTimeslots": 643,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 419,
+                    "openAppointmentSlots": 643,
                     "name": "Wells Branch H-E-B",
                     "longitude": -97.66419,
                     "latitude": 30.44263,
                     "fluUrl": "",
                     "city": "PFLUGERVILLE",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer",
                         "Flu",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna"
+                        "COVID-19 Pfizer"
                     ]
                 },
                 {
@@ -222,24 +179,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 120,
-                            "openAppointmentSlots": 120,
+                            "openTimeslots": 41,
+                            "openAppointmentSlots": 41,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 120,
+                    "openTimeslots": 41,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 120,
+                    "openAppointmentSlots": 41,
                     "name": "Louis Henna Blvd H-E-B",
                     "longitude": -97.65938,
                     "latitude": 30.48179,
                     "fluUrl": "",
                     "city": "ROUND ROCK",
                     "availableImmunizations": [
-                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "Flu"
+                        "Flu",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -251,28 +208,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 57,
-                            "openAppointmentSlots": 57,
+                            "openTimeslots": 13,
+                            "openAppointmentSlots": 13,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 57,
+                    "openTimeslots": 13,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 57,
+                    "openAppointmentSlots": 13,
                     "name": "H-E-B at Ronald Reagan Blvd",
                     "longitude": -97.82446,
                     "latitude": 30.63307,
                     "fluUrl": "",
                     "city": "GEORGETOWN",
                     "availableImmunizations": [
+                        "Flu",
                         "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
                         "COVID-19 Novavax",
-                        "Flu",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -284,15 +240,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 89,
-                            "openAppointmentSlots": 89,
+                            "openTimeslots": 77,
+                            "openAppointmentSlots": 77,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 89,
+                    "openTimeslots": 77,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 89,
+                    "openAppointmentSlots": 77,
                     "name": "El Dorado H-E-B",
                     "longitude": -95.14874,
                     "latitude": 29.55117,
@@ -308,62 +264,41 @@
                 },
                 {
                     "zip": "78045-2802",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucLQAS",
+                    "url": null,
                     "type": "store",
                     "street": "7811 MCPHERSON RD.",
                     "storeNumber": 449,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 1,
-                            "openAppointmentSlots": 1,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 1,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 1,
+                    "openAppointmentSlots": 0,
                     "name": "McPherson Rd H-E-B",
                     "longitude": -99.4733,
                     "latitude": 27.5754,
                     "fluUrl": "",
                     "city": "LAREDO",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78355-4365",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gub8QAC",
+                    "url": null,
                     "type": "store",
                     "street": "700 S SAINT MARYS ST",
                     "storeNumber": 200,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 168,
-                            "openAppointmentSlots": 168,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 168,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 168,
+                    "openAppointmentSlots": 0,
                     "name": "Falfurrias H-E-B",
                     "longitude": -98.14572,
                     "latitude": 27.22043,
                     "fluUrl": "",
                     "city": "FALFURRIAS",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
-                        "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78756-1100",
@@ -374,22 +309,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 3,
-                            "openAppointmentSlots": 3,
+                            "openTimeslots": 11,
+                            "openAppointmentSlots": 11,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 3,
+                    "openTimeslots": 11,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 3,
+                    "openAppointmentSlots": 11,
                     "name": "Burnet Rd H-E-B",
                     "longitude": -97.74016,
                     "latitude": 30.33374,
                     "fluUrl": "",
                     "city": "AUSTIN",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu"
                     ]
                 },
                 {
@@ -401,24 +337,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 406,
-                            "openAppointmentSlots": 406,
+                            "openTimeslots": 126,
+                            "openAppointmentSlots": 126,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 406,
+                    "openTimeslots": 126,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 406,
+                    "openAppointmentSlots": 126,
                     "name": "Las Palmas H-E-B",
                     "longitude": -98.55132,
                     "latitude": 29.41734,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
-                        "COVID-19 Moderna_Updated_Booster",
                         "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer"
                     ]
                 },
@@ -431,15 +370,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 42,
-                            "openAppointmentSlots": 42,
+                            "openTimeslots": 56,
+                            "openAppointmentSlots": 56,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 42,
+                    "openTimeslots": 56,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 42,
+                    "openAppointmentSlots": 56,
                     "name": "Guadalupe and Stone H-E-B",
                     "longitude": -99.48344,
                     "latitude": 27.50656,
@@ -447,11 +386,9 @@
                     "city": "LAREDO",
                     "availableImmunizations": [
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
                         "Flu",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -520,15 +457,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 22,
-                            "openAppointmentSlots": 22,
+                            "openTimeslots": 41,
+                            "openAppointmentSlots": 41,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 22,
+                    "openTimeslots": 41,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 22,
+                    "openAppointmentSlots": 41,
                     "name": "Parmer and Mopac H-E-B",
                     "longitude": -97.70326,
                     "latitude": 30.41883,
@@ -537,8 +474,9 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -550,23 +488,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 331,
-                            "openAppointmentSlots": 331,
+                            "openTimeslots": 116,
+                            "openAppointmentSlots": 116,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 331,
+                    "openTimeslots": 116,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 331,
+                    "openAppointmentSlots": 116,
                     "name": "Pleasanton H-E-B",
                     "longitude": -98.48567,
                     "latitude": 28.95696,
                     "fluUrl": "",
                     "city": "PLEASANTON",
                     "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "Flu"
                     ]
                 },
                 {
@@ -586,11 +525,7 @@
                     "latitude": 28.40071,
                     "fluUrl": "",
                     "city": "BEEVILLE",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78404-2505",
@@ -601,21 +536,22 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 26,
-                            "openAppointmentSlots": 26,
+                            "openTimeslots": 63,
+                            "openAppointmentSlots": 63,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 26,
+                    "openTimeslots": 63,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 26,
+                    "openAppointmentSlots": 63,
                     "name": "Alameda / Texan Trail (Medical District)",
                     "longitude": -97.3912,
                     "latitude": 27.75745,
                     "fluUrl": "",
                     "city": "CORPUS CHRISTI",
                     "availableImmunizations": [
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
@@ -628,26 +564,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 1248,
-                            "openAppointmentSlots": 1248,
+                            "openTimeslots": 543,
+                            "openAppointmentSlots": 543,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 1248,
+                    "openTimeslots": 543,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 1248,
+                    "openAppointmentSlots": 543,
                     "name": "Brenham H-E-B",
                     "longitude": -96.39591,
                     "latitude": 30.14381,
                     "fluUrl": "",
                     "city": "BRENHAM",
                     "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
                         "COVID-19 Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu",
                         "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -671,34 +608,22 @@
                 },
                 {
                     "zip": "78945-2655",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Guc3QAC",
+                    "url": null,
                     "type": "store",
                     "street": "450 E. TRAVIS",
                     "storeNumber": 416,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 53,
-                            "openAppointmentSlots": 53,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 53,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 53,
+                    "openAppointmentSlots": 0,
                     "name": "La Grange H-E-B",
                     "longitude": -96.87264,
                     "latitude": 29.9073,
                     "fluUrl": "",
                     "city": "LA GRANGE",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78840-4658",
@@ -728,22 +653,21 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 8,
-                            "openAppointmentSlots": 8,
+                            "openTimeslots": 19,
+                            "openAppointmentSlots": 19,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 8,
+                    "openTimeslots": 19,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 8,
+                    "openAppointmentSlots": 19,
                     "name": "Eagle Pass H-E-B",
                     "longitude": -100.48583,
                     "latitude": 28.70894,
                     "fluUrl": "",
                     "city": "EAGLE PASS",
                     "availableImmunizations": [
-                        "COVID-19 Moderna_Updated_Booster",
                         "Flu"
                     ]
                 },
@@ -787,63 +711,41 @@
                 },
                 {
                     "zip": "78861-2504",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Guc8QAC",
+                    "url": null,
                     "type": "store",
                     "street": "609 19TH STREET",
                     "storeNumber": 424,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 58,
-                            "openAppointmentSlots": 58,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 58,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 58,
+                    "openAppointmentSlots": 0,
                     "name": "Hondo H-E-B",
                     "longitude": -99.13501,
                     "latitude": 29.34784,
                     "fluUrl": "",
                     "city": "HONDO",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78751-4810",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Guc9QAC",
+                    "url": null,
                     "type": "store",
                     "street": "1000 EAST 41 ST.",
                     "storeNumber": 425,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 225,
-                            "openAppointmentSlots": 225,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 225,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 225,
+                    "openAppointmentSlots": 0,
                     "name": "Hancock Center H-E-B",
                     "longitude": -97.71973,
                     "latitude": 30.30057,
                     "fluUrl": "",
                     "city": "AUSTIN",
-                    "availableImmunizations": [
-                        "COVID-19 Moderna_Updated_Booster",
-                        "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Janssen",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "75165-1884",
@@ -854,31 +756,30 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 3,
-                            "openAppointmentSlots": 3,
+                            "openTimeslots": 112,
+                            "openAppointmentSlots": 112,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 3,
+                    "openTimeslots": 112,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 3,
+                    "openAppointmentSlots": 112,
                     "name": "Waxahachie H-E-B",
                     "longitude": -96.83983,
                     "latitude": 32.41159,
                     "fluUrl": "",
                     "city": "WAXAHACHIE",
                     "availableImmunizations": [
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Janssen",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
-                        "COVID-19 Pediatric_Moderna",
                         "COVID-19 Novavax",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna"
                     ]
                 },
                 {
@@ -890,15 +791,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 90,
-                            "openAppointmentSlots": 90,
+                            "openTimeslots": 139,
+                            "openAppointmentSlots": 139,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 90,
+                    "openTimeslots": 139,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 90,
+                    "openAppointmentSlots": 139,
                     "name": "Military and Pleasanton H-E-B",
                     "longitude": -98.50277,
                     "latitude": 29.35666,
@@ -908,7 +809,8 @@
                         "Flu",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer"
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -920,23 +822,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 152,
-                            "openAppointmentSlots": 152,
+                            "openTimeslots": 1064,
+                            "openAppointmentSlots": 1064,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 152,
+                    "openTimeslots": 1064,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 152,
+                    "openAppointmentSlots": 1064,
                     "name": "Blanco and West Ave H-E-B",
                     "longitude": -98.51025,
                     "latitude": 29.54526,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Moderna",
                         "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
@@ -949,15 +853,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 581,
-                            "openAppointmentSlots": 581,
+                            "openTimeslots": 218,
+                            "openAppointmentSlots": 218,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 581,
+                    "openTimeslots": 218,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 581,
+                    "openAppointmentSlots": 218,
                     "name": "Pflugerville H-E-B",
                     "longitude": -97.6133,
                     "latitude": 30.4373,
@@ -967,9 +871,8 @@
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer"
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -981,23 +884,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 98,
-                            "openAppointmentSlots": 98,
+                            "openTimeslots": 25,
+                            "openAppointmentSlots": 25,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 98,
+                    "openTimeslots": 25,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 98,
+                    "openAppointmentSlots": 25,
                     "name": "I10 and Wurzbach H-E-B",
                     "longitude": -98.5595,
                     "latitude": 29.5336,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -1013,8 +916,8 @@
                     "openFluAppointmentSlots": 0,
                     "openAppointmentSlots": 0,
                     "name": "83 and Westgate H-E-B",
-                    "longitude": -97.98934,
-                    "latitude": 26.17109,
+                    "longitude": -98.00129,
+                    "latitude": 26.16495,
                     "fluUrl": "",
                     "city": "WESLACO",
                     "availableImmunizations": null
@@ -1028,15 +931,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 1,
-                            "openAppointmentSlots": 1,
+                            "openTimeslots": 2,
+                            "openAppointmentSlots": 2,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 1,
+                    "openTimeslots": 2,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 1,
+                    "openAppointmentSlots": 2,
                     "name": "Williams Drive H-E-B",
                     "longitude": -97.71873,
                     "latitude": 30.68312,
@@ -1057,15 +960,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 46,
-                            "openAppointmentSlots": 46,
+                            "openTimeslots": 63,
+                            "openAppointmentSlots": 63,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 46,
+                    "openTimeslots": 63,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 46,
+                    "openAppointmentSlots": 63,
                     "name": "Elsa H-E-B",
                     "longitude": -97.99272,
                     "latitude": 26.29384,
@@ -1085,58 +988,51 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 883,
-                            "openAppointmentSlots": 883,
+                            "openTimeslots": 887,
+                            "openAppointmentSlots": 887,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 883,
+                    "openTimeslots": 887,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 883,
+                    "openAppointmentSlots": 887,
                     "name": "Valley Hi H-E-B",
                     "longitude": -98.64021,
                     "latitude": 29.38099,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Moderna",
                         "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
                         "COVID-19 Novavax",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
                         "Flu"
                     ]
                 },
                 {
                     "zip": "76033-4830",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudzQAC",
+                    "url": null,
                     "type": "store",
                     "street": "600 W HENDERSON",
                     "storeNumber": 679,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 61,
-                            "openAppointmentSlots": 61,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 61,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 61,
+                    "openAppointmentSlots": 0,
                     "name": "Cleburne H-E-B",
                     "longitude": -97.39485,
                     "latitude": 32.3478,
                     "fluUrl": "",
                     "city": "CLEBURNE",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77375-1478",
@@ -1147,15 +1043,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 109,
-                            "openAppointmentSlots": 109,
+                            "openTimeslots": 278,
+                            "openAppointmentSlots": 278,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 109,
+                    "openTimeslots": 278,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 109,
+                    "openAppointmentSlots": 278,
                     "name": "Creekside Park H-E-B",
                     "longitude": -95.55072,
                     "latitude": 30.14362,
@@ -1164,8 +1060,10 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
                         "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
@@ -1178,15 +1076,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 390,
-                            "openAppointmentSlots": 390,
+                            "openTimeslots": 82,
+                            "openAppointmentSlots": 82,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 390,
+                    "openTimeslots": 82,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 390,
+                    "openAppointmentSlots": 82,
                     "name": "San Felipe H-E-B",
                     "longitude": -95.48512,
                     "latitude": 29.74797,
@@ -1225,24 +1123,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 81,
-                            "openAppointmentSlots": 81,
+                            "openTimeslots": 157,
+                            "openAppointmentSlots": 157,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 81,
+                    "openTimeslots": 157,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 81,
+                    "openAppointmentSlots": 157,
                     "name": "Bandera and Guilbeau H-E-B",
                     "longitude": -98.64364,
                     "latitude": 29.51985,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
-                        "COVID-19 Moderna_Updated_Booster",
+                        "Flu",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "Flu"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -1254,22 +1152,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 30,
-                            "openAppointmentSlots": 30,
+                            "openTimeslots": 70,
+                            "openAppointmentSlots": 70,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 30,
+                    "openTimeslots": 70,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 30,
+                    "openAppointmentSlots": 70,
                     "name": "Oak Hill H-E-B",
                     "longitude": -97.88755,
                     "latitude": 30.22696,
                     "fluUrl": "",
                     "city": "AUSTIN",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -1281,26 +1180,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 291,
-                            "openAppointmentSlots": 291,
+                            "openTimeslots": 274,
+                            "openAppointmentSlots": 274,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 291,
+                    "openTimeslots": 274,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 291,
+                    "openAppointmentSlots": 274,
                     "name": "Burnet H-E-B",
                     "longitude": -98.22452,
                     "latitude": 30.7588,
                     "fluUrl": "",
                     "city": "BURNET",
                     "availableImmunizations": [
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "Flu"
+                        "Flu",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -1350,15 +1247,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 72,
-                            "openAppointmentSlots": 72,
+                            "openTimeslots": 96,
+                            "openAppointmentSlots": 96,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 72,
+                    "openTimeslots": 96,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 72,
+                    "openAppointmentSlots": 96,
                     "name": "Military and Goliad H-E-B",
                     "longitude": -98.4362,
                     "latitude": 29.35194,
@@ -1370,7 +1267,9 @@
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -1382,15 +1281,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 164,
-                            "openAppointmentSlots": 164,
+                            "openTimeslots": 170,
+                            "openAppointmentSlots": 170,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 164,
+                    "openTimeslots": 170,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 164,
+                    "openAppointmentSlots": 170,
                     "name": "Lockhart H-E-B",
                     "longitude": -97.66994,
                     "latitude": 29.88213,
@@ -1400,51 +1299,87 @@
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer"
                     ]
                 },
                 {
                     "zip": "78521-1609",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucJQAS",
+                    "url": null,
                     "type": "store",
                     "street": "2155 PAREDES LINE RD",
                     "storeNumber": 446,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 17,
-                            "openAppointmentSlots": 17,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 17,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 17,
+                    "openAppointmentSlots": 0,
                     "name": "Paredes and Torres H-E-B plus!",
                     "longitude": -97.48904,
                     "latitude": 25.95015,
                     "fluUrl": "",
                     "city": "BROWNSVILLE",
+                    "availableImmunizations": null
+                },
+                {
+                    "zip": "78572-5362",
+                    "url": null,
+                    "type": "store",
+                    "street": "820 S. CONWAY",
+                    "storeNumber": 226,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "Conway and 9th St H-E-B",
+                    "longitude": -98.3262,
+                    "latitude": 26.21354,
+                    "fluUrl": "",
+                    "city": "MISSION",
+                    "availableImmunizations": null
+                },
+                {
+                    "zip": "78374-2816",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuccQAC",
+                    "type": "store",
+                    "street": "1600 WILDCAT DRIVE",
+                    "storeNumber": 488,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 27,
+                            "openAppointmentSlots": 27,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 27,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 27,
+                    "name": "Portland H-E-B",
+                    "longitude": -97.31836,
+                    "latitude": 27.88722,
+                    "fluUrl": "",
+                    "city": "PORTLAND",
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Janssen",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
-                    "zip": "78572-5362",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubJQAS",
+                    "zip": "78521-2216",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucdQAC",
                     "type": "store",
-                    "street": "820 S. CONWAY",
-                    "storeNumber": 226,
+                    "street": "2250 BOCA CHICA",
+                    "storeNumber": 489,
                     "state": "TX",
                     "slotDetails": [
                         {
@@ -1457,72 +1392,18 @@
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
                     "openAppointmentSlots": 26,
-                    "name": "Conway and 9th St H-E-B",
-                    "longitude": -98.3262,
-                    "latitude": 26.21354,
-                    "fluUrl": "",
-                    "city": "MISSION",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
-                },
-                {
-                    "zip": "78374-2816",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuccQAC",
-                    "type": "store",
-                    "street": "1600 WILDCAT DRIVE",
-                    "storeNumber": 488,
-                    "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 124,
-                            "openAppointmentSlots": 124,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 124,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 124,
-                    "name": "Portland H-E-B",
-                    "longitude": -97.31836,
-                    "latitude": 27.88722,
-                    "fluUrl": "",
-                    "city": "PORTLAND",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
-                },
-                {
-                    "zip": "78521-2216",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucdQAC",
-                    "type": "store",
-                    "street": "2250 BOCA CHICA",
-                    "storeNumber": 489,
-                    "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 28,
-                            "openAppointmentSlots": 28,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 28,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 28,
                     "name": "Boca Chica H-E-B",
                     "longitude": -97.48722,
                     "latitude": 25.92214,
                     "fluUrl": "",
                     "city": "BROWNSVILLE",
                     "availableImmunizations": [
-                        "Flu"
+                        "Flu",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -1534,22 +1415,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 168,
-                            "openAppointmentSlots": 168,
+                            "openTimeslots": 256,
+                            "openAppointmentSlots": 256,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 168,
+                    "openTimeslots": 256,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 168,
+                    "openAppointmentSlots": 256,
                     "name": "Fry Rd and I10 H-E-B",
                     "longitude": -95.7189,
                     "latitude": 29.7898,
                     "fluUrl": "",
                     "city": "HOUSTON",
                     "availableImmunizations": [
-                        "Flu"
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -1561,30 +1445,30 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 502,
-                            "openAppointmentSlots": 502,
+                            "openTimeslots": 321,
+                            "openAppointmentSlots": 321,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 416,
-                    "openFluTimeslots": 86,
-                    "openFluAppointmentSlots": 86,
-                    "openAppointmentSlots": 416,
+                    "openTimeslots": 321,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 321,
                     "name": "Culebra and 1604 H-E-B",
                     "longitude": -98.70445,
                     "latitude": 29.49292,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3BQAU",
+                    "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Janssen",
                         "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Novavax",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
                         "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
@@ -1597,25 +1481,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 405,
-                            "openAppointmentSlots": 405,
+                            "openTimeslots": 387,
+                            "openAppointmentSlots": 387,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 405,
+                    "openTimeslots": 387,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 405,
+                    "openAppointmentSlots": 387,
                     "name": "Beaumont 6 H-E-B",
                     "longitude": -94.12834,
                     "latitude": 30.06853,
                     "fluUrl": "",
                     "city": "BEAUMONT",
                     "availableImmunizations": [
-                        "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Pfizer_Updated_Booster",
+                        "Flu",
                         "COVID-19 Pediatric_Pfizer"
                     ]
                 },
@@ -1628,24 +1512,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 79,
-                            "openAppointmentSlots": 79,
+                            "openTimeslots": 63,
+                            "openAppointmentSlots": 63,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 79,
+                    "openTimeslots": 63,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 79,
+                    "openAppointmentSlots": 63,
                     "name": "Kenedy H-E-B",
                     "longitude": -97.85797,
                     "latitude": 28.81419,
                     "fluUrl": "",
                     "city": "KENEDY",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
                         "Flu",
-                        "COVID-19 Pediatric_Pfizer"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -1657,26 +1542,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 128,
-                            "openAppointmentSlots": 128,
+                            "openTimeslots": 215,
+                            "openAppointmentSlots": 215,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 128,
+                    "openTimeslots": 215,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 128,
+                    "openAppointmentSlots": 215,
                     "name": "New Braunfels H-E-B plus!",
                     "longitude": -98.0782,
                     "latitude": 29.731,
                     "fluUrl": "",
                     "city": "NEW BRAUNFELS",
                     "availableImmunizations": [
+                        "COVID-19 Pediatric_Moderna",
                         "COVID-19 Ultra_Pediatric_Pfizer",
-                        "COVID-19 Moderna",
-                        "Flu",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Novavax"
+                        "COVID-19 Novavax",
+                        "Flu",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -1688,24 +1574,22 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 578,
-                            "openAppointmentSlots": 578,
+                            "openTimeslots": 737,
+                            "openAppointmentSlots": 737,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 578,
+                    "openTimeslots": 737,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 578,
+                    "openAppointmentSlots": 737,
                     "name": "Gattis School H-E-B plus! Hutto",
                     "longitude": -97.58284,
                     "latitude": 30.50112,
                     "fluUrl": "",
                     "city": "HUTTO",
                     "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "Flu"
                     ]
                 },
                 {
@@ -1717,15 +1601,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 859,
-                            "openAppointmentSlots": 859,
+                            "openTimeslots": 388,
+                            "openAppointmentSlots": 388,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 602,
-                    "openFluTimeslots": 257,
-                    "openFluAppointmentSlots": 257,
-                    "openAppointmentSlots": 602,
+                    "openTimeslots": 294,
+                    "openFluTimeslots": 94,
+                    "openFluAppointmentSlots": 94,
+                    "openAppointmentSlots": 294,
                     "name": "League City Market H-E-B",
                     "longitude": -95.04131,
                     "latitude": 29.50588,
@@ -1733,43 +1617,31 @@
                     "city": "LEAGUE CITY",
                     "availableImmunizations": [
                         "COVID-19 Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Moderna",
                         "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer"
                     ]
                 },
                 {
                     "zip": "79764-7155",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueGQAS",
+                    "url": null,
                     "type": "store",
                     "street": "2501 W UNIVERSITY BLVD",
                     "storeNumber": 711,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 87,
-                            "openAppointmentSlots": 87,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 87,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 87,
+                    "openAppointmentSlots": 0,
                     "name": "Odessa H-E-B University Blvd",
                     "longitude": -102.41008,
                     "latitude": 31.86213,
                     "fluUrl": "",
                     "city": "ODESSA",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
-                        "COVID-19 Novavax",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77954-2126",
@@ -1799,23 +1671,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 132,
-                            "openAppointmentSlots": 132,
+                            "openTimeslots": 113,
+                            "openAppointmentSlots": 113,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 132,
+                    "openTimeslots": 113,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 132,
+                    "openAppointmentSlots": 113,
                     "name": "Clear Lake Marketplace H-E-B",
                     "longitude": -95.12473,
                     "latitude": 29.60563,
                     "fluUrl": "",
                     "city": "HOUSTON",
                     "availableImmunizations": [
+                        "Flu",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "Flu"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -1827,15 +1701,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 25,
-                            "openAppointmentSlots": 25,
+                            "openTimeslots": 15,
+                            "openAppointmentSlots": 15,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 25,
+                    "openTimeslots": 15,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 25,
+                    "openAppointmentSlots": 15,
                     "name": "Lakeway H-E-B",
                     "longitude": -97.96662,
                     "latitude": 30.34368,
@@ -1874,15 +1748,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 2,
-                            "openAppointmentSlots": 2,
+                            "openTimeslots": 5,
+                            "openAppointmentSlots": 5,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 2,
+                    "openTimeslots": 5,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 2,
+                    "openAppointmentSlots": 5,
                     "name": "35 and Del Mar H-E-B",
                     "longitude": -99.49676,
                     "latitude": 27.56786,
@@ -1890,7 +1764,7 @@
                     "city": "LAREDO",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -1914,37 +1788,22 @@
                 },
                 {
                     "zip": "77375-4546",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gud3QAC",
+                    "url": null,
                     "type": "store",
                     "street": "28520 TOMBALL PARKWAY",
                     "storeNumber": 574,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 65,
-                            "openAppointmentSlots": 65,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 65,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 65,
+                    "openAppointmentSlots": 0,
                     "name": "Tomball Pkwy and Graham H-E-B",
                     "longitude": -95.63218,
                     "latitude": 30.08868,
                     "fluUrl": "",
                     "city": "TOMBALL",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
-                        "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Novavax",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77379-7234",
@@ -1955,23 +1814,21 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 90,
-                            "openAppointmentSlots": 90,
+                            "openTimeslots": 14,
+                            "openAppointmentSlots": 14,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 90,
+                    "openTimeslots": 14,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 90,
+                    "openAppointmentSlots": 14,
                     "name": "Louetta and Stuebner H-E-B",
                     "longitude": -95.5243,
                     "latitude": 30.0209,
                     "fluUrl": "",
                     "city": "SPRING",
                     "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
@@ -1984,15 +1841,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 80,
-                            "openAppointmentSlots": 80,
+                            "openTimeslots": 13,
+                            "openAppointmentSlots": 13,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 80,
+                    "openTimeslots": 13,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 80,
+                    "openAppointmentSlots": 13,
                     "name": "Kempwood and Gessner H-E-B",
                     "longitude": -95.5468,
                     "latitude": 29.8226,
@@ -2002,8 +1859,11 @@
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -2015,15 +1875,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 41,
-                            "openAppointmentSlots": 41,
+                            "openTimeslots": 52,
+                            "openAppointmentSlots": 52,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 41,
+                    "openTimeslots": 52,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 41,
+                    "openAppointmentSlots": 52,
                     "name": "Woodlands Market H-E-B",
                     "longitude": -95.46575,
                     "latitude": 30.16409,
@@ -2033,8 +1893,10 @@
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -2046,15 +1908,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 18,
-                            "openAppointmentSlots": 18,
+                            "openTimeslots": 37,
+                            "openAppointmentSlots": 37,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 18,
+                    "openTimeslots": 37,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 18,
+                    "openAppointmentSlots": 37,
                     "name": "Parmer and Whitestone H-E-B",
                     "longitude": -97.78545,
                     "latitude": 30.5328,
@@ -2062,9 +1924,7 @@
                     "city": "CEDAR PARK",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -2076,15 +1936,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 76,
-                            "openAppointmentSlots": 76,
+                            "openTimeslots": 70,
+                            "openAppointmentSlots": 70,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 76,
+                    "openTimeslots": 70,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 76,
+                    "openAppointmentSlots": 70,
                     "name": "Stephenville H-E-B",
                     "longitude": -98.22569,
                     "latitude": 32.20975,
@@ -2107,30 +1967,29 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 206,
-                            "openAppointmentSlots": 206,
+                            "openTimeslots": 351,
+                            "openAppointmentSlots": 351,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 206,
+                    "openTimeslots": 351,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 206,
+                    "openAppointmentSlots": 351,
                     "name": "Slaughter and Manchaca H-E-B",
                     "longitude": -97.82509,
                     "latitude": 30.17524,
                     "fluUrl": "",
                     "city": "AUSTIN",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "Flu",
                         "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
                         "COVID-19 Novavax",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Moderna"
+                        "COVID-19 Pediatric_Moderna",
+                        "Flu"
                     ]
                 },
                 {
@@ -2142,15 +2001,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 40,
-                            "openAppointmentSlots": 40,
+                            "openTimeslots": 26,
+                            "openAppointmentSlots": 26,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 40,
+                    "openTimeslots": 26,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 40,
+                    "openAppointmentSlots": 26,
                     "name": "I 35 and William Cannon H-E-B",
                     "longitude": -97.76922,
                     "latitude": 30.19107,
@@ -2170,15 +2029,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 672,
-                            "openAppointmentSlots": 672,
+                            "openTimeslots": 452,
+                            "openAppointmentSlots": 452,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 672,
+                    "openTimeslots": 452,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 672,
+                    "openAppointmentSlots": 452,
                     "name": "Nacogdoches and O'Connor H-E-B",
                     "longitude": -98.3856,
                     "latitude": 29.56937,
@@ -2186,46 +2045,72 @@
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "78596-4511",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubNQAS",
                     "type": "store",
                     "street": "1004 N. TEXAS",
                     "storeNumber": 231,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 99,
+                            "openAppointmentSlots": 99,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 99,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 99,
                     "name": "83 and N Texas H-E-B",
                     "longitude": -97.99096,
                     "latitude": 26.17103,
                     "fluUrl": "",
                     "city": "WESLACO",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Novavax",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer"
+                    ]
                 },
                 {
                     "zip": "77488-3204",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubOQAS",
                     "type": "store",
                     "street": "1616 N ALABAMA",
                     "storeNumber": 233,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 34,
+                            "openAppointmentSlots": 34,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 34,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 34,
                     "name": "Wharton H-E-B",
                     "longitude": -96.08492,
                     "latitude": 29.32162,
                     "fluUrl": "",
                     "city": "WHARTON",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77450-4564",
@@ -2236,15 +2121,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 101,
-                            "openAppointmentSlots": 101,
+                            "openTimeslots": 45,
+                            "openAppointmentSlots": 45,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 101,
+                    "openTimeslots": 45,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 101,
+                    "openAppointmentSlots": 45,
                     "name": "Mason Rd H-E-B",
                     "longitude": -95.75102,
                     "latitude": 29.75787,
@@ -2264,15 +2149,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 694,
-                            "openAppointmentSlots": 694,
+                            "openTimeslots": 339,
+                            "openAppointmentSlots": 339,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 480,
-                    "openFluTimeslots": 214,
-                    "openFluAppointmentSlots": 214,
-                    "openAppointmentSlots": 480,
+                    "openTimeslots": 199,
+                    "openFluTimeslots": 140,
+                    "openFluAppointmentSlots": 140,
+                    "openAppointmentSlots": 199,
                     "name": "Atascocita H-E-B",
                     "longitude": -95.1642,
                     "latitude": 29.9983,
@@ -2294,15 +2179,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 79,
-                            "openAppointmentSlots": 79,
+                            "openTimeslots": 68,
+                            "openAppointmentSlots": 68,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 79,
+                    "openTimeslots": 68,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 79,
+                    "openAppointmentSlots": 68,
                     "name": "Gulfgate H-E-B",
                     "longitude": -95.2968,
                     "latitude": 29.6994,
@@ -2311,43 +2196,29 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
                         "COVID-19 Novavax",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "77072-5000",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuckQAC",
+                    "url": null,
                     "type": "store",
                     "street": "10100 BEECHNUT",
                     "storeNumber": 541,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 119,
-                            "openAppointmentSlots": 119,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 119,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 119,
+                    "openAppointmentSlots": 0,
                     "name": "Beechnut H-E-B",
                     "longitude": -95.5604,
                     "latitude": 29.6896,
                     "fluUrl": "",
                     "city": "HOUSTON",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77840-3914",
@@ -2358,55 +2229,43 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 240,
-                            "openAppointmentSlots": 240,
+                            "openTimeslots": 84,
+                            "openAppointmentSlots": 84,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 240,
+                    "openTimeslots": 84,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 240,
+                    "openAppointmentSlots": 84,
                     "name": "Texas Avenue H-E-B",
                     "longitude": -96.3165,
                     "latitude": 30.6131,
                     "fluUrl": "",
                     "city": "COLLEGE STATION",
                     "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu"
                     ]
                 },
                 {
                     "zip": "77429-6286",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gue7QAC",
+                    "url": null,
                     "type": "store",
                     "street": "14100 SPRING CYPRESS RD",
                     "storeNumber": 698,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 187,
-                            "openAppointmentSlots": 187,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 187,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 187,
+                    "openAppointmentSlots": 0,
                     "name": "Grant and Spring Cypress H-E-B",
                     "longitude": -95.63698,
                     "latitude": 30.00365,
                     "fluUrl": "",
                     "city": "CYPRESS",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78204-2427",
@@ -2417,15 +2276,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 280,
-                            "openAppointmentSlots": 280,
+                            "openTimeslots": 108,
+                            "openAppointmentSlots": 108,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 280,
+                    "openTimeslots": 108,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 280,
+                    "openAppointmentSlots": 108,
                     "name": "Nogalitos H-E-B",
                     "longitude": -98.51485,
                     "latitude": 29.39799,
@@ -2433,11 +2292,10 @@
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -2506,15 +2364,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 291,
-                            "openAppointmentSlots": 291,
+                            "openTimeslots": 237,
+                            "openAppointmentSlots": 237,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 291,
+                    "openTimeslots": 237,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 291,
+                    "openAppointmentSlots": 237,
                     "name": "Spring Creek Market H-E-B",
                     "longitude": -95.38801,
                     "latitude": 30.11036,
@@ -2523,54 +2381,56 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "78155-5131",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueLQAS",
                     "type": "store",
                     "street": "1340 E COURT ST",
                     "storeNumber": 716,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 128,
+                            "openAppointmentSlots": 128,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 128,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 128,
+                    "name": "Seguin H-E-B",
+                    "longitude": -97.94366,
+                    "latitude": 29.57065,
+                    "fluUrl": "",
+                    "city": "SEGUIN",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                    ]
+                },
+                {
+                    "zip": "79706-2851",
+                    "url": null,
+                    "type": "store",
+                    "street": "5407 ANDREWS HIGHWAY",
+                    "storeNumber": 717,
                     "state": "TX",
                     "slotDetails": [],
                     "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
                     "openAppointmentSlots": 0,
-                    "name": "Seguin H-E-B",
-                    "longitude": -97.94366,
-                    "latitude": 29.57065,
-                    "fluUrl": "",
-                    "city": "SEGUIN",
-                    "availableImmunizations": null
-                },
-                {
-                    "zip": "79706-2851",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueMQAS",
-                    "type": "store",
-                    "street": "5407 ANDREWS HIGHWAY",
-                    "storeNumber": 717,
-                    "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 48,
-                            "openAppointmentSlots": 48,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 48,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 48,
                     "name": "Midland Loop 250 H-E-B",
                     "longitude": -102.15509,
                     "latitude": 31.99588,
                     "fluUrl": "",
                     "city": "MIDLAND",
-                    "availableImmunizations": [
-                        "Flu"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77345-2621",
@@ -2581,25 +2441,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 44,
-                            "openAppointmentSlots": 44,
+                            "openTimeslots": 83,
+                            "openAppointmentSlots": 83,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 44,
+                    "openTimeslots": 83,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 44,
+                    "openAppointmentSlots": 83,
                     "name": "Kingwood Market H-E-B",
                     "longitude": -95.18375,
                     "latitude": 30.05329,
                     "fluUrl": "",
                     "city": "KINGWOOD",
                     "availableImmunizations": [
-                        "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer"
                     ]
                 },
                 {
@@ -2611,15 +2473,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 26,
-                            "openAppointmentSlots": 26,
+                            "openTimeslots": 32,
+                            "openAppointmentSlots": 32,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 26,
+                    "openTimeslots": 32,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 26,
+                    "openAppointmentSlots": 32,
                     "name": "Fort Hood Stan Schlueter H-E-B",
                     "longitude": -97.75988,
                     "latitude": 31.07989,
@@ -2627,9 +2489,8 @@
                     "city": "KILLEEN",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -2641,15 +2502,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 103,
-                            "openAppointmentSlots": 103,
+                            "openTimeslots": 112,
+                            "openAppointmentSlots": 112,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 103,
+                    "openTimeslots": 112,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 103,
+                    "openAppointmentSlots": 112,
                     "name": "Magnolia Market H-E-B",
                     "longitude": -95.5837,
                     "latitude": 30.2217,
@@ -2660,7 +2521,8 @@
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -2672,56 +2534,44 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 102,
-                            "openAppointmentSlots": 102,
+                            "openTimeslots": 165,
+                            "openAppointmentSlots": 165,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 102,
+                    "openTimeslots": 165,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 102,
+                    "openAppointmentSlots": 165,
                     "name": "Aliana Market H-E-B",
                     "longitude": -95.7137,
                     "latitude": 29.6597,
                     "fluUrl": "",
                     "city": "RICHMOND",
                     "availableImmunizations": [
-                        "Flu",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "Flu",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "78572-9139",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucKQAS",
+                    "url": null,
                     "type": "store",
                     "street": "6010 W EXPRESSWAY 83",
                     "storeNumber": 448,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 27,
-                            "openAppointmentSlots": 27,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 27,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 27,
+                    "openAppointmentSlots": 0,
                     "name": "Palmview H-E-B",
                     "longitude": -98.38385,
                     "latitude": 26.23538,
                     "fluUrl": "",
                     "city": "PALMVIEW",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78726-4539",
@@ -2732,15 +2582,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 36,
-                            "openAppointmentSlots": 36,
+                            "openTimeslots": 14,
+                            "openAppointmentSlots": 14,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 36,
+                    "openTimeslots": 14,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 36,
+                    "openAppointmentSlots": 14,
                     "name": "Four Points H-E-B",
                     "longitude": -97.85202,
                     "latitude": 30.40458,
@@ -2748,6 +2598,8 @@
                     "city": "AUSTIN",
                     "availableImmunizations": [
                         "Flu",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
@@ -2772,22 +2624,31 @@
                 },
                 {
                     "zip": "78405-2040",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucOQAS",
                     "type": "store",
                     "street": "3033 SOUTH PORT ST.",
                     "storeNumber": 462,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 43,
+                            "openAppointmentSlots": 43,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 43,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 43,
                     "name": "S Port and Tarlton H-E-B",
                     "longitude": -97.42137,
                     "latitude": 27.76687,
                     "fluUrl": "",
                     "city": "CORPUS CHRISTI",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "Senior_Flu"
+                    ]
                 },
                 {
                     "zip": "78248-4552",
@@ -2798,30 +2659,28 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 1321,
-                            "openAppointmentSlots": 1321,
+                            "openTimeslots": 442,
+                            "openAppointmentSlots": 442,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 1321,
+                    "openTimeslots": 442,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 1321,
+                    "openAppointmentSlots": 442,
                     "name": "Loop 1604 and Blanco Rd H-E-B plus!",
                     "longitude": -98.50968,
                     "latitude": 29.60792,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Moderna",
                         "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Novavax",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Ultra_Pediatric_Pfizer"
                     ]
                 },
                 {
@@ -2833,15 +2692,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 673,
-                            "openAppointmentSlots": 673,
+                            "openTimeslots": 452,
+                            "openAppointmentSlots": 452,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 673,
+                    "openTimeslots": 452,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 673,
+                    "openAppointmentSlots": 452,
                     "name": "7th Street H-E-B",
                     "longitude": -97.71143,
                     "latitude": 30.26046,
@@ -2899,15 +2758,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 145,
-                            "openAppointmentSlots": 145,
+                            "openTimeslots": 80,
+                            "openAppointmentSlots": 80,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 145,
+                    "openTimeslots": 80,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 145,
+                    "openAppointmentSlots": 80,
                     "name": "Fairmont Pkwy H-E-B",
                     "longitude": -95.14512,
                     "latitude": 29.6497,
@@ -2917,9 +2776,8 @@
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -2931,27 +2789,28 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 1099,
-                            "openAppointmentSlots": 1099,
+                            "openTimeslots": 821,
+                            "openAppointmentSlots": 821,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 1099,
+                    "openTimeslots": 821,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 1099,
+                    "openAppointmentSlots": 821,
                     "name": "Lake Colony H-E-B",
                     "longitude": -95.58244,
                     "latitude": 29.58032,
                     "fluUrl": "",
                     "city": "MISSOURI CITY",
                     "availableImmunizations": [
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -2963,15 +2822,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 242,
-                            "openAppointmentSlots": 242,
+                            "openTimeslots": 90,
+                            "openAppointmentSlots": 90,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 242,
+                    "openTimeslots": 90,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 242,
+                    "openAppointmentSlots": 90,
                     "name": "Elgin H-E-B",
                     "longitude": -97.38258,
                     "latitude": 30.34701,
@@ -2979,9 +2838,7 @@
                     "city": "ELGIN",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -2993,25 +2850,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 130,
-                            "openAppointmentSlots": 130,
+                            "openTimeslots": 85,
+                            "openAppointmentSlots": 85,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 84,
-                    "openFluTimeslots": 46,
-                    "openFluAppointmentSlots": 46,
-                    "openAppointmentSlots": 84,
+                    "openTimeslots": 85,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 85,
                     "name": "Tech Ridge H-E-B",
                     "longitude": -97.67201,
                     "latitude": 30.40443,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF32QAE",
+                    "fluUrl": "",
                     "city": "AUSTIN",
                     "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
                         "Flu",
-                        "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Novavax",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -3023,15 +2881,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 82,
-                            "openAppointmentSlots": 82,
+                            "openTimeslots": 67,
+                            "openAppointmentSlots": 67,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 82,
+                    "openTimeslots": 67,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 82,
+                    "openAppointmentSlots": 67,
                     "name": "Buda H-E-B",
                     "longitude": -97.82074,
                     "latitude": 30.08769,
@@ -3063,50 +2921,51 @@
                 },
                 {
                     "zip": "78626-5400",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubRQAS",
+                    "url": null,
                     "type": "store",
                     "street": "1100 SOUTH IH35",
                     "storeNumber": 237,
-                    "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 35,
-                            "openAppointmentSlots": 35,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 35,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 35,
-                    "name": "35 and West University H-E-B",
-                    "longitude": -97.69028,
-                    "latitude": 30.63446,
-                    "fluUrl": "",
-                    "city": "GEORGETOWN",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
-                },
-                {
-                    "zip": "75110-5138",
-                    "url": null,
-                    "type": "store",
-                    "street": "201 S. 15TH STREET",
-                    "storeNumber": 238,
                     "state": "TX",
                     "slotDetails": [],
                     "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
                     "openAppointmentSlots": 0,
+                    "name": "35 and West University H-E-B",
+                    "longitude": -97.69028,
+                    "latitude": 30.63446,
+                    "fluUrl": "",
+                    "city": "GEORGETOWN",
+                    "availableImmunizations": null
+                },
+                {
+                    "zip": "75110-5138",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubSQAS",
+                    "type": "store",
+                    "street": "201 S. 15TH STREET",
+                    "storeNumber": 238,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 16,
+                            "openAppointmentSlots": 16,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 16,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 16,
                     "name": "Corsicana H-E-B",
                     "longitude": -96.46827,
                     "latitude": 32.09005,
                     "fluUrl": "",
                     "city": "CORSICANA",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78666-7055",
@@ -3117,15 +2976,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 261,
-                            "openAppointmentSlots": 261,
+                            "openTimeslots": 116,
+                            "openAppointmentSlots": 116,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 261,
+                    "openTimeslots": 116,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 261,
+                    "openAppointmentSlots": 116,
                     "name": "East Hopkins H-E-B",
                     "longitude": -97.93132,
                     "latitude": 29.88489,
@@ -3133,41 +2992,30 @@
                     "city": "SAN MARCOS",
                     "availableImmunizations": [
                         "COVID-19 Moderna",
-                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster",
                         "Flu",
                         "COVID-19 Pfizer",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "78408-3204",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubUQAS",
+                    "url": null,
                     "type": "store",
                     "street": "3500 LEOPARD",
                     "storeNumber": 253,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 69,
-                            "openAppointmentSlots": 69,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 69,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 69,
+                    "openAppointmentSlots": 0,
                     "name": "Leopard and Nueces Bay H-E-B",
                     "longitude": -97.42774,
                     "latitude": 27.79695,
                     "fluUrl": "",
                     "city": "CORPUS CHRISTI",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77802-5320",
@@ -3178,15 +3026,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 30,
-                            "openAppointmentSlots": 30,
+                            "openTimeslots": 54,
+                            "openAppointmentSlots": 54,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 30,
+                    "openTimeslots": 54,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 30,
+                    "openAppointmentSlots": 54,
                     "name": "Tejas Center H-E-B",
                     "longitude": -96.3513,
                     "latitude": 30.64506,
@@ -3197,7 +3045,8 @@
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -3209,15 +3058,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 263,
-                            "openAppointmentSlots": 263,
+                            "openTimeslots": 150,
+                            "openAppointmentSlots": 150,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 263,
+                    "openTimeslots": 150,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 263,
+                    "openAppointmentSlots": 150,
                     "name": "Westheimer and Kirkwood H-E-B",
                     "longitude": -95.587,
                     "latitude": 29.7363,
@@ -3225,7 +3074,9 @@
                     "city": "HOUSTON",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "COVID-19 Moderna"
                     ]
                 },
                 {
@@ -3237,26 +3088,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 537,
-                            "openAppointmentSlots": 537,
+                            "openTimeslots": 68,
+                            "openAppointmentSlots": 68,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 416,
-                    "openFluTimeslots": 121,
-                    "openFluAppointmentSlots": 121,
-                    "openAppointmentSlots": 416,
+                    "openTimeslots": 68,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 68,
                     "name": "Bear Creek H-E-B",
                     "longitude": -95.6457,
                     "latitude": 29.8487,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3KQAU",
+                    "fluUrl": "",
                     "city": "HOUSTON",
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -3306,15 +3158,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 87,
-                            "openAppointmentSlots": 87,
+                            "openTimeslots": 59,
+                            "openAppointmentSlots": 59,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 87,
+                    "openTimeslots": 59,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 87,
+                    "openAppointmentSlots": 59,
                     "name": "Deco District H-E-B",
                     "longitude": -98.5261,
                     "latitude": 29.4646,
@@ -3333,23 +3185,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 122,
-                            "openAppointmentSlots": 122,
+                            "openTimeslots": 63,
+                            "openAppointmentSlots": 63,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 122,
+                    "openTimeslots": 63,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 122,
+                    "openAppointmentSlots": 63,
                     "name": "35 and 84 H-E-B plus!",
                     "longitude": -97.10723,
                     "latitude": 31.58764,
                     "fluUrl": "",
                     "city": "BELLMEAD",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -3361,24 +3214,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 339,
-                            "openAppointmentSlots": 339,
+                            "openTimeslots": 638,
+                            "openAppointmentSlots": 638,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 339,
+                    "openTimeslots": 638,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 339,
+                    "openAppointmentSlots": 638,
                     "name": "Friendswood H-E-B",
                     "longitude": -95.1912,
                     "latitude": 29.5066,
                     "fluUrl": "",
                     "city": "FRIENDSWOOD",
                     "availableImmunizations": [
+                        "Flu",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "Flu"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -3390,28 +3243,22 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 123,
-                            "openAppointmentSlots": 123,
+                            "openTimeslots": 70,
+                            "openAppointmentSlots": 70,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 123,
+                    "openTimeslots": 70,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 123,
+                    "openAppointmentSlots": 70,
                     "name": "Lake Jackson H-E-B",
                     "longitude": -95.44554,
                     "latitude": 29.04151,
                     "fluUrl": "",
                     "city": "LAKE JACKSON",
                     "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "Flu"
                     ]
                 },
                 {
@@ -3423,15 +3270,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 17,
-                            "openAppointmentSlots": 17,
+                            "openTimeslots": 69,
+                            "openAppointmentSlots": 69,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 17,
+                    "openTimeslots": 69,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 17,
+                    "openAppointmentSlots": 69,
                     "name": "Wimberley H-E-B",
                     "longitude": -98.10174,
                     "latitude": 30.00144,
@@ -3440,7 +3287,6 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
-                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
@@ -3454,15 +3300,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 287,
-                            "openAppointmentSlots": 287,
+                            "openTimeslots": 500,
+                            "openAppointmentSlots": 500,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 287,
+                    "openTimeslots": 500,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 287,
+                    "openAppointmentSlots": 500,
                     "name": "H-E-B Market at Tuckerton",
                     "longitude": -95.72501,
                     "latitude": 29.92737,
@@ -3470,10 +3316,11 @@
                     "city": "CYPRESS",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Novavax",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Moderna"
+                        "COVID-19 Pfizer"
                     ]
                 },
                 {
@@ -3485,15 +3332,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 53,
-                            "openAppointmentSlots": 53,
+                            "openTimeslots": 180,
+                            "openAppointmentSlots": 180,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 53,
+                    "openTimeslots": 180,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 53,
+                    "openAppointmentSlots": 180,
                     "name": "Champion Forest Market H-E-B",
                     "longitude": -95.57475,
                     "latitude": 30.0551,
@@ -3501,7 +3348,8 @@
                     "city": "SPRING",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -3513,15 +3361,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 155,
-                            "openAppointmentSlots": 155,
+                            "openTimeslots": 56,
+                            "openAppointmentSlots": 56,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 155,
+                    "openTimeslots": 56,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 155,
+                    "openAppointmentSlots": 56,
                     "name": "Richmond Market H-E-B",
                     "longitude": -95.74781,
                     "latitude": 29.55142,
@@ -3542,15 +3390,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 61,
-                            "openAppointmentSlots": 61,
+                            "openTimeslots": 40,
+                            "openAppointmentSlots": 40,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 61,
+                    "openTimeslots": 40,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 61,
+                    "openAppointmentSlots": 40,
                     "name": "Huntsville H-E-B",
                     "longitude": -95.56075,
                     "latitude": 30.72274,
@@ -3558,11 +3406,13 @@
                     "city": "HUNTSVILLE",
                     "availableImmunizations": [
                         "Flu",
+                        "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna"
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -3574,23 +3424,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 335,
-                            "openAppointmentSlots": 335,
+                            "openTimeslots": 810,
+                            "openAppointmentSlots": 810,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 300,
-                    "openFluTimeslots": 35,
-                    "openFluAppointmentSlots": 35,
-                    "openAppointmentSlots": 300,
+                    "openTimeslots": 810,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 810,
                     "name": "Bulverde and 1604 H-E-B",
                     "longitude": -98.41746,
                     "latitude": 29.59497,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF1UQAU",
+                    "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
                         "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
                         "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
@@ -3603,24 +3455,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 8,
-                            "openAppointmentSlots": 8,
+                            "openTimeslots": 5,
+                            "openAppointmentSlots": 5,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 8,
+                    "openTimeslots": 5,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 8,
+                    "openAppointmentSlots": 5,
                     "name": "35 and Calton H-E-B",
                     "longitude": -99.50182,
                     "latitude": 27.54172,
                     "fluUrl": "",
                     "city": "LAREDO",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Ultra_Pediatric_Pfizer"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -3651,15 +3506,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 250,
-                            "openAppointmentSlots": 250,
+                            "openTimeslots": 148,
+                            "openAppointmentSlots": 148,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 250,
+                    "openTimeslots": 148,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 250,
+                    "openAppointmentSlots": 148,
                     "name": "Central Blvd H-E-B",
                     "longitude": -97.51093,
                     "latitude": 25.92849,
@@ -3668,12 +3523,14 @@
                     "availableImmunizations": [
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "Flu",
                         "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Novavax",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Flu"
                     ]
                 },
                 {
@@ -3685,24 +3542,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 67,
-                            "openAppointmentSlots": 67,
+                            "openTimeslots": 1,
+                            "openAppointmentSlots": 1,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 67,
+                    "openTimeslots": 1,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 67,
+                    "openAppointmentSlots": 1,
                     "name": "Hwy 183 and Whitestone Blvd H-E-B",
                     "longitude": -97.82911,
                     "latitude": 30.5225,
                     "fluUrl": "",
                     "city": "CEDAR PARK",
                     "availableImmunizations": [
-                        "COVID-19 Moderna_Updated_Booster",
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -3714,22 +3570,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 68,
-                            "openAppointmentSlots": 68,
+                            "openTimeslots": 151,
+                            "openAppointmentSlots": 151,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 68,
+                    "openTimeslots": 151,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 68,
+                    "openAppointmentSlots": 151,
                     "name": "North Hills H-E-B",
                     "longitude": -97.74832,
                     "latitude": 30.39868,
                     "fluUrl": "",
                     "city": "AUSTIN",
                     "availableImmunizations": [
-                        "Flu"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Flu",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -3741,42 +3600,52 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 98,
-                            "openAppointmentSlots": 98,
+                            "openTimeslots": 69,
+                            "openAppointmentSlots": 69,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 98,
+                    "openTimeslots": 69,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 98,
+                    "openAppointmentSlots": 69,
                     "name": "Moore Plaza H-E-B",
                     "longitude": -97.37238,
                     "latitude": 27.70605,
                     "fluUrl": "",
                     "city": "CORPUS CHRISTI",
                     "availableImmunizations": [
-                        "Flu"
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "78624-4146",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucuQAC",
                     "type": "store",
                     "street": "407 SOUTH ADAMS",
                     "storeNumber": 561,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 31,
+                            "openAppointmentSlots": 31,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 31,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 31,
                     "name": "Fredericksburg H-E-B",
                     "longitude": -98.87538,
                     "latitude": 30.27006,
                     "fluUrl": "",
                     "city": "FREDERICKSBURG",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78382-3314",
@@ -3806,15 +3675,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 137,
-                            "openAppointmentSlots": 137,
+                            "openTimeslots": 286,
+                            "openAppointmentSlots": 286,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 137,
+                    "openTimeslots": 286,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 137,
+                    "openAppointmentSlots": 286,
                     "name": "Riverpark H-E-B",
                     "longitude": -95.6815,
                     "latitude": 29.5636,
@@ -3824,7 +3693,10 @@
                         "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Novavax",
                         "Flu",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -3836,15 +3708,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 41,
-                            "openAppointmentSlots": 41,
+                            "openTimeslots": 147,
+                            "openAppointmentSlots": 147,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 41,
+                    "openTimeslots": 147,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 41,
+                    "openAppointmentSlots": 147,
                     "name": "Sawdust Rd and 45 H-E-B",
                     "longitude": -95.44512,
                     "latitude": 30.12684,
@@ -3852,8 +3724,13 @@
                     "city": "SPRING",
                     "availableImmunizations": [
                         "Flu",
+                        "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "COVID-19 Moderna",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -3865,23 +3742,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 329,
-                            "openAppointmentSlots": 329,
+                            "openTimeslots": 360,
+                            "openAppointmentSlots": 360,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 329,
+                    "openTimeslots": 360,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 329,
+                    "openAppointmentSlots": 360,
                     "name": "Leon Springs H-E-B",
                     "longitude": -98.63218,
                     "latitude": 29.6659,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster",
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -3912,15 +3791,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 45,
-                            "openAppointmentSlots": 45,
+                            "openTimeslots": 39,
+                            "openAppointmentSlots": 39,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 45,
+                    "openTimeslots": 39,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 45,
+                    "openAppointmentSlots": 39,
                     "name": "Perrin Beitel and Thousand Oaks H-E-B",
                     "longitude": -98.4082,
                     "latitude": 29.5491,
@@ -3928,8 +3807,11 @@
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
                         "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -3979,15 +3861,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 24,
-                            "openAppointmentSlots": 24,
+                            "openTimeslots": 32,
+                            "openAppointmentSlots": 32,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 24,
+                    "openTimeslots": 32,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 24,
+                    "openAppointmentSlots": 32,
                     "name": "Bay City H-E-B",
                     "longitude": -95.95804,
                     "latitude": 28.98306,
@@ -4000,30 +3882,22 @@
                 },
                 {
                     "zip": "78244-1300",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubdQAC",
+                    "url": null,
                     "type": "store",
                     "street": "6580 F.M. 78",
                     "storeNumber": 294,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 27,
-                            "openAppointmentSlots": 27,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 27,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 27,
+                    "openAppointmentSlots": 0,
                     "name": "Foster Rd H-E-B",
                     "longitude": -98.3591,
                     "latitude": 29.48109,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
-                    "availableImmunizations": [
-                        "Flu"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78521-4787",
@@ -4091,15 +3965,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 4,
-                            "openAppointmentSlots": 4,
+                            "openTimeslots": 37,
+                            "openAppointmentSlots": 37,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 4,
+                    "openTimeslots": 37,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 4,
+                    "openAppointmentSlots": 37,
                     "name": "Kyle H-E-B plus!",
                     "longitude": -97.86258,
                     "latitude": 30.01533,
@@ -4110,11 +3984,13 @@
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Janssen",
                         "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
                         "COVID-19 Novavax",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -4126,15 +4002,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 437,
-                            "openAppointmentSlots": 437,
+                            "openTimeslots": 121,
+                            "openAppointmentSlots": 121,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 437,
+                    "openTimeslots": 121,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 437,
+                    "openAppointmentSlots": 121,
                     "name": "Burleson H-E-B plus!",
                     "longitude": -97.34901,
                     "latitude": 32.52083,
@@ -4143,9 +4019,10 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
-                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -4157,15 +4034,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 316,
-                            "openAppointmentSlots": 316,
+                            "openTimeslots": 424,
+                            "openAppointmentSlots": 424,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 316,
+                    "openTimeslots": 424,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 316,
+                    "openAppointmentSlots": 424,
                     "name": "Lytle H-E-B plus!",
                     "longitude": -98.78924,
                     "latitude": 29.23224,
@@ -4188,15 +4065,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 242,
-                            "openAppointmentSlots": 242,
+                            "openTimeslots": 140,
+                            "openAppointmentSlots": 140,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 242,
+                    "openTimeslots": 140,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 242,
+                    "openAppointmentSlots": 140,
                     "name": "Cypress Market H-E-B",
                     "longitude": -95.6765,
                     "latitude": 29.95569,
@@ -4204,8 +4081,8 @@
                     "city": "CYPRESS",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
@@ -4218,15 +4095,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 30,
-                            "openAppointmentSlots": 30,
+                            "openTimeslots": 26,
+                            "openAppointmentSlots": 26,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 30,
+                    "openTimeslots": 26,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 30,
+                    "openAppointmentSlots": 26,
                     "name": "Anderson Mill H-E-B plus!",
                     "longitude": -97.82626,
                     "latitude": 30.45495,
@@ -4235,7 +4112,8 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -4247,15 +4125,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 116,
-                            "openAppointmentSlots": 116,
+                            "openTimeslots": 84,
+                            "openAppointmentSlots": 84,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 116,
+                    "openTimeslots": 84,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 116,
+                    "openAppointmentSlots": 84,
                     "name": "Trimmier H-E-B plus!",
                     "longitude": -97.7338,
                     "latitude": 31.0909,
@@ -4267,10 +4145,7 @@
                         "COVID-19 Pfizer",
                         "COVID-19 Novavax",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
-                        "COVID-19 Pediatric_Moderna"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -4282,15 +4157,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 11,
-                            "openAppointmentSlots": 11,
+                            "openTimeslots": 18,
+                            "openAppointmentSlots": 18,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 11,
+                    "openTimeslots": 18,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 11,
+                    "openAppointmentSlots": 18,
                     "name": "Bastrop H-E-B plus!",
                     "longitude": -97.33458,
                     "latitude": 30.10981,
@@ -4300,66 +4175,47 @@
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "76712-3371",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudAQAS",
+                    "url": null,
                     "type": "store",
                     "street": "9100 WOODWAY DRIVE",
                     "storeNumber": 583,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 5,
-                            "openAppointmentSlots": 5,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 5,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 5,
+                    "openAppointmentSlots": 0,
                     "name": "Woodway H-E-B plus!",
                     "longitude": -97.22132,
                     "latitude": 31.49664,
                     "fluUrl": "",
                     "city": "WOODWAY",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77437-4420",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudBQAS",
+                    "url": null,
                     "type": "store",
                     "street": "306 N. MECHANIC",
                     "storeNumber": 584,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 43,
-                            "openAppointmentSlots": 43,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 43,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 43,
+                    "openAppointmentSlots": 0,
                     "name": "El Campo H-E-B",
                     "longitude": -96.26988,
                     "latitude": 29.19683,
                     "fluUrl": "",
                     "city": "EL CAMPO",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78218-6039",
@@ -4370,15 +4226,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 157,
-                            "openAppointmentSlots": 157,
+                            "openTimeslots": 48,
+                            "openAppointmentSlots": 48,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 157,
+                    "openTimeslots": 48,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 157,
+                    "openAppointmentSlots": 48,
                     "name": "Austin Highway H-E-B",
                     "longitude": -98.43132,
                     "latitude": 29.4937,
@@ -4386,8 +4242,7 @@
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -4399,24 +4254,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 72,
-                            "openAppointmentSlots": 72,
+                            "openTimeslots": 36,
+                            "openAppointmentSlots": 36,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 72,
+                    "openTimeslots": 36,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 72,
+                    "openAppointmentSlots": 36,
                     "name": "Zapata Highway H-E-B",
                     "longitude": -99.47479,
                     "latitude": 27.47673,
                     "fluUrl": "",
                     "city": "LAREDO",
                     "availableImmunizations": [
-                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "Flu"
+                        "Flu",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -4447,24 +4302,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 238,
-                            "openAppointmentSlots": 238,
+                            "openTimeslots": 152,
+                            "openAppointmentSlots": 152,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 238,
+                    "openTimeslots": 152,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 238,
+                    "openAppointmentSlots": 152,
                     "name": "Sherwood & FM 2288 H-E-B",
                     "longitude": -100.51103,
                     "latitude": 31.43158,
                     "fluUrl": "",
                     "city": "SAN ANGELO",
                     "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Janssen",
                         "COVID-19 Pfizer_Updated_Booster",
+                        "Flu",
                         "COVID-19 Moderna"
                     ]
                 },
@@ -4477,15 +4331,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 77,
-                            "openAppointmentSlots": 77,
+                            "openTimeslots": 48,
+                            "openAppointmentSlots": 48,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 77,
+                    "openTimeslots": 48,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 77,
+                    "openAppointmentSlots": 48,
                     "name": "Cross Creek Ranch H-E-B",
                     "longitude": -95.84788,
                     "latitude": 29.71936,
@@ -4494,7 +4348,7 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -4506,15 +4360,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 99,
-                            "openAppointmentSlots": 99,
+                            "openTimeslots": 102,
+                            "openAppointmentSlots": 102,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 99,
+                    "openTimeslots": 102,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 99,
+                    "openAppointmentSlots": 102,
                     "name": "The Heights H-E-B",
                     "longitude": -95.40865,
                     "latitude": 29.80735,
@@ -4522,6 +4376,7 @@
                     "city": "HOUSTON",
                     "availableImmunizations": [
                         "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
@@ -4534,19 +4389,19 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 178,
-                            "openAppointmentSlots": 178,
+                            "openTimeslots": 31,
+                            "openAppointmentSlots": 31,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 149,
-                    "openFluTimeslots": 29,
-                    "openFluAppointmentSlots": 29,
-                    "openAppointmentSlots": 149,
+                    "openTimeslots": 31,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 31,
                     "name": "Bellaire Market H-E-B",
                     "longitude": -95.46938,
                     "latitude": 29.70764,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF1pQAE",
+                    "fluUrl": "",
                     "city": "BELLAIRE",
                     "availableImmunizations": [
                         "Flu",
@@ -4557,7 +4412,9 @@
                         "COVID-19 Pediatric_Moderna",
                         "COVID-19 Novavax",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -4569,15 +4426,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 80,
-                            "openAppointmentSlots": 80,
+                            "openTimeslots": 78,
+                            "openAppointmentSlots": 78,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 80,
+                    "openTimeslots": 78,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 80,
+                    "openAppointmentSlots": 78,
                     "name": "Mont Belvieu H-E-B",
                     "longitude": -94.84973,
                     "latitude": 29.82755,
@@ -4585,38 +4442,30 @@
                     "city": "MONT BELVIEU",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Moderna",
-                        "COVID-19 Pediatric_Pfizer"
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "78114-1851",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaKQAS",
+                    "url": null,
                     "type": "store",
                     "street": "925 10TH STREET",
                     "storeNumber": 25,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 7,
-                            "openAppointmentSlots": 7,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 7,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 7,
+                    "openAppointmentSlots": 0,
                     "name": "Floresville H-E-B",
                     "longitude": -98.15681,
                     "latitude": 29.14284,
                     "fluUrl": "",
                     "city": "FLORESVILLE",
-                    "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78223-1717",
@@ -4627,27 +4476,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 962,
-                            "openAppointmentSlots": 962,
+                            "openTimeslots": 917,
+                            "openAppointmentSlots": 917,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 812,
-                    "openFluTimeslots": 150,
-                    "openFluAppointmentSlots": 150,
-                    "openAppointmentSlots": 812,
+                    "openTimeslots": 917,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 917,
                     "name": "McCreless Market H-E-B plus!",
                     "longitude": -98.46115,
                     "latitude": 29.37828,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF41QAE",
+                    "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
                         "COVID-19 Pfizer",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna",
                         "Flu",
-                        "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Novavax"
                     ]
@@ -4661,15 +4507,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 116,
-                            "openAppointmentSlots": 116,
+                            "openTimeslots": 185,
+                            "openAppointmentSlots": 185,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 116,
+                    "openTimeslots": 185,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 116,
+                    "openAppointmentSlots": 185,
                     "name": "Bay Colony H-E-B",
                     "longitude": -95.0926,
                     "latitude": 29.4677,
@@ -4685,30 +4531,22 @@
                 },
                 {
                     "zip": "78746-5256",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaNQAS",
+                    "url": null,
                     "type": "store",
                     "street": "701 CAPITAL OF TEXAS HWY-BLD C",
                     "storeNumber": 29,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 18,
-                            "openAppointmentSlots": 18,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 18,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 18,
+                    "openAppointmentSlots": 0,
                     "name": "Westlake H-E-B",
                     "longitude": -97.82813,
                     "latitude": 30.2928,
                     "fluUrl": "",
                     "city": "WEST LAKE HILLS",
-                    "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78750-3222",
@@ -4719,24 +4557,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 191,
-                            "openAppointmentSlots": 191,
+                            "openTimeslots": 144,
+                            "openAppointmentSlots": 144,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 191,
+                    "openTimeslots": 144,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 191,
+                    "openAppointmentSlots": 144,
                     "name": "Spicewood Springs H-E-B",
                     "longitude": -97.7713,
                     "latitude": 30.43494,
                     "fluUrl": "",
                     "city": "AUSTIN",
                     "availableImmunizations": [
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "Flu",
-                        "COVID-19 Novavax"
+                        "Flu"
                     ]
                 },
                 {
@@ -4748,58 +4586,46 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 830,
-                            "openAppointmentSlots": 830,
+                            "openTimeslots": 475,
+                            "openAppointmentSlots": 475,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 676,
-                    "openFluTimeslots": 154,
-                    "openFluAppointmentSlots": 154,
-                    "openAppointmentSlots": 676,
+                    "openTimeslots": 475,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 475,
                     "name": "Gattis School H-E-B Round Rock",
                     "longitude": -97.61475,
                     "latitude": 30.49721,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4IQAU",
+                    "fluUrl": "",
                     "city": "ROUND ROCK",
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "77957-2728",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubhQAC",
+                    "url": null,
                     "type": "store",
                     "street": "301 N. WELLS ST",
                     "storeNumber": 351,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 21,
-                            "openAppointmentSlots": 21,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 21,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 21,
+                    "openAppointmentSlots": 0,
                     "name": "Edna H-E-B",
                     "longitude": -96.64731,
                     "latitude": 28.97947,
                     "fluUrl": "",
                     "city": "EDNA",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78209-2217",
@@ -4810,15 +4636,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 147,
-                            "openAppointmentSlots": 147,
+                            "openTimeslots": 101,
+                            "openAppointmentSlots": 101,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 147,
+                    "openTimeslots": 101,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 147,
+                    "openAppointmentSlots": 101,
                     "name": "Oak Park H-E-B",
                     "longitude": -98.45759,
                     "latitude": 29.50774,
@@ -4827,10 +4653,11 @@
                     "availableImmunizations": [
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer",
                         "Flu",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -4842,15 +4669,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 2407,
-                            "openAppointmentSlots": 2407,
+                            "openTimeslots": 1894,
+                            "openAppointmentSlots": 1894,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 2407,
+                    "openTimeslots": 1894,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 2407,
+                    "openAppointmentSlots": 1894,
                     "name": "620 and O'Connor H-E-B",
                     "longitude": -97.72218,
                     "latitude": 30.50028,
@@ -4875,15 +4702,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 221,
-                            "openAppointmentSlots": 221,
+                            "openTimeslots": 306,
+                            "openAppointmentSlots": 306,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 221,
+                    "openTimeslots": 306,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 221,
+                    "openAppointmentSlots": 306,
                     "name": "New Braunfels H-E-B at Walnut",
                     "longitude": -98.12631,
                     "latitude": 29.68903,
@@ -4893,10 +4720,8 @@
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Janssen",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -4908,26 +4733,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 357,
-                            "openAppointmentSlots": 357,
+                            "openTimeslots": 113,
+                            "openAppointmentSlots": 113,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 357,
+                    "openTimeslots": 113,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 357,
+                    "openAppointmentSlots": 113,
                     "name": "Harker Heights H-E-B",
                     "longitude": -97.65511,
                     "latitude": 31.07905,
                     "fluUrl": "",
                     "city": "HARKER HEIGHTS",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer",
                         "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
+                        "Flu",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "Flu"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -4939,15 +4765,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 54,
-                            "openAppointmentSlots": 54,
+                            "openTimeslots": 179,
+                            "openAppointmentSlots": 179,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 54,
+                    "openTimeslots": 179,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 54,
+                    "openAppointmentSlots": 179,
                     "name": "West Wadley H-E-B",
                     "longitude": -102.12562,
                     "latitude": 32.01955,
@@ -4956,8 +4782,8 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
@@ -4970,15 +4796,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 285,
-                            "openAppointmentSlots": 285,
+                            "openTimeslots": 107,
+                            "openAppointmentSlots": 107,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 285,
+                    "openTimeslots": 107,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 285,
+                    "openAppointmentSlots": 107,
                     "name": "Montgomery at Walzem",
                     "longitude": -98.37092,
                     "latitude": 29.5105,
@@ -4988,7 +4814,6 @@
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
                         "Flu"
                     ]
@@ -5002,22 +4827,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 18,
-                            "openAppointmentSlots": 18,
+                            "openTimeslots": 64,
+                            "openAppointmentSlots": 64,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 18,
+                    "openTimeslots": 64,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 18,
+                    "openAppointmentSlots": 64,
                     "name": "Olmos Park H-E-B",
                     "longitude": -98.497,
                     "latitude": 29.4707,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -5048,15 +4874,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 159,
-                            "openAppointmentSlots": 159,
+                            "openTimeslots": 45,
+                            "openAppointmentSlots": 45,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 89,
-                    "openFluTimeslots": 70,
-                    "openFluAppointmentSlots": 70,
-                    "openAppointmentSlots": 89,
+                    "openTimeslots": 15,
+                    "openFluTimeslots": 30,
+                    "openFluAppointmentSlots": 30,
+                    "openAppointmentSlots": 15,
                     "name": "Parmer and McNeil H-E-B",
                     "longitude": -97.74278,
                     "latitude": 30.44181,
@@ -5067,10 +4893,11 @@
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Janssen",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -5082,15 +4909,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 220,
-                            "openAppointmentSlots": 220,
+                            "openTimeslots": 128,
+                            "openAppointmentSlots": 128,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 220,
+                    "openTimeslots": 128,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 220,
+                    "openAppointmentSlots": 128,
                     "name": "Mid County H-E-B",
                     "longitude": -93.9758,
                     "latitude": 29.966,
@@ -5099,9 +4926,7 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
                         "COVID-19 Novavax",
                         "COVID-19 Pfizer_Updated_Booster"
@@ -5135,15 +4960,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 42,
-                            "openAppointmentSlots": 42,
+                            "openTimeslots": 172,
+                            "openAppointmentSlots": 172,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 42,
+                    "openTimeslots": 172,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 42,
+                    "openAppointmentSlots": 172,
                     "name": "Leander H-E-B plus!",
                     "longitude": -97.8582,
                     "latitude": 30.58369,
@@ -5164,15 +4989,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 140,
-                            "openAppointmentSlots": 140,
+                            "openTimeslots": 170,
+                            "openAppointmentSlots": 170,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 140,
+                    "openTimeslots": 170,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 140,
+                    "openAppointmentSlots": 170,
                     "name": "Baytown H-E-B",
                     "longitude": -94.9788,
                     "latitude": 29.79503,
@@ -5183,7 +5008,9 @@
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Flu"
                     ]
                 },
                 {
@@ -5195,26 +5022,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 276,
-                            "openAppointmentSlots": 276,
+                            "openTimeslots": 309,
+                            "openAppointmentSlots": 309,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 276,
+                    "openTimeslots": 309,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 276,
+                    "openAppointmentSlots": 309,
                     "name": "Buffalo Heights H-E-B On Washington Ave",
                     "longitude": -95.39658,
                     "latitude": 29.76901,
                     "fluUrl": "",
                     "city": "HOUSTON",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
                         "Flu",
-                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
                         "COVID-19 Moderna",
-                        "COVID-19 Pfizer"
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -5226,24 +5054,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 88,
-                            "openAppointmentSlots": 88,
+                            "openTimeslots": 62,
+                            "openAppointmentSlots": 62,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 88,
+                    "openTimeslots": 62,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 88,
+                    "openAppointmentSlots": 62,
                     "name": "Meyerland Market H-E-B",
                     "longitude": -95.46406,
                     "latitude": 29.68854,
                     "fluUrl": "",
                     "city": "HOUSTON",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu",
                         "COVID-19 Moderna_Updated_Booster",
-                        "Flu"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -5255,15 +5085,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 101,
-                            "openAppointmentSlots": 101,
+                            "openTimeslots": 87,
+                            "openAppointmentSlots": 87,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 101,
+                    "openTimeslots": 87,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 101,
+                    "openAppointmentSlots": 87,
                     "name": "Jones Crossing H-E-B",
                     "longitude": -96.32324,
                     "latitude": 30.58444,
@@ -5273,7 +5103,8 @@
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -5323,15 +5154,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 223,
-                            "openAppointmentSlots": 223,
+                            "openTimeslots": 30,
+                            "openAppointmentSlots": 30,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 223,
+                    "openTimeslots": 30,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 223,
+                    "openAppointmentSlots": 30,
                     "name": "South Congress H-E-B",
                     "longitude": -97.7516,
                     "latitude": 30.23963,
@@ -5339,7 +5170,8 @@
                     "city": "AUSTIN",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -5351,15 +5183,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 150,
-                            "openAppointmentSlots": 150,
+                            "openTimeslots": 248,
+                            "openAppointmentSlots": 248,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 150,
+                    "openTimeslots": 248,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 150,
+                    "openAppointmentSlots": 248,
                     "name": "Beaumont H-E-B plus!",
                     "longitude": -94.1685,
                     "latitude": 30.10501,
@@ -5367,7 +5199,6 @@
                     "city": "BEAUMONT",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Pfizer_Updated_Booster"
@@ -5382,24 +5213,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 85,
-                            "openAppointmentSlots": 85,
+                            "openTimeslots": 103,
+                            "openAppointmentSlots": 103,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 85,
+                    "openTimeslots": 103,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 85,
+                    "openAppointmentSlots": 103,
                     "name": "West Ave and Jackson Keller H-E-B",
                     "longitude": -98.52574,
                     "latitude": 29.51639,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "Flu",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "Flu"
                     ]
                 },
                 {
@@ -5411,24 +5242,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 144,
-                            "openAppointmentSlots": 144,
+                            "openTimeslots": 169,
+                            "openAppointmentSlots": 169,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 144,
+                    "openTimeslots": 169,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 144,
+                    "openAppointmentSlots": 169,
                     "name": "De Zavala H-E-B",
                     "longitude": -98.5889,
                     "latitude": 29.56222,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
-                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -5440,15 +5271,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 396,
-                            "openAppointmentSlots": 396,
+                            "openTimeslots": 389,
+                            "openAppointmentSlots": 389,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 396,
+                    "openTimeslots": 389,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 396,
+                    "openAppointmentSlots": 389,
                     "name": "281 and 1604 H-E-B",
                     "longitude": -98.46828,
                     "latitude": 29.60772,
@@ -5469,15 +5300,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 562,
-                            "openAppointmentSlots": 562,
+                            "openTimeslots": 649,
+                            "openAppointmentSlots": 649,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 264,
-                    "openFluTimeslots": 298,
-                    "openFluAppointmentSlots": 298,
-                    "openAppointmentSlots": 264,
+                    "openTimeslots": 392,
+                    "openFluTimeslots": 257,
+                    "openFluAppointmentSlots": 257,
+                    "openAppointmentSlots": 392,
                     "name": "Thousand Oaks H-E-B",
                     "longitude": -98.44108,
                     "latitude": 29.57781,
@@ -5497,15 +5328,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 131,
-                            "openAppointmentSlots": 131,
+                            "openTimeslots": 67,
+                            "openAppointmentSlots": 67,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 131,
+                    "openTimeslots": 67,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 131,
+                    "openAppointmentSlots": 67,
                     "name": "Kingsville H-E-B",
                     "longitude": -97.86453,
                     "latitude": 27.51658,
@@ -5517,7 +5348,7 @@
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -5529,15 +5360,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 63,
-                            "openAppointmentSlots": 63,
+                            "openTimeslots": 31,
+                            "openAppointmentSlots": 31,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 63,
+                    "openTimeslots": 31,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 63,
+                    "openAppointmentSlots": 31,
                     "name": "Indian Springs H-E-B",
                     "longitude": -95.53672,
                     "latitude": 30.17791,
@@ -5547,8 +5378,10 @@
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -5560,15 +5393,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 279,
-                            "openAppointmentSlots": 279,
+                            "openTimeslots": 127,
+                            "openAppointmentSlots": 127,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 279,
+                    "openTimeslots": 127,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 279,
+                    "openAppointmentSlots": 127,
                     "name": "N Frazier At Loop 336 H-E-B",
                     "longitude": -95.46548,
                     "latitude": 30.33593,
@@ -5576,10 +5409,10 @@
                     "city": "CONROE",
                     "availableImmunizations": [
                         "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer"
                     ]
                 },
                 {
@@ -5591,15 +5424,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 49,
-                            "openAppointmentSlots": 49,
+                            "openTimeslots": 80,
+                            "openAppointmentSlots": 80,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 49,
+                    "openTimeslots": 80,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 49,
+                    "openAppointmentSlots": 80,
                     "name": "Grand Parkway H-E-B plus!",
                     "longitude": -95.7739,
                     "latitude": 29.7144,
@@ -5607,9 +5440,9 @@
                     "city": "KATY",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna"
                     ]
                 },
                 {
@@ -5621,15 +5454,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 1,
-                            "openAppointmentSlots": 1,
+                            "openTimeslots": 7,
+                            "openAppointmentSlots": 7,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 1,
+                    "openTimeslots": 7,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 1,
+                    "openAppointmentSlots": 7,
                     "name": "Buffalo Market H-E-B On Buffalo Speedway",
                     "longitude": -95.4271,
                     "latitude": 29.7261,
@@ -5649,24 +5482,28 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 74,
-                            "openAppointmentSlots": 74,
+                            "openTimeslots": 49,
+                            "openAppointmentSlots": 49,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 74,
+                    "openTimeslots": 49,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 74,
+                    "openAppointmentSlots": 49,
                     "name": "Spring Market H-E-B",
                     "longitude": -95.44894,
                     "latitude": 30.07042,
                     "fluUrl": "",
                     "city": "SPRING",
                     "availableImmunizations": [
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
                         "Flu",
-                        "COVID-19 Pediatric_Pfizer"
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -5678,53 +5515,45 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 219,
-                            "openAppointmentSlots": 219,
+                            "openTimeslots": 71,
+                            "openAppointmentSlots": 71,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 204,
-                    "openFluTimeslots": 15,
-                    "openFluAppointmentSlots": 15,
-                    "openAppointmentSlots": 204,
+                    "openTimeslots": 71,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 71,
                     "name": "Dripping Springs H-E-B",
                     "longitude": -98.08146,
                     "latitude": 30.18968,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF46QAE",
+                    "fluUrl": "",
                     "city": "DRIPPING SPRINGS",
                     "availableImmunizations": [
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "78121-5922",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudPQAS",
+                    "url": null,
                     "type": "store",
                     "street": "14414 US HWY 87 WEST",
                     "storeNumber": 612,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 36,
-                            "openAppointmentSlots": 36,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 36,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 36,
+                    "openAppointmentSlots": 0,
                     "name": "La Vernia H-E-B",
                     "longitude": -98.13514,
                     "latitude": 29.35803,
                     "fluUrl": "",
                     "city": "LA VERNIA",
-                    "availableImmunizations": [
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77388-0",
@@ -5735,15 +5564,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 60,
-                            "openAppointmentSlots": 60,
+                            "openTimeslots": 267,
+                            "openAppointmentSlots": 267,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 60,
+                    "openTimeslots": 267,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 60,
+                    "openAppointmentSlots": 267,
                     "name": "H-E-B Market at Gosling",
                     "longitude": -95.50178,
                     "latitude": 30.07179,
@@ -5801,24 +5630,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 247,
-                            "openAppointmentSlots": 247,
+                            "openTimeslots": 234,
+                            "openAppointmentSlots": 234,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 247,
+                    "openTimeslots": 234,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 247,
+                    "openAppointmentSlots": 234,
                     "name": "MacGregor Market H-E-B",
                     "longitude": -95.37644,
                     "latitude": 29.71432,
                     "fluUrl": "",
                     "city": "HOUSTON",
                     "availableImmunizations": [
-                        "Flu",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Moderna"
                     ]
                 },
                 {
@@ -5830,15 +5660,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 273,
-                            "openAppointmentSlots": 273,
+                            "openTimeslots": 136,
+                            "openAppointmentSlots": 136,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 273,
+                    "openTimeslots": 136,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 273,
+                    "openAppointmentSlots": 136,
                     "name": "Harper's Trace H-E-B",
                     "longitude": -95.42563,
                     "latitude": 30.20692,
@@ -5861,27 +5691,29 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 220,
-                            "openAppointmentSlots": 220,
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 209,
-                    "openFluTimeslots": 11,
-                    "openFluAppointmentSlots": 11,
-                    "openAppointmentSlots": 209,
+                    "openTimeslots": 50,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 50,
                     "name": "H-E-B Market at Northpark",
                     "longitude": -95.25033,
                     "latitude": 30.06864,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2FQAU",
+                    "fluUrl": "",
                     "city": "KINGWOOD",
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -5893,15 +5725,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 21,
-                            "openAppointmentSlots": 21,
+                            "openTimeslots": 54,
+                            "openAppointmentSlots": 54,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 21,
+                    "openTimeslots": 54,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 21,
+                    "openAppointmentSlots": 54,
                     "name": "211 and Potranco H-E-B",
                     "longitude": -98.77966,
                     "latitude": 29.42367,
@@ -5909,10 +5741,10 @@
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -5924,15 +5756,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 318,
-                            "openAppointmentSlots": 318,
+                            "openTimeslots": 66,
+                            "openAppointmentSlots": 66,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 318,
+                    "openTimeslots": 66,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 318,
+                    "openAppointmentSlots": 66,
                     "name": "Lubbock H-E-B",
                     "longitude": -101.90638,
                     "latitude": 33.48958,
@@ -5946,7 +5778,6 @@
                         "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
                         "COVID-19 Novavax",
-                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
@@ -5959,15 +5790,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 64,
-                            "openAppointmentSlots": 64,
+                            "openTimeslots": 72,
+                            "openAppointmentSlots": 72,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 64,
+                    "openTimeslots": 72,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 64,
+                    "openAppointmentSlots": 72,
                     "name": "Big Spring H-E-B",
                     "longitude": -101.47211,
                     "latitude": 32.23493,
@@ -5976,7 +5807,6 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
@@ -5990,15 +5820,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 222,
-                            "openAppointmentSlots": 222,
+                            "openTimeslots": 234,
+                            "openAppointmentSlots": 234,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 222,
+                    "openTimeslots": 234,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 222,
+                    "openAppointmentSlots": 234,
                     "name": "Sherwood Avenue N H-E-B",
                     "longitude": -100.47977,
                     "latitude": 31.44511,
@@ -6007,7 +5837,6 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
@@ -6021,27 +5850,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 187,
-                            "openAppointmentSlots": 187,
+                            "openTimeslots": 87,
+                            "openAppointmentSlots": 87,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 187,
+                    "openTimeslots": 87,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 187,
+                    "openAppointmentSlots": 87,
                     "name": "Blackhawk H-E-B",
                     "longitude": -95.24868,
                     "latitude": 29.60234,
                     "fluUrl": "",
                     "city": "HOUSTON",
                     "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pediatric_Pfizer"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "Flu"
                     ]
                 },
                 {
@@ -6053,15 +5879,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 54,
-                            "openAppointmentSlots": 54,
+                            "openTimeslots": 57,
+                            "openAppointmentSlots": 57,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 54,
+                    "openTimeslots": 57,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 54,
+                    "openAppointmentSlots": 57,
                     "name": "Flour Bluff H-E-B plus!",
                     "longitude": -97.28288,
                     "latitude": 27.66767,
@@ -6069,8 +5895,8 @@
                     "city": "CORPUS CHRISTI",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -6082,15 +5908,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 36,
-                            "openAppointmentSlots": 36,
+                            "openTimeslots": 93,
+                            "openAppointmentSlots": 93,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 36,
+                    "openTimeslots": 93,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 36,
+                    "openAppointmentSlots": 93,
                     "name": "Pearland H-E-B plus!",
                     "longitude": -95.39002,
                     "latitude": 29.55932,
@@ -6104,7 +5930,10 @@
                         "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
                         "COVID-19 Novavax",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -6116,15 +5945,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 110,
-                            "openAppointmentSlots": 110,
+                            "openTimeslots": 80,
+                            "openAppointmentSlots": 80,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 110,
+                    "openTimeslots": 80,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 110,
+                    "openAppointmentSlots": 80,
                     "name": "19th and Meridian H-E-B",
                     "longitude": -97.17255,
                     "latitude": 31.5804,
@@ -6147,24 +5976,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 39,
-                            "openAppointmentSlots": 39,
+                            "openTimeslots": 75,
+                            "openAppointmentSlots": 75,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 17,
-                    "openFluTimeslots": 22,
-                    "openFluAppointmentSlots": 22,
-                    "openAppointmentSlots": 17,
+                    "openTimeslots": 75,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 75,
                     "name": "Slaughter and Escarpment H-E-B",
                     "longitude": -97.87642,
                     "latitude": 30.20247,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4TQAU",
+                    "fluUrl": "",
                     "city": "AUSTIN",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
                         "Flu",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -6214,56 +6042,43 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 65,
-                            "openAppointmentSlots": 65,
+                            "openTimeslots": 22,
+                            "openAppointmentSlots": 22,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 65,
+                    "openTimeslots": 22,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 65,
+                    "openAppointmentSlots": 22,
                     "name": "Bee Cave H-E-B",
                     "longitude": -97.93238,
                     "latitude": 30.30489,
                     "fluUrl": "",
                     "city": "BEE CAVE",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
                         "Flu",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
-                        "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "78227-1652",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudQQAS",
+                    "url": null,
                     "type": "store",
                     "street": "8219 MARBACH",
                     "storeNumber": 613,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 240,
-                            "openAppointmentSlots": 240,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 240,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 240,
+                    "openAppointmentSlots": 0,
                     "name": "Marbach and 410 H-E-B plus!",
                     "longitude": -98.65227,
                     "latitude": 29.41837,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
-                    "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "Flu",
-                        "COVID-19 Moderna_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77044-6087",
@@ -6274,25 +6089,31 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 340,
-                            "openAppointmentSlots": 340,
+                            "openTimeslots": 103,
+                            "openAppointmentSlots": 103,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 340,
+                    "openTimeslots": 103,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 340,
+                    "openAppointmentSlots": 103,
                     "name": "Summerwood Market H-E-B",
                     "longitude": -95.19697,
                     "latitude": 29.92325,
                     "fluUrl": "",
                     "city": "HOUSTON",
                     "availableImmunizations": [
-                        "COVID-19 Moderna_Updated_Booster",
                         "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna",
                         "COVID-19 Novavax",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -6304,15 +6125,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 174,
-                            "openAppointmentSlots": 174,
+                            "openTimeslots": 103,
+                            "openAppointmentSlots": 103,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 174,
+                    "openTimeslots": 103,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 174,
+                    "openAppointmentSlots": 103,
                     "name": "Katy Market H-E-B",
                     "longitude": -95.82005,
                     "latitude": 29.77644,
@@ -6328,22 +6149,33 @@
                 },
                 {
                     "zip": "78240-2136",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudTQAS",
                     "type": "store",
                     "street": "5910 BABCOCK RD",
                     "storeNumber": 618,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 40,
+                            "openAppointmentSlots": 40,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 40,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 40,
                     "name": "Babcock H-E-B",
                     "longitude": -98.60198,
                     "latitude": 29.5271,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77845-4638",
@@ -6354,19 +6186,19 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 215,
-                            "openAppointmentSlots": 215,
+                            "openTimeslots": 183,
+                            "openAppointmentSlots": 183,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 137,
-                    "openFluTimeslots": 78,
-                    "openFluAppointmentSlots": 78,
-                    "openAppointmentSlots": 137,
+                    "openTimeslots": 183,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 183,
                     "name": "Tower Point Market H-E-B",
                     "longitude": -96.26315,
                     "latitude": 30.55969,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4CQAU",
+                    "fluUrl": "",
                     "city": "COLLEGE STATION",
                     "availableImmunizations": [
                         "Flu",
@@ -6401,15 +6233,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 47,
-                            "openAppointmentSlots": 47,
+                            "openTimeslots": 112,
+                            "openAppointmentSlots": 112,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 47,
+                    "openTimeslots": 112,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 47,
+                    "openAppointmentSlots": 112,
                     "name": "H-E-B Pharmacy at the UTHTB",
                     "longitude": -97.73507,
                     "latitude": 30.27747,
@@ -6417,7 +6249,8 @@
                     "city": "AUSTIN",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -6429,15 +6262,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 89,
-                            "openAppointmentSlots": 89,
+                            "openTimeslots": 119,
+                            "openAppointmentSlots": 119,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 89,
+                    "openTimeslots": 119,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 89,
+                    "openAppointmentSlots": 119,
                     "name": "Abilene H-E-B",
                     "longitude": -99.75934,
                     "latitude": 32.43348,
@@ -6447,42 +6280,30 @@
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
-                        "COVID-19 Pediatric_Moderna",
                         "COVID-19 Novavax",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "76504-2448",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuadQAC",
+                    "url": null,
                     "type": "store",
                     "street": "1314 WEST ADAMS",
                     "storeNumber": 71,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 28,
-                            "openAppointmentSlots": 28,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 28,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 28,
+                    "openAppointmentSlots": 0,
                     "name": "Adams and 25th St H-E-B",
                     "longitude": -97.35378,
                     "latitude": 31.10153,
                     "fluUrl": "",
                     "city": "TEMPLE",
-                    "availableImmunizations": [
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "Flu"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78006-2523",
@@ -6493,15 +6314,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 123,
-                            "openAppointmentSlots": 123,
+                            "openTimeslots": 30,
+                            "openAppointmentSlots": 30,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 123,
+                    "openTimeslots": 30,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 123,
+                    "openAppointmentSlots": 30,
                     "name": "Boerne H-E-B plus!",
                     "longitude": -98.73481,
                     "latitude": 29.78173,
@@ -6509,8 +6330,7 @@
                     "city": "BOERNE",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -6522,15 +6342,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 199,
-                            "openAppointmentSlots": 199,
+                            "openTimeslots": 92,
+                            "openAppointmentSlots": 92,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 199,
+                    "openTimeslots": 92,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 199,
+                    "openAppointmentSlots": 92,
                     "name": "Bulverde H-E-B plus!",
                     "longitude": -98.43022,
                     "latitude": 29.79882,
@@ -6538,11 +6358,9 @@
                     "city": "SPRING BRANCH",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Ultra_Pediatric_Pfizer",
-                        "COVID-19 Pediatric_Moderna",
                         "COVID-19 Novavax",
                         "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Moderna_Updated_Booster"
@@ -6557,43 +6375,58 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 214,
-                            "openAppointmentSlots": 214,
+                            "openTimeslots": 297,
+                            "openAppointmentSlots": 297,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 214,
+                    "openTimeslots": 297,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 214,
+                    "openAppointmentSlots": 297,
                     "name": "Bandera and 1604 H-E-B plus!",
                     "longitude": -98.66444,
                     "latitude": 29.55498,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
+                        "Flu",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "Flu"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "78586-4395",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudZQAS",
                     "type": "store",
                     "street": "1095 WEST BUSINESS 77",
                     "storeNumber": 626,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 175,
+                            "openAppointmentSlots": 175,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 175,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 175,
                     "name": "San Benito H-E-B",
                     "longitude": -97.63395,
                     "latitude": 26.14392,
                     "fluUrl": "",
                     "city": "SAN BENITO",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77478-4947",
@@ -6604,23 +6437,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 154,
-                            "openAppointmentSlots": 154,
+                            "openTimeslots": 162,
+                            "openAppointmentSlots": 162,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 154,
+                    "openTimeslots": 162,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 154,
+                    "openAppointmentSlots": 162,
                     "name": "Sugar Land Market H-E-B",
                     "longitude": -95.64596,
                     "latitude": 29.60871,
                     "fluUrl": "",
                     "city": "SUGAR LAND",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -6651,15 +6484,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 119,
-                            "openAppointmentSlots": 119,
+                            "openTimeslots": 69,
+                            "openAppointmentSlots": 69,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 119,
+                    "openTimeslots": 69,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 119,
+                    "openAppointmentSlots": 69,
                     "name": "Spring Green Market H-E-B",
                     "longitude": -95.81427,
                     "latitude": 29.69558,
@@ -6671,7 +6504,7 @@
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -6683,24 +6516,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 142,
-                            "openAppointmentSlots": 142,
+                            "openTimeslots": 217,
+                            "openAppointmentSlots": 217,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 142,
+                    "openTimeslots": 217,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 142,
+                    "openAppointmentSlots": 217,
                     "name": "New Braunfels H-E-B at Hwy 46",
                     "longitude": -98.16041,
                     "latitude": 29.71309,
                     "fluUrl": "",
                     "city": "NEW BRAUNFELS",
                     "availableImmunizations": [
-                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -6712,15 +6545,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 1276,
-                            "openAppointmentSlots": 1276,
+                            "openTimeslots": 569,
+                            "openAppointmentSlots": 569,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 1276,
+                    "openTimeslots": 569,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 1276,
+                    "openAppointmentSlots": 569,
                     "name": "Zarzamora and Military H-E-B plus!",
                     "longitude": -98.5339,
                     "latitude": 29.35787,
@@ -6728,32 +6561,41 @@
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Janssen",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "78251-3312",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuagQAC",
                     "type": "store",
                     "street": "10718 POTRANCO ROAD",
                     "storeNumber": 85,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 194,
+                            "openAppointmentSlots": 194,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 194,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 194,
                     "name": "Potranco and 1604 H-E-B plus!",
                     "longitude": -98.70445,
                     "latitude": 29.43536,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu"
+                    ]
                 },
                 {
                     "zip": "78028-0",
@@ -6764,21 +6606,22 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 57,
-                            "openAppointmentSlots": 57,
+                            "openTimeslots": 76,
+                            "openAppointmentSlots": 76,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 57,
+                    "openTimeslots": 76,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 57,
+                    "openAppointmentSlots": 76,
                     "name": "Kerrville H-E-B On Main Street",
                     "longitude": -99.14287,
                     "latitude": 30.05056,
                     "fluUrl": "",
                     "city": "KERRVILLE",
                     "availableImmunizations": [
+                        "Flu",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
@@ -6791,15 +6634,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 94,
-                            "openAppointmentSlots": 94,
+                            "openTimeslots": 77,
+                            "openAppointmentSlots": 77,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 94,
+                    "openTimeslots": 77,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 94,
+                    "openAppointmentSlots": 77,
                     "name": "Riverside H-E-B plus!",
                     "longitude": -97.72401,
                     "latitude": 30.23547,
@@ -6807,43 +6650,29 @@
                     "city": "AUSTIN",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "77904-1767",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuajQAC",
+                    "url": null,
                     "type": "store",
                     "street": "6106 N. NAVARRO",
                     "storeNumber": 92,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 145,
-                            "openAppointmentSlots": 145,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 145,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 145,
+                    "openAppointmentSlots": 0,
                     "name": "Victoria H-E-B plus!",
                     "longitude": -96.99736,
                     "latitude": 28.85159,
                     "fluUrl": "",
                     "city": "VICTORIA",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Janssen",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
-                        "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Novavax",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77055-6209",
@@ -6854,31 +6683,29 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 436,
-                            "openAppointmentSlots": 436,
+                            "openTimeslots": 297,
+                            "openAppointmentSlots": 297,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 391,
-                    "openFluTimeslots": 45,
-                    "openFluAppointmentSlots": 45,
-                    "openAppointmentSlots": 391,
+                    "openTimeslots": 297,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 297,
                     "name": "Bunker Hill H-E-B",
                     "longitude": -95.53206,
                     "latitude": 29.78485,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF0aQAE",
+                    "fluUrl": "",
                     "city": "HOUSTON",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
-                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Moderna",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Novavax",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pediatric_Moderna_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -6890,15 +6717,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 107,
-                            "openAppointmentSlots": 107,
+                            "openTimeslots": 74,
+                            "openAppointmentSlots": 74,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 107,
+                    "openTimeslots": 74,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 107,
+                    "openAppointmentSlots": 74,
                     "name": "Sienna Market H-E-B",
                     "longitude": -95.53497,
                     "latitude": 29.53928,
@@ -6906,74 +6733,89 @@
                     "city": "MISSOURI CITY",
                     "availableImmunizations": [
                         "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "78550-7708",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuauQAC",
                     "type": "store",
                     "street": "1213 S. COMMERCE",
                     "storeNumber": 136,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 46,
+                            "openAppointmentSlots": 46,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 46,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 46,
                     "name": "Southland and 12th St H-E-B",
                     "longitude": -97.68171,
                     "latitude": 26.18251,
                     "fluUrl": "",
                     "city": "HARLINGEN",
-                    "availableImmunizations": null
-                },
-                {
-                    "zip": "78413-3966",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuavQAC",
-                    "type": "store",
-                    "street": "5801 WEBER ROAD",
-                    "storeNumber": 139,
-                    "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 44,
-                            "openAppointmentSlots": 44,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 44,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 44,
-                    "name": "Weber and Holly H-E-B",
-                    "longitude": -97.40529,
-                    "latitude": 27.71118,
-                    "fluUrl": "",
-                    "city": "CORPUS CHRISTI",
                     "availableImmunizations": [
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Janssen",
+                        "Flu",
                         "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
-                    "zip": "78723-2924",
+                    "zip": "78413-3966",
                     "url": null,
                     "type": "store",
-                    "street": "7112 ED BLUESTEIN_#125",
-                    "storeNumber": 161,
+                    "street": "5801 WEBER ROAD",
+                    "storeNumber": 139,
                     "state": "TX",
                     "slotDetails": [],
                     "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
                     "openAppointmentSlots": 0,
+                    "name": "Weber and Holly H-E-B",
+                    "longitude": -97.40529,
+                    "latitude": 27.71118,
+                    "fluUrl": "",
+                    "city": "CORPUS CHRISTI",
+                    "availableImmunizations": null
+                },
+                {
+                    "zip": "78723-2924",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuawQAC",
+                    "type": "store",
+                    "street": "7112 ED BLUESTEIN_#125",
+                    "storeNumber": 161,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 388,
+                            "openAppointmentSlots": 388,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 388,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 388,
                     "name": "Ed Bluestein H-E-B",
                     "longitude": -97.66465,
                     "latitude": 30.31211,
                     "fluUrl": "",
                     "city": "AUSTIN",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu"
+                    ]
                 },
                 {
                     "zip": "78232-3714",
@@ -6984,15 +6826,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 77,
-                            "openAppointmentSlots": 77,
+                            "openTimeslots": 57,
+                            "openAppointmentSlots": 57,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 77,
+                    "openTimeslots": 57,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 77,
+                    "openAppointmentSlots": 57,
                     "name": "Brook Hollow H-E-B",
                     "longitude": -98.47734,
                     "latitude": 29.5774,
@@ -7006,22 +6848,31 @@
                 },
                 {
                     "zip": "78572-8354",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuakQAC",
                     "type": "store",
                     "street": "2409 EAST EXPRESSWAY 83",
                     "storeNumber": 94,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 18,
+                            "openAppointmentSlots": 18,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 18,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 18,
                     "name": "Mission H-E-B plus!",
                     "longitude": -98.28628,
                     "latitude": 26.19755,
                     "fluUrl": "",
                     "city": "MISSION",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Ultra_Pediatric_Pfizer"
+                    ]
                 },
                 {
                     "zip": "78045-6596",
@@ -7032,15 +6883,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 34,
-                            "openAppointmentSlots": 34,
+                            "openTimeslots": 23,
+                            "openAppointmentSlots": 23,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 34,
+                    "openTimeslots": 23,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 34,
+                    "openAppointmentSlots": 23,
                     "name": "Laredo H-E-B plus!",
                     "longitude": -99.47435,
                     "latitude": 27.60863,
@@ -7048,11 +6899,11 @@
                     "city": "LAREDO",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -7083,15 +6934,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 235,
-                            "openAppointmentSlots": 235,
+                            "openTimeslots": 176,
+                            "openAppointmentSlots": 176,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 235,
+                    "openTimeslots": 176,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 235,
+                    "openAppointmentSlots": 176,
                     "name": "Vintage Park Market H-E-B",
                     "longitude": -95.57661,
                     "latitude": 29.9967,
@@ -7099,9 +6950,10 @@
                     "city": "HOUSTON",
                     "availableImmunizations": [
                         "Flu",
+                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pfizer"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -7113,15 +6965,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 259,
-                            "openAppointmentSlots": 259,
+                            "openTimeslots": 516,
+                            "openAppointmentSlots": 516,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 259,
+                    "openTimeslots": 516,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 259,
+                    "openAppointmentSlots": 516,
                     "name": "Alon Market H-E-B",
                     "longitude": -98.53463,
                     "latitude": 29.55254,
@@ -7130,7 +6982,9 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -7142,23 +6996,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 9,
-                            "openAppointmentSlots": 9,
+                            "openTimeslots": 8,
+                            "openAppointmentSlots": 8,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 9,
+                    "openTimeslots": 8,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 9,
+                    "openAppointmentSlots": 8,
                     "name": "Brodie Lane H-E-B",
                     "longitude": -97.83076,
                     "latitude": 30.21489,
                     "fluUrl": "",
                     "city": "AUSTIN",
                     "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Flu"
                     ]
                 },
                 {
@@ -7189,15 +7044,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 82,
-                            "openAppointmentSlots": 82,
+                            "openTimeslots": 191,
+                            "openAppointmentSlots": 191,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 82,
+                    "openTimeslots": 191,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 82,
+                    "openAppointmentSlots": 191,
                     "name": "Montrose Market H-E-B",
                     "longitude": -95.40284,
                     "latitude": 29.7379,
@@ -7219,23 +7074,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 124,
-                            "openAppointmentSlots": 124,
+                            "openTimeslots": 294,
+                            "openAppointmentSlots": 294,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 26,
-                    "openFluTimeslots": 98,
-                    "openFluAppointmentSlots": 98,
-                    "openAppointmentSlots": 26,
+                    "openTimeslots": 294,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 294,
                     "name": "Granbury H-E-B",
                     "longitude": -97.73026,
                     "latitude": 32.45528,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4ZQAU",
+                    "fluUrl": "",
                     "city": "GRANBURY",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -7247,15 +7103,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 74,
-                            "openAppointmentSlots": 74,
+                            "openTimeslots": 184,
+                            "openAppointmentSlots": 184,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 74,
+                    "openTimeslots": 184,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 74,
+                    "openAppointmentSlots": 184,
                     "name": "North Woodlands Market H-E-B",
                     "longitude": -95.51296,
                     "latitude": 30.22918,
@@ -7263,8 +7119,8 @@
                     "city": "THE WOODLANDS",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -7402,51 +7258,56 @@
                 },
                 {
                     "zip": "78550-5152",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuayQAC",
                     "type": "store",
                     "street": "1103 MORGAN BLVD",
                     "storeNumber": 168,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 56,
+                            "openAppointmentSlots": 56,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 56,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 56,
+                    "name": "Morgan and Grimes H-E-B",
+                    "longitude": -97.67639,
+                    "latitude": 26.20337,
+                    "fluUrl": "",
+                    "city": "HARLINGEN",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Novavax",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                    ]
+                },
+                {
+                    "zip": "78539-5664",
+                    "url": null,
+                    "type": "store",
+                    "street": "1212 S CLOSNER BLVD",
+                    "storeNumber": 172,
                     "state": "TX",
                     "slotDetails": [],
                     "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
                     "openAppointmentSlots": 0,
-                    "name": "Morgan and Grimes H-E-B",
-                    "longitude": -97.67639,
-                    "latitude": 26.20337,
-                    "fluUrl": "",
-                    "city": "HARLINGEN",
-                    "availableImmunizations": null
-                },
-                {
-                    "zip": "78539-5664",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuazQAC",
-                    "type": "store",
-                    "street": "1212 S CLOSNER BLVD",
-                    "storeNumber": 172,
-                    "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 18,
-                            "openAppointmentSlots": 18,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 18,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 18,
                     "name": "Closner and Baker H-E-B",
                     "longitude": -98.1642,
                     "latitude": 26.29029,
                     "fluUrl": "",
                     "city": "EDINBURG",
-                    "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "Flu",
-                        "COVID-19 Pediatric_Pfizer"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78216-7202",
@@ -7457,25 +7318,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 63,
-                            "openAppointmentSlots": 63,
+                            "openTimeslots": 83,
+                            "openAppointmentSlots": 83,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 63,
+                    "openTimeslots": 83,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 63,
+                    "openAppointmentSlots": 83,
                     "name": "San Pedro and Oblate H-E-B",
                     "longitude": -98.4995,
                     "latitude": 29.50282,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "COVID-19 Pfizer"
                     ]
                 },
                 {
@@ -7506,15 +7367,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 807,
-                            "openAppointmentSlots": 807,
+                            "openTimeslots": 422,
+                            "openAppointmentSlots": 422,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 807,
+                    "openTimeslots": 422,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 807,
+                    "openAppointmentSlots": 422,
                     "name": "Lamar and Rundberg H-E-B",
                     "longitude": -97.69689,
                     "latitude": 30.36357,
@@ -7527,8 +7388,10 @@
                         "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
                         "COVID-19 Novavax",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -7540,15 +7403,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 28,
-                            "openAppointmentSlots": 28,
+                            "openTimeslots": 12,
+                            "openAppointmentSlots": 12,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 28,
+                    "openTimeslots": 12,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 28,
+                    "openAppointmentSlots": 12,
                     "name": "Leopard and Violet H-E-B",
                     "longitude": -97.58473,
                     "latitude": 27.84494,
@@ -7556,7 +7419,7 @@
                     "city": "CORPUS CHRISTI",
                     "availableImmunizations": [
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -7580,34 +7443,22 @@
                 },
                 {
                     "zip": "78745-0",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P00000003PYQAY",
+                    "url": null,
                     "type": "store",
                     "street": "8801 SOUTH CONGRESS AVENUE",
                     "storeNumber": 710,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 191,
-                            "openAppointmentSlots": 191,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 191,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 191,
+                    "openAppointmentSlots": 0,
                     "name": "Slaughter and South Congress H-E-B",
                     "longitude": -97.78723,
                     "latitude": 30.16862,
                     "fluUrl": "",
                     "city": "AUSTIN",
-                    "availableImmunizations": [
-                        "COVID-19 Moderna",
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78220-2530",
@@ -7618,25 +7469,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 282,
-                            "openAppointmentSlots": 282,
+                            "openTimeslots": 87,
+                            "openAppointmentSlots": 87,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 282,
+                    "openTimeslots": 87,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 282,
+                    "openAppointmentSlots": 87,
                     "name": "W. W. White H-E-B",
                     "longitude": -98.40568,
                     "latitude": 29.41476,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
-                        "COVID-19 Moderna_Updated_Booster",
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pfizer"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -7648,15 +7497,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 98,
-                            "openAppointmentSlots": 98,
+                            "openTimeslots": 49,
+                            "openAppointmentSlots": 49,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 98,
+                    "openTimeslots": 49,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 98,
+                    "openAppointmentSlots": 49,
                     "name": "Ennis H-E-B",
                     "longitude": -96.63251,
                     "latitude": 32.32542,
@@ -7680,15 +7529,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 99,
-                            "openAppointmentSlots": 99,
+                            "openTimeslots": 100,
+                            "openAppointmentSlots": 100,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 99,
+                    "openTimeslots": 100,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 99,
+                    "openAppointmentSlots": 100,
                     "name": "281 and Evans Road H-E-B plus!",
                     "longitude": -98.45756,
                     "latitude": 29.63886,
@@ -7708,22 +7557,21 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 2748,
-                            "openAppointmentSlots": 2748,
+                            "openTimeslots": 2512,
+                            "openAppointmentSlots": 2512,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 2748,
+                    "openTimeslots": 2512,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 2748,
+                    "openAppointmentSlots": 2512,
                     "name": "Fairfield Market H-E-B",
                     "longitude": -95.74599,
                     "latitude": 29.9925,
                     "fluUrl": "",
                     "city": "CYPRESS",
                     "availableImmunizations": [
-                        "COVID-19 Moderna_Updated_Booster",
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
@@ -7739,23 +7587,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 257,
-                            "openAppointmentSlots": 257,
+                            "openTimeslots": 292,
+                            "openAppointmentSlots": 292,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 257,
+                    "openTimeslots": 292,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 257,
+                    "openAppointmentSlots": 292,
                     "name": "Jones and West H-E-B",
                     "longitude": -95.5859,
                     "latitude": 29.91104,
                     "fluUrl": "",
                     "city": "HOUSTON",
                     "availableImmunizations": [
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
                         "Flu",
-                        "COVID-19 Moderna"
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -7767,24 +7616,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 78,
-                            "openAppointmentSlots": 78,
+                            "openTimeslots": 138,
+                            "openAppointmentSlots": 138,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 78,
+                    "openTimeslots": 138,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 78,
+                    "openAppointmentSlots": 138,
                     "name": "The Market at Stone Oak",
                     "longitude": -98.50062,
                     "latitude": 29.662,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
-                        "COVID-19 Moderna_Updated_Booster",
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -7796,23 +7646,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 10,
-                            "openAppointmentSlots": 10,
+                            "openTimeslots": 27,
+                            "openAppointmentSlots": 27,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 4,
-                    "openFluTimeslots": 6,
-                    "openFluAppointmentSlots": 6,
-                    "openAppointmentSlots": 4,
+                    "openTimeslots": 27,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 27,
                     "name": "Lakeline H-E-B plus!",
                     "longitude": -97.8034,
                     "latitude": 30.47786,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF4lQAE",
+                    "fluUrl": "",
                     "city": "AUSTIN",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "Flu"
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -7829,20 +7679,20 @@
                             "manufacturer": "Moderna"
                         },
                         {
-                            "openTimeslots": 392,
-                            "openAppointmentSlots": 392,
+                            "openTimeslots": 391,
+                            "openAppointmentSlots": 391,
                             "manufacturer": "Pfizer"
                         },
                         {
-                            "openTimeslots": 1026,
-                            "openAppointmentSlots": 1026,
+                            "openTimeslots": 1039,
+                            "openAppointmentSlots": 1039,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 1768,
+                    "openTimeslots": 1780,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 1768,
+                    "openAppointmentSlots": 1780,
                     "name": "Conroe Market H-E-B",
                     "longitude": -95.49817,
                     "latitude": 30.32647,
@@ -7865,15 +7715,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 489,
-                            "openAppointmentSlots": 489,
+                            "openTimeslots": 410,
+                            "openAppointmentSlots": 410,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 489,
+                    "openTimeslots": 410,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 489,
+                    "openAppointmentSlots": 410,
                     "name": "Texas City H-E-B",
                     "longitude": -94.94893,
                     "latitude": 29.39535,
@@ -7915,15 +7765,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 196,
-                            "openAppointmentSlots": 196,
+                            "openTimeslots": 376,
+                            "openAppointmentSlots": 376,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 196,
+                    "openTimeslots": 376,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 196,
+                    "openAppointmentSlots": 376,
                     "name": "Broadway Central Market",
                     "longitude": -98.46408,
                     "latitude": 29.47069,
@@ -7933,9 +7783,11 @@
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "Flu",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Janssen"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer"
                     ]
                 },
                 {
@@ -7959,22 +7811,32 @@
                 },
                 {
                     "zip": "78834-2028",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudsQAC",
                     "type": "store",
                     "street": "2030 N. 1ST STREET",
                     "storeNumber": 671,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 29,
+                            "openAppointmentSlots": 29,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 29,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 29,
                     "name": "Carrizo Springs H-E-B",
                     "longitude": -99.85102,
                     "latitude": 28.53642,
                     "fluUrl": "",
                     "city": "CARRIZO SPRINGS",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "76711-2119",
@@ -7985,27 +7847,30 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 85,
-                            "openAppointmentSlots": 85,
+                            "openTimeslots": 205,
+                            "openAppointmentSlots": 205,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 85,
+                    "openTimeslots": 205,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 85,
+                    "openAppointmentSlots": 205,
                     "name": "Valley Mills H-E-B plus!",
                     "longitude": -97.13916,
                     "latitude": 31.52508,
                     "fluUrl": "",
                     "city": "WACO",
                     "availableImmunizations": [
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Janssen",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
-                        "COVID-19 Pediatric_Moderna",
                         "COVID-19 Novavax",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster"
@@ -8020,15 +7885,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 7,
-                            "openAppointmentSlots": 7,
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 7,
+                    "openTimeslots": 50,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 7,
+                    "openAppointmentSlots": 50,
                     "name": "University Blvd H-E-B",
                     "longitude": -97.68859,
                     "latitude": 30.56107,
@@ -8037,11 +7902,15 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
                         "COVID-19 Novavax",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -8053,24 +7922,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 44,
-                            "openAppointmentSlots": 44,
+                            "openTimeslots": 40,
+                            "openAppointmentSlots": 40,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 44,
+                    "openTimeslots": 40,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 44,
+                    "openAppointmentSlots": 40,
                     "name": "Palmhurst H-E-B",
                     "longitude": -98.31816,
                     "latitude": 26.25684,
                     "fluUrl": "",
                     "city": "PALMHURST",
                     "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Flu"
                     ]
                 },
                 {
@@ -8082,15 +7952,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 337,
-                            "openAppointmentSlots": 337,
+                            "openTimeslots": 98,
+                            "openAppointmentSlots": 98,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 337,
+                    "openTimeslots": 98,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 337,
+                    "openAppointmentSlots": 98,
                     "name": "Pearland Market H-E-B",
                     "longitude": -95.26499,
                     "latitude": 29.55812,
@@ -8099,6 +7969,7 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster"
@@ -8151,30 +8022,28 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 162,
-                            "openAppointmentSlots": 162,
+                            "openTimeslots": 104,
+                            "openAppointmentSlots": 104,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 162,
+                    "openTimeslots": 104,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 162,
-                    "name": "Frisco H-E-B",
+                    "openAppointmentSlots": 104,
+                    "name": "H-E-B Frisco",
                     "longitude": -96.84583,
                     "latitude": 33.15458,
                     "fluUrl": "",
                     "city": "FRISCO",
                     "availableImmunizations": [
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Moderna",
                         "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Janssen",
                         "COVID-19 Ultra_Pediatric_Pfizer",
-                        "COVID-19 Pediatric_Moderna",
                         "COVID-19 Novavax",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 }
             ]
@@ -8183,29 +8052,31 @@
             "Content-Type",
             "binary/octet-stream",
             "Content-Length",
-            "175054",
+            "173376",
             "Connection",
             "close",
-            "Date",
-            "Wed, 05 Oct 2022 22:47:32 GMT",
             "Last-Modified",
-            "Wed, 05 Oct 2022 22:47:19 GMT",
-            "ETag",
-            "\"307b0a3d351db28f64060f105a537870\"",
-            "Cache-Control",
-            "max-age:0",
+            "Tue, 25 Oct 2022 16:44:21 GMT",
             "Accept-Ranges",
             "bytes",
             "Server",
             "AmazonS3",
+            "Date",
+            "Tue, 25 Oct 2022 16:45:20 GMT",
+            "Cache-Control",
+            "max-age:0",
+            "ETag",
+            "\"67847a393bf3338ea5111bc942b1aa59\"",
+            "Vary",
+            "Accept-Encoding",
             "X-Cache",
-            "Miss from cloudfront",
+            "RefreshHit from cloudfront",
             "Via",
-            "1.1 5e3db235184770510999a272e515dfbc.cloudfront.net (CloudFront)",
+            "1.1 21e2c668bb54ebb4456425e394c3356a.cloudfront.net (CloudFront)",
             "X-Amz-Cf-Pop",
-            "SFO5-P1",
+            "SFO20-C1",
             "X-Amz-Cf-Id",
-            "YUy2f7PdC4LyMEnXEd_vUetSx4_F-bWzr0V-A7DEvp3kmp_rCjHvYQ=="
+            "M0ku-xN7TYES3ZCiYi4gg5jXiwnj7UjK7G2ixsXfuvdt_0Sp2n_VwA=="
         ],
         "responseIsBinary": false
     }


### PR DESCRIPTION
H-E-B recently starting surfacing a `Senior_Flu` immunization type, which we should ignore. Fixes https://sentry.io/organizations/usdr/issues/3696454234.