### PR TITLE
CDC: handle new Walmart store name format

### DIFF
--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -228,7 +228,7 @@ function getWalmartId(location) {
   // When the number is not in loc_store_no, it may be formatted like above
   // (10-NNN) or without the "10-" prefix.
   const numberInName = location.loc_name.match(
-    /^(?:Walmart|Sam['\u2019]?s Club) [^#\d]*#?(?:10-)?(\d+)$/i
+    /^(?:Walmart|Sam['\u2019]?s Club) [^#\d]*#?\s?(?:10-)?(\d+)$/i
   );
   if (numberInName) {
     return unpadNumber(numberInName[1]);


### PR DESCRIPTION
Walmart store names now sometimes include a space between the "#" and the numbers in the store number, e.g. "Walmart Pharmacy # 6467". This handles the new pattern.

Fixes https://sentry.io/organizations/usdr/issues/3699677873.