### PR TITLE
Upgrade Node.js to v18.12.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.18.1
+          node-version: 18.12.1
 
       - name: Cache Dependencies
         uses: actions/cache@v3
@@ -98,7 +98,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.18.1
+          node-version: 18.12.1
 
       - name: Cache Dependencies
         uses: actions/cache@v3

--- a/.github/workflows/ui-deploy.yml
+++ b/.github/workflows/ui-deploy.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.18.1
+          node-version: 18.12.1
 
       - name: Cache Dependencies
         uses: actions/cache@v3

--- a/loader/Dockerfile
+++ b/loader/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.18.1-slim
+FROM node:18.12.1-slim
 # Name for the version/release of the software. (Optional)
 ARG RELEASE
 

--- a/render.yaml
+++ b/render.yaml
@@ -238,7 +238,7 @@ envVarGroups:
   - name: "Server Environment"
     envVars:
       - key: NODE_VERSION
-        value: "16.18.1"
+        value: "18.12.1"
       - key: NODE_ENV
         value: production
       - key: API_KEYS
@@ -257,7 +257,7 @@ envVarGroups:
   - name: "Loader Environment"
     envVars:
       - key: NODE_VERSION
-        value: "16.18.1"
+        value: "18.12.1"
       - key: NODE_ENV
         value: production
       - key: API_URL

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.18.1-slim
+FROM node:18.12.1-slim
 
 # Upgrade to NPM 7
 RUN npm install -g npm

--- a/server/Dockerfile.seed-db
+++ b/server/Dockerfile.seed-db
@@ -4,7 +4,7 @@ FROM ubuntu:22.04
 RUN apt-get update
 RUN apt-get install -qy postgresql-client-12 curl
 
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
 RUN apt-get install -y nodejs
 
 # copy our files

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -43,7 +43,7 @@
         "@types/jest": "29.2.0",
         "@types/lodash": "4.14.186",
         "@types/luxon": "^3.1.0",
-        "@types/node": "16.11.64",
+        "@types/node": "18.11.9",
         "@types/pg": "^8.6.5",
         "@typescript-eslint/eslint-plugin": "5.43.0",
         "@typescript-eslint/parser": "5.43.0",
@@ -3270,9 +3270,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.11.64",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.64.tgz",
-      "integrity": "sha512-z5hPTlVFzNwtJ2LNozTpJcD1Cu44c4LNuzaq1mwxmiHWQh2ULdR6Vjwo1UGldzRpzL0yUEdZddnfqGW2G70z6Q==",
+      "version": "18.11.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
+      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
       "dev": true
     },
     "node_modules/@types/pg": {
@@ -11926,9 +11926,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.11.64",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.64.tgz",
-      "integrity": "sha512-z5hPTlVFzNwtJ2LNozTpJcD1Cu44c4LNuzaq1mwxmiHWQh2ULdR6Vjwo1UGldzRpzL0yUEdZddnfqGW2G70z6Q==",
+      "version": "18.11.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
+      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
       "dev": true
     },
     "@types/pg": {

--- a/server/package.json
+++ b/server/package.json
@@ -65,7 +65,7 @@
     "@types/jest": "29.2.0",
     "@types/lodash": "4.14.186",
     "@types/luxon": "^3.1.0",
-    "@types/node": "16.11.64",
+    "@types/node": "18.11.9",
     "@types/pg": "^8.6.5",
     "@typescript-eslint/eslint-plugin": "5.43.0",
     "@typescript-eslint/parser": "5.43.0",


### PR DESCRIPTION
Node 18 is now the LTS release, so it's probably time to upgrade to it from 16. There are some changes to Node.js types, but no new JS language features that warrant updating.