### PR TITLE
Fix UI deploy workflow

### DIFF
--- a/.github/workflows/ui-deploy.yml
+++ b/.github/workflows/ui-deploy.yml
@@ -28,13 +28,14 @@ jobs:
           path: |
             ~/.npm
             ~/.cache
-          key: ${{ runner.os }}-npm-v2-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-npm-v2-${{ hashFiles('main/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-npm-v2
             ${{ runner.os }}-npm-
 
       - name: Install dependencies
         run: |
+          cd main
           npm ci
 
       - name: Build UI


### PR DESCRIPTION
I broke the UI deploy workflow in #1133 - I treated it as if it were installed in the main working directory of the CI server, but it's not (because there are *two* checkouts side-by-side in that workflow). This fixes the path from which we run NPM, which should solve the issue.