### PR TITLE
Support bivalent vaccines for ages 6+ months in Prepmod

### DIFF
--- a/common/src/vaccines.ts
+++ b/common/src/vaccines.ts
@@ -15,12 +15,14 @@ export type VaccineCode =
   | "moderna_age_6_11"
   | "moderna_ba4_ba5_age_6_11"
   | "moderna_age_0_5"
+  | "moderna_ba4_ba5_age_0_5"
   | "novavax"
   | "pfizer"
   | "pfizer_ba4_ba5"
   | "pfizer_age_5_11"
   | "pfizer_ba4_ba5_age_5_11"
   | "pfizer_age_0_4"
+  | "pfizer_ba4_ba5_age_0_4"
   | "sanofi";
 
 /**
@@ -36,12 +38,14 @@ export const VACCINE_PRODUCTS = {
   modernaAge6_11: "moderna_age_6_11",
   modernaBa4Ba5Age6_11: "moderna_ba4_ba5_age_6_11",
   modernaAge0_5: "moderna_age_0_5",
+  modernaBa4Ba5Age0_5: "moderna_ba4_ba5_age_0_5",
   novavax: "novavax",
   pfizer: "pfizer",
   pfizerBa4Ba5: "pfizer_ba4_ba5",
   pfizerAge5_11: "pfizer_age_5_11",
   pfizerBa4Ba5Age5_11: "pfizer_ba4_ba5_age_5_11",
   pfizerAge0_4: "pfizer_age_0_4",
+  pfizerBa4Ba5Age0_4: "pfizer_ba4_ba5_age_0_4",
   sanofi: "sanofi",
 } satisfies { [index: string]: VaccineCode };
 
@@ -74,12 +78,14 @@ export const CVX_CODES: { [code in VaccineCode]: number } = {
   moderna_age_6_11: 227,
   moderna_ba4_ba5_age_6_11: 229,
   moderna_age_0_5: 228,
+  moderna_ba4_ba5_age_0_5: 230,
   novavax: 211,
   pfizer: 208,
   pfizer_ba4_ba5: 300,
   pfizer_age_5_11: 218,
   pfizer_ba4_ba5_age_5_11: 301,
   pfizer_age_0_4: 219,
+  pfizer_ba4_ba5_age_0_4: 302,
   sanofi: 225,
 };
 
@@ -93,6 +99,8 @@ export const PRODUCT_NAMES: { [code in VaccineCode]: string } = {
   moderna_ba4_ba5_age_6_11:
     "Moderna Pediatric (Ages 6-11, for Omicron BA.4/BA.5)",
   moderna_age_0_5: "Moderna Pediatric (Ages 0-5)",
+  moderna_ba4_ba5_age_0_5:
+    "Moderna Pediatric (Ages 0-5, for Omicron BA.4/BA.5)",
   novavax: "NovaVax",
   pfizer: "Pfizer",
   pfizer_ba4_ba5: "Pfizer (for Omicron BA.4/BA.5)",
@@ -100,6 +108,7 @@ export const PRODUCT_NAMES: { [code in VaccineCode]: string } = {
   pfizer_ba4_ba5_age_5_11:
     "Pfizer Pediatric (Ages 5-11, for Omicron BA.4/BA.5)",
   pfizer_age_0_4: "Pfizer Pediatric (Ages 0-4)",
+  pfizer_ba4_ba5_age_0_4: "Pfizer Pediatric (Ages 0-4, for Omicron BA.4/BA.5)",
   sanofi: "Sanofi Pasteur",
 };
 
@@ -114,12 +123,14 @@ export const MINIMUM_PRODUCT_AGES: { [code in VaccineCode]: number } = {
   moderna_age_6_11: 6 * 12,
   moderna_ba4_ba5_age_6_11: 6 * 12,
   moderna_age_0_5: 6,
+  moderna_ba4_ba5_age_0_5: 6,
   novavax: 18 * 12,
   pfizer: 12 * 12,
   pfizer_ba4_ba5: 12 * 12,
   pfizer_age_5_11: 5 * 12,
   pfizer_ba4_ba5_age_5_11: 5 * 12,
   pfizer_age_0_4: 6,
+  pfizer_ba4_ba5_age_0_4: 6,
   sanofi: 18 * 12,
 };
 

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -491,6 +491,9 @@ const ndcLookup = {
   [normalizeNdc("59267-0565-01")]: VaccineProduct.pfizerBa4Ba5Age5_11, // sale
   [normalizeNdc("59267-0565-02")]: VaccineProduct.pfizerBa4Ba5Age5_11, // sale
 
+  [normalizeNdc("59267-0609-02")]: VaccineProduct.pfizerBa4Ba5Age0_4, // sale
+  [normalizeNdc("59267-0609-01")]: VaccineProduct.pfizerBa4Ba5Age0_4, // use
+
   [normalizeNdc("59676-0580-05")]: VaccineProduct.janssen, // use
   [normalizeNdc("59676-0580-15")]: VaccineProduct.janssen, // sale
 
@@ -523,6 +526,9 @@ const ndcLookup = {
   // It's designed for ages 6+, but as of 2022-09-02 only authorized for 18+.
   [normalizeNdc("80777-0282-05")]: VaccineProduct.modernaBa4Ba5, // use
   [normalizeNdc("80777-0282-99")]: VaccineProduct.modernaBa4Ba5, // sale
+
+  [normalizeNdc("80777-283-99")]: VaccineProduct.modernaBa4Ba5Age0_5, // sale
+  [normalizeNdc("80777-283-02")]: VaccineProduct.modernaBa4Ba5Age0_5, // use
 
   [normalizeNdc("49281-0618-78")]: VaccineProduct.sanofi, // use
   [normalizeNdc("49281-0618-20")]: VaccineProduct.sanofi, // sale

--- a/loader/src/utils.js
+++ b/loader/src/utils.js
@@ -539,9 +539,13 @@ module.exports = {
       if (/ages?\s+(6|12|18)( (years )?and up|\s*\+)/i.test(text)) {
         return isBa4Ba5 ? VaccineProduct.modernaBa4Ba5 : VaccineProduct.moderna;
       } else if (/ages?\s+6\s*(m|months)\b/i.test(text)) {
-        return isBa4Ba5 ? undefined : VaccineProduct.modernaAge0_5;
+        return isBa4Ba5
+          ? VaccineProduct.modernaBa4Ba5Age0_5
+          : VaccineProduct.modernaAge0_5;
       } else if (/ages? 6\s?(-|through)\s?11/i.test(text)) {
-        return isBa4Ba5 ? undefined : VaccineProduct.modernaAge6_11;
+        return isBa4Ba5
+          ? VaccineProduct.modernaBa4Ba5Age6_11
+          : VaccineProduct.modernaAge6_11;
       } else if (/ped|child|age/i.test(text)) {
         // Possibly a pediatric variation we haven't seen, so return nothing to
         // trigger warnings so we can address it.
@@ -559,7 +563,9 @@ module.exports = {
           ? VaccineProduct.pfizerBa4Ba5Age5_11
           : VaccineProduct.pfizerAge5_11;
       } else if (/ages?\s+6\s*(m|months)\b/i.test(text)) {
-        return isBa4Ba5 ? undefined : VaccineProduct.pfizerAge0_4;
+        return isBa4Ba5
+          ? VaccineProduct.pfizerBa4Ba5Age0_4
+          : VaccineProduct.pfizerAge0_4;
       } else if (/ped|child|age/i.test(text)) {
         // Possibly a pediatric variation we haven't seen, so return nothing to
         // trigger warnings so we can address it.

--- a/loader/test/utils.test.js
+++ b/loader/test/utils.test.js
@@ -253,6 +253,8 @@ describe("matchVaccineProduct", () => {
     [v.modernaAge0_5, "Moderna Pediatric COVID-19 Vaccine (Ages 6 months through 5 years)"],
     [v.modernaAge0_5, "Moderna COVID-19 Vaccine (Ages 6m-5yrs)"],
 
+    [v.modernaBa4Ba5Age0_5, "Moderna COVID-19 Bivalent Booster (Ages 6m - 5yrs)"],
+
     [v.pfizer, "Pfizer-BioNTech"],
     [v.pfizer, "Pfizer-BioNTech COVID-19 Vaccine (Ages 12+)"],
     [v.pfizer, "Pfizer-BioNTech COVID-19 Vaccine/Booster (Ages 12+)"],

--- a/server/public/docs/openapi.yaml
+++ b/server/public/docs/openapi.yaml
@@ -551,8 +551,9 @@ components:
             List of vaccine products available on this date. Not present if not
             known. Current possible values include: `moderna`, `moderna_ba4_ba5`,
             `moderna_age_6_11`, `moderna_ba4_ba5_age_6_11`, `moderna_age_0_5`,
-            `pfizer`, `pfizer_ba4_ba5`, `pfizer_age_5_11`,
-            `pfizer_ba4_ba5_age_5_11`, `pfizer_age_0_4`, `jj`, `sanofi`.
+            `moderna_ba4_ba5_age_0_5`, `pfizer`, `pfizer_ba4_ba5`,
+            `pfizer_age_5_11`, `pfizer_ba4_ba5_age_5_11`, `pfizer_age_0_4`,
+            `pfizer_ba4_ba5_age_0_4` `jj`, `sanofi`.
         dose:
           type: string
           description: |
@@ -604,8 +605,9 @@ components:
             List of vaccine products available for this slot. Not present if not
             known. Current possible values include: `moderna`, `moderna_ba4_ba5`,
             `moderna_age_6_11`, `moderna_ba4_ba5_age_6_11`, `moderna_age_0_5`,
-            `pfizer`, `pfizer_ba4_ba5`, `pfizer_age_5_11`,
-            `pfizer_ba4_ba5_age_5_11`, `pfizer_age_0_4`, `jj`, `sanofi`.
+            `moderna_ba4_ba5_age_0_5`, `pfizer`, `pfizer_ba4_ba5`,
+            `pfizer_age_5_11`, `pfizer_ba4_ba5_age_5_11`, `pfizer_age_0_4`,
+            `pfizer_ba4_ba5_age_0_4` `jj`, `sanofi`.
         dose:
           type: string
           description: |
@@ -669,8 +671,9 @@ components:
             List of vaccine products available. Not present if not known.
             Current possible values include: `moderna`, `moderna_ba4_ba5`,
             `moderna_age_6_11`, `moderna_ba4_ba5_age_6_11`, `moderna_age_0_5`,
-            `pfizer`, `pfizer_ba4_ba5`, `pfizer_age_5_11`,
-            `pfizer_ba4_ba5_age_5_11`, `pfizer_age_0_4`, `jj`, `sanofi`.
+            `moderna_ba4_ba5_age_0_5`, `pfizer`, `pfizer_ba4_ba5`,
+            `pfizer_age_5_11`, `pfizer_ba4_ba5_age_5_11`, `pfizer_age_0_4`,
+            `pfizer_ba4_ba5_age_0_4` `jj`, `sanofi`.
         doses:
           type: array
           items:


### PR DESCRIPTION
Prepmod started surfacing vaccine names for Bivalent vaccines for ages 6+ months a few hours ago. This adds the codes, constants, and fuzzy parsing needed to handle it.

Fixes https://sentry.io/organizations/usdr/issues/3798626687