### PR TITLE
Bump up the timeout on HyVee requests

### DIFF
--- a/loader/src/sources/hyvee/index.js
+++ b/loader/src/sources/hyvee/index.js
@@ -60,7 +60,7 @@ async function fetchRawData() {
   const response = await httpClient(API_URL, {
     method: "POST",
     responseType: "json",
-    timeout: 30000,
+    timeout: 60000,
     retry: 0,
     json: {
       operationName: "SearchPharmaciesNearPointWithCovidVaccineAvailability",


### PR DESCRIPTION
We have been seeing a lot of timeouts recently for HyVee (see https://sentry.io/organizations/usdr/issues/3116608217), so I'm trying bumping up the timeout a bit to see if that helps smooth things over.