### PR TITLE
Support bivalent boosters for infants at H-E-B

### DIFF
--- a/loader/src/sources/heb/index.js
+++ b/loader/src/sources/heb/index.js
@@ -68,6 +68,10 @@ const IMMUNIZATION_TYPES = {
     manufacturer: "pediatric_moderna",
     product: VaccineProduct.modernaBa4Ba5Age6_11,
   },
+  "COVID-19 Ultra_Pediatric_Moderna_Updated_Booster": {
+    manufacturer: "moderna",
+    product: VaccineProduct.modernaBa4Ba5Age0_5,
+  },
   "COVID-19 Novavax": {
     // We haven't seen a "manufacturer" field with this, so it's a guess.
     manufacturer: "novavax",

--- a/loader/src/sources/heb/index.js
+++ b/loader/src/sources/heb/index.js
@@ -73,7 +73,7 @@ const IMMUNIZATION_TYPES = {
     product: VaccineProduct.modernaBa4Ba5Age6_11,
   },
   "COVID-19 Ultra_Pediatric_Moderna_Updated_Booster": {
-    manufacturer: "moderna",
+    manufacturer: "ultra_pediatric_moderna",
     product: VaccineProduct.modernaBa4Ba5Age0_5,
   },
   "COVID-19 Novavax": {

--- a/loader/src/sources/heb/index.js
+++ b/loader/src/sources/heb/index.js
@@ -40,25 +40,29 @@ const IMMUNIZATION_TYPES = {
     manufacturer: "pfizer",
     product: VaccineProduct.pfizer,
   },
-  "COVID-19 Pediatric_Pfizer": {
-    manufacturer: "pediatric_pfizer",
-    product: VaccineProduct.pfizerAge5_11,
-  },
   "COVID-19 Pfizer_Updated_Booster": {
     manufacturer: "pfizer",
     product: VaccineProduct.pfizerBa4Ba5,
+  },
+  "COVID-19 Pediatric_Pfizer": {
+    manufacturer: "pediatric_pfizer",
+    product: VaccineProduct.pfizerAge5_11,
   },
   "COVID-19 Pediatric_Pfizer_Updated_Booster": {
     manufacturer: "pediatric_pfizer",
     product: VaccineProduct.pfizerBa4Ba5Age5_11,
   },
-  "COVID-19 Moderna_Updated_Booster": {
-    manufacturer: "moderna",
-    product: VaccineProduct.modernaBa4Ba5,
+  "COVID-19 Ultra_Pediatric_Pfizer": {
+    manufacturer: "ultra_pediatric_pfizer",
+    product: VaccineProduct.pfizerAge0_4,
   },
   "COVID-19 Moderna": {
     manufacturer: "moderna",
     product: VaccineProduct.moderna,
+  },
+  "COVID-19 Moderna_Updated_Booster": {
+    manufacturer: "moderna",
+    product: VaccineProduct.modernaBa4Ba5,
   },
   "COVID-19 Pediatric_Moderna": {
     manufacturer: "pediatric_moderna",
@@ -76,10 +80,6 @@ const IMMUNIZATION_TYPES = {
     // We haven't seen a "manufacturer" field with this, so it's a guess.
     manufacturer: "novavax",
     product: VaccineProduct.novavax,
-  },
-  "COVID-19 Ultra_Pediatric_Pfizer": {
-    manufacturer: "ultra_pediatric_pfizer",
-    product: VaccineProduct.pfizerAge0_4,
   },
   "COVID-19 Janssen": {
     manufacturer: "janssen",

--- a/loader/test/fixtures/nock/h-e-b_should_output_valid_data.json
+++ b/loader/test/fixtures/nock/h-e-b_should_output_valid_data.json
@@ -2,66 +2,11 @@
     {
         "scope": "https://heb-ecom-covid-vaccine.hebdigital-prd.com:443",
         "method": "GET",
-        "path": "/vaccine_locations.json?v=314803397183.5125",
+        "path": "/vaccine_locations.json?v=480604202775.56006",
         "body": "",
         "status": 200,
         "response": {
             "locations": [
-                {
-                    "zip": "78654",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h6P0000004EAwQAM",
-                    "type": "offsite",
-                    "street": "177 Broadmoor",
-                    "storeNumber": null,
-                    "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 6,
-                            "openAppointmentSlots": 6,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 6,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 6,
-                    "name": "H-E-B Hosted City of Meadowlakes-Totten Hall",
-                    "longitude": null,
-                    "latitude": null,
-                    "fluUrl": "",
-                    "city": "Marble Falls",
-                    "availableImmunizations": [
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
-                },
-                {
-                    "zip": "78654",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h6P0000004EufQAE",
-                    "type": "offsite",
-                    "street": "700 Avenue N",
-                    "storeNumber": null,
-                    "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 86,
-                            "openAppointmentSlots": 86,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 86,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 86,
-                    "name": "H-E-B Hosted Marble Falls Fire Station",
-                    "longitude": null,
-                    "latitude": null,
-                    "fluUrl": "",
-                    "city": "Marble Falls",
-                    "availableImmunizations": [
-                        "Flu"
-                    ]
-                },
                 {
                     "zip": "78664-4677",
                     "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudGQAS",
@@ -71,26 +16,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 162,
-                            "openAppointmentSlots": 162,
+                            "openTimeslots": 24,
+                            "openAppointmentSlots": 24,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 162,
+                    "openTimeslots": 24,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 162,
+                    "openAppointmentSlots": 24,
                     "name": "Round Rock H-E-B plus!",
                     "longitude": -97.65978,
                     "latitude": 30.5177,
                     "fluUrl": "",
                     "city": "ROUND ROCK",
                     "availableImmunizations": [
-                        "COVID-19 Moderna_Updated_Booster",
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -121,23 +63,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 64,
-                            "openAppointmentSlots": 64,
+                            "openTimeslots": 94,
+                            "openAppointmentSlots": 94,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 64,
+                    "openTimeslots": 94,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 64,
+                    "openAppointmentSlots": 94,
                     "name": "Marble Falls H-E-B",
                     "longitude": -98.27972,
                     "latitude": 30.58301,
                     "fluUrl": "",
                     "city": "MARBLE FALLS",
                     "availableImmunizations": [
-                        "Flu",
                         "COVID-19 Moderna_Updated_Booster",
+                        "Senior_Flu",
+                        "Flu",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
@@ -150,15 +93,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 643,
-                            "openAppointmentSlots": 643,
+                            "openTimeslots": 473,
+                            "openAppointmentSlots": 473,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 643,
+                    "openTimeslots": 473,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 643,
+                    "openAppointmentSlots": 473,
                     "name": "Wells Branch H-E-B",
                     "longitude": -97.66419,
                     "latitude": 30.44263,
@@ -166,8 +109,7 @@
                     "city": "PFLUGERVILLE",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pfizer"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -179,15 +121,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 41,
-                            "openAppointmentSlots": 41,
+                            "openTimeslots": 94,
+                            "openAppointmentSlots": 94,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 41,
+                    "openTimeslots": 94,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 41,
+                    "openAppointmentSlots": 94,
                     "name": "Louis Henna Blvd H-E-B",
                     "longitude": -97.65938,
                     "latitude": 30.48179,
@@ -208,15 +150,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 13,
-                            "openAppointmentSlots": 13,
+                            "openTimeslots": 61,
+                            "openAppointmentSlots": 61,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 13,
+                    "openTimeslots": 61,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 13,
+                    "openAppointmentSlots": 61,
                     "name": "H-E-B at Ronald Reagan Blvd",
                     "longitude": -97.82446,
                     "latitude": 30.63307,
@@ -224,12 +166,54 @@
                     "city": "GEORGETOWN",
                     "availableImmunizations": [
                         "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "Senior_Flu",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Novavax",
                         "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Novavax",
-                        "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
+                },
+                {
+                    "zip": "75093-0",
+                    "url": null,
+                    "type": "store",
+                    "street": "6001 PRESTON ROAD SUITE 100",
+                    "storeNumber": 790,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "H-E-B Plano",
+                    "longitude": -96.79698,
+                    "latitude": 33.05554,
+                    "fluUrl": "",
+                    "city": "PLANO",
+                    "availableImmunizations": null
+                },
+                {
+                    "zip": "77378-9999",
+                    "url": null,
+                    "type": "store",
+                    "street": "12350 INTERSTATE 45 N,",
+                    "storeNumber": 791,
+                    "state": "TX",
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
+                    "name": "H-E-B Willis",
+                    "longitude": -95.49015,
+                    "latitude": 30.42057,
+                    "fluUrl": "",
+                    "city": "WILLIS",
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77598-0",
@@ -240,15 +224,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 77,
-                            "openAppointmentSlots": 77,
+                            "openTimeslots": 213,
+                            "openAppointmentSlots": 213,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 77,
+                    "openTimeslots": 213,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 77,
+                    "openAppointmentSlots": 213,
                     "name": "El Dorado H-E-B",
                     "longitude": -95.14874,
                     "latitude": 29.55117,
@@ -258,28 +242,70 @@
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
+                    ]
+                },
+                {
+                    "zip": "77354-0",
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h6P00000006b8QAA",
+                    "type": "store",
+                    "street": "13663 FM 1488",
+                    "storeNumber": 767,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 240,
+                            "openAppointmentSlots": 240,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 240,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 240,
+                    "name": "H-E-B Magnolia Place",
+                    "longitude": -95.68208,
+                    "latitude": 30.22109,
+                    "fluUrl": "",
+                    "city": "MAGNOLIA",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
                     "zip": "78045-2802",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucLQAS",
                     "type": "store",
                     "street": "7811 MCPHERSON RD.",
                     "storeNumber": 449,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 1,
+                            "openAppointmentSlots": 1,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 1,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 1,
                     "name": "McPherson Rd H-E-B",
                     "longitude": -99.4733,
                     "latitude": 27.5754,
                     "fluUrl": "",
                     "city": "LAREDO",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Senior_Flu"
+                    ]
                 },
                 {
                     "zip": "78355-4365",
@@ -309,57 +335,46 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 11,
-                            "openAppointmentSlots": 11,
+                            "openTimeslots": 39,
+                            "openAppointmentSlots": 39,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 11,
+                    "openTimeslots": 39,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 11,
+                    "openAppointmentSlots": 39,
                     "name": "Burnet Rd H-E-B",
                     "longitude": -97.74016,
                     "latitude": 30.33374,
                     "fluUrl": "",
                     "city": "AUSTIN",
                     "availableImmunizations": [
+                        "Flu",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "Flu"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "78237-3134",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubAQAS",
+                    "url": null,
                     "type": "store",
                     "street": "721 CASTROVILLE RD",
                     "storeNumber": 205,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 126,
-                            "openAppointmentSlots": 126,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 126,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 126,
+                    "openAppointmentSlots": 0,
                     "name": "Las Palmas H-E-B",
                     "longitude": -98.55132,
                     "latitude": 29.41734,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78040-5343",
@@ -370,15 +385,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 56,
-                            "openAppointmentSlots": 56,
+                            "openTimeslots": 19,
+                            "openAppointmentSlots": 19,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 56,
+                    "openTimeslots": 19,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 56,
+                    "openAppointmentSlots": 19,
                     "name": "Guadalupe and Stone H-E-B",
                     "longitude": -99.48344,
                     "latitude": 27.50656,
@@ -386,9 +401,7 @@
                     "city": "LAREDO",
                     "availableImmunizations": [
                         "COVID-19 Pfizer_Updated_Booster",
-                        "Flu",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -457,15 +470,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 41,
-                            "openAppointmentSlots": 41,
+                            "openTimeslots": 78,
+                            "openAppointmentSlots": 78,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 41,
+                    "openTimeslots": 78,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 41,
+                    "openAppointmentSlots": 78,
                     "name": "Parmer and Mopac H-E-B",
                     "longitude": -97.70326,
                     "latitude": 30.41883,
@@ -473,40 +486,31 @@
                     "city": "AUSTIN",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
                         "COVID-19 Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
                     "zip": "78064-4221",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubyQAC",
+                    "url": null,
                     "type": "store",
                     "street": "219 W OAKLAWN",
                     "storeNumber": 411,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 116,
-                            "openAppointmentSlots": 116,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 116,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 116,
+                    "openAppointmentSlots": 0,
                     "name": "Pleasanton H-E-B",
                     "longitude": -98.48567,
                     "latitude": 28.95696,
                     "fluUrl": "",
                     "city": "PLEASANTON",
-                    "availableImmunizations": [
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Moderna_Updated_Booster",
-                        "Flu"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78102-5613",
@@ -536,15 +540,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 63,
-                            "openAppointmentSlots": 63,
+                            "openTimeslots": 226,
+                            "openAppointmentSlots": 226,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 63,
+                    "openTimeslots": 226,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 63,
+                    "openAppointmentSlots": 226,
                     "name": "Alameda / Texan Trail (Medical District)",
                     "longitude": -97.3912,
                     "latitude": 27.75745,
@@ -552,7 +556,8 @@
                     "city": "CORPUS CHRISTI",
                     "availableImmunizations": [
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -564,27 +569,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 543,
-                            "openAppointmentSlots": 543,
+                            "openTimeslots": 988,
+                            "openAppointmentSlots": 988,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 543,
+                    "openTimeslots": 988,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 543,
+                    "openAppointmentSlots": 988,
                     "name": "Brenham H-E-B",
                     "longitude": -96.39591,
                     "latitude": 30.14381,
                     "fluUrl": "",
                     "city": "BRENHAM",
                     "availableImmunizations": [
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "Flu",
                         "COVID-19 Pfizer",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "Flu",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -646,30 +651,22 @@
                 },
                 {
                     "zip": "78852-4718",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Guc5QAC",
+                    "url": null,
                     "type": "store",
                     "street": "2135 E. MAIN",
                     "storeNumber": 419,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 19,
-                            "openAppointmentSlots": 19,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 19,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 19,
+                    "openAppointmentSlots": 0,
                     "name": "Eagle Pass H-E-B",
                     "longitude": -100.48583,
                     "latitude": 28.70894,
                     "fluUrl": "",
                     "city": "EAGLE PASS",
-                    "availableImmunizations": [
-                        "Flu"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78516-2315",
@@ -730,22 +727,32 @@
                 },
                 {
                     "zip": "78751-4810",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Guc9QAC",
                     "type": "store",
                     "street": "1000 EAST 41 ST.",
                     "storeNumber": 425,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 211,
+                            "openAppointmentSlots": 211,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 211,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 211,
                     "name": "Hancock Center H-E-B",
                     "longitude": -97.71973,
                     "latitude": 30.30057,
                     "fluUrl": "",
                     "city": "AUSTIN",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "75165-1884",
@@ -756,30 +763,29 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 112,
-                            "openAppointmentSlots": 112,
+                            "openTimeslots": 68,
+                            "openAppointmentSlots": 68,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 112,
+                    "openTimeslots": 68,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 112,
+                    "openAppointmentSlots": 68,
                     "name": "Waxahachie H-E-B",
                     "longitude": -96.83983,
                     "latitude": 32.41159,
                     "fluUrl": "",
                     "city": "WAXAHACHIE",
                     "availableImmunizations": [
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
                         "Flu",
-                        "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Janssen",
                         "COVID-19 Novavax",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
-                        "COVID-19 Pediatric_Moderna"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -791,15 +797,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 139,
-                            "openAppointmentSlots": 139,
+                            "openTimeslots": 353,
+                            "openAppointmentSlots": 353,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 139,
+                    "openTimeslots": 353,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 139,
+                    "openAppointmentSlots": 353,
                     "name": "Military and Pleasanton H-E-B",
                     "longitude": -98.50277,
                     "latitude": 29.35666,
@@ -807,10 +813,13 @@
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
                         "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -822,26 +831,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 1064,
-                            "openAppointmentSlots": 1064,
+                            "openTimeslots": 553,
+                            "openAppointmentSlots": 553,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 1064,
+                    "openTimeslots": 553,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 1064,
+                    "openAppointmentSlots": 553,
                     "name": "Blanco and West Ave H-E-B",
                     "longitude": -98.51025,
                     "latitude": 29.54526,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
-                        "Flu",
+                        "COVID-19 Pfizer",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "Flu"
                     ]
                 },
                 {
@@ -853,15 +861,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 218,
-                            "openAppointmentSlots": 218,
+                            "openTimeslots": 496,
+                            "openAppointmentSlots": 496,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 218,
+                    "openTimeslots": 496,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 218,
+                    "openAppointmentSlots": 496,
                     "name": "Pflugerville H-E-B",
                     "longitude": -97.6133,
                     "latitude": 30.4373,
@@ -872,7 +880,11 @@
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -884,21 +896,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 25,
-                            "openAppointmentSlots": 25,
+                            "openTimeslots": 155,
+                            "openAppointmentSlots": 155,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 25,
+                    "openTimeslots": 155,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 25,
+                    "openAppointmentSlots": 155,
                     "name": "I10 and Wurzbach H-E-B",
                     "longitude": -98.5595,
                     "latitude": 29.5336,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
@@ -931,15 +947,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 2,
-                            "openAppointmentSlots": 2,
+                            "openTimeslots": 22,
+                            "openAppointmentSlots": 22,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 2,
+                    "openTimeslots": 22,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 2,
+                    "openAppointmentSlots": 22,
                     "name": "Williams Drive H-E-B",
                     "longitude": -97.71873,
                     "latitude": 30.68312,
@@ -948,7 +964,8 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -960,21 +977,22 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 63,
-                            "openAppointmentSlots": 63,
+                            "openTimeslots": 21,
+                            "openAppointmentSlots": 21,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 63,
+                    "openTimeslots": 21,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 63,
+                    "openAppointmentSlots": 21,
                     "name": "Elsa H-E-B",
                     "longitude": -97.99272,
                     "latitude": 26.29384,
                     "fluUrl": "",
                     "city": "ELSA",
                     "availableImmunizations": [
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
                         "Flu"
                     ]
@@ -988,31 +1006,32 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 887,
-                            "openAppointmentSlots": 887,
+                            "openTimeslots": 556,
+                            "openAppointmentSlots": 556,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 887,
+                    "openTimeslots": 556,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 887,
+                    "openAppointmentSlots": 556,
                     "name": "Valley Hi H-E-B",
                     "longitude": -98.64021,
                     "latitude": 29.38099,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
+                        "Flu",
                         "COVID-19 Pfizer",
                         "COVID-19 Pfizer_Updated_Booster",
+                        "Senior_Flu",
                         "COVID-19 Moderna",
-                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
                         "COVID-19 Novavax",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Moderna_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "Flu"
+                        "COVID-19 Pediatric_Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -1043,27 +1062,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 278,
-                            "openAppointmentSlots": 278,
+                            "openTimeslots": 12,
+                            "openAppointmentSlots": 12,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 278,
+                    "openTimeslots": 12,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 278,
+                    "openAppointmentSlots": 12,
                     "name": "Creekside Park H-E-B",
                     "longitude": -95.55072,
                     "latitude": 30.14362,
                     "fluUrl": "",
                     "city": "TOMBALL",
                     "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
                         "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
@@ -1076,15 +1091,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 82,
-                            "openAppointmentSlots": 82,
+                            "openTimeslots": 315,
+                            "openAppointmentSlots": 315,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 82,
+                    "openTimeslots": 315,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 82,
+                    "openAppointmentSlots": 315,
                     "name": "San Felipe H-E-B",
                     "longitude": -95.48512,
                     "latitude": 29.74797,
@@ -1092,7 +1107,10 @@
                     "city": "HOUSTON",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -1123,15 +1141,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 157,
-                            "openAppointmentSlots": 157,
+                            "openTimeslots": 186,
+                            "openAppointmentSlots": 186,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 157,
+                    "openTimeslots": 186,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 157,
+                    "openAppointmentSlots": 186,
                     "name": "Bandera and Guilbeau H-E-B",
                     "longitude": -98.64364,
                     "latitude": 29.51985,
@@ -1139,7 +1157,9 @@
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
                         "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
@@ -1152,15 +1172,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 70,
-                            "openAppointmentSlots": 70,
+                            "openTimeslots": 260,
+                            "openAppointmentSlots": 260,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 70,
+                    "openTimeslots": 260,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 70,
+                    "openAppointmentSlots": 260,
                     "name": "Oak Hill H-E-B",
                     "longitude": -97.88755,
                     "latitude": 30.22696,
@@ -1168,37 +1188,28 @@
                     "city": "AUSTIN",
                     "availableImmunizations": [
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "Flu",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "78611-3201",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucEQAS",
+                    "url": null,
                     "type": "store",
                     "street": "105 S BOUNDARY",
                     "storeNumber": 433,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 274,
-                            "openAppointmentSlots": 274,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 274,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 274,
+                    "openAppointmentSlots": 0,
                     "name": "Burnet H-E-B",
                     "longitude": -98.22452,
                     "latitude": 30.7588,
                     "fluUrl": "",
                     "city": "BURNET",
-                    "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "Flu",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77979-2423",
@@ -1247,15 +1258,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 96,
-                            "openAppointmentSlots": 96,
+                            "openTimeslots": 120,
+                            "openAppointmentSlots": 120,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 96,
+                    "openTimeslots": 120,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 96,
+                    "openAppointmentSlots": 120,
                     "name": "Military and Goliad H-E-B",
                     "longitude": -98.4362,
                     "latitude": 29.35194,
@@ -1263,13 +1274,10 @@
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -1281,15 +1289,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 170,
-                            "openAppointmentSlots": 170,
+                            "openTimeslots": 160,
+                            "openAppointmentSlots": 160,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 170,
+                    "openTimeslots": 160,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 170,
+                    "openAppointmentSlots": 160,
                     "name": "Lockhart H-E-B",
                     "longitude": -97.66994,
                     "latitude": 29.88213,
@@ -1297,12 +1305,7 @@
                     "city": "LOCKHART",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -1345,34 +1348,22 @@
                 },
                 {
                     "zip": "78374-2816",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuccQAC",
+                    "url": null,
                     "type": "store",
                     "street": "1600 WILDCAT DRIVE",
                     "storeNumber": 488,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 27,
-                            "openAppointmentSlots": 27,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 27,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 27,
+                    "openAppointmentSlots": 0,
                     "name": "Portland H-E-B",
                     "longitude": -97.31836,
                     "latitude": 27.88722,
                     "fluUrl": "",
                     "city": "PORTLAND",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78521-2216",
@@ -1383,15 +1374,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 26,
-                            "openAppointmentSlots": 26,
+                            "openTimeslots": 51,
+                            "openAppointmentSlots": 51,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 26,
+                    "openTimeslots": 51,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 26,
+                    "openAppointmentSlots": 51,
                     "name": "Boca Chica H-E-B",
                     "longitude": -97.48722,
                     "latitude": 25.92214,
@@ -1399,11 +1390,14 @@
                     "city": "BROWNSVILLE",
                     "availableImmunizations": [
                         "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -1415,15 +1409,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 256,
-                            "openAppointmentSlots": 256,
+                            "openTimeslots": 126,
+                            "openAppointmentSlots": 126,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 256,
+                    "openTimeslots": 126,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 256,
+                    "openAppointmentSlots": 126,
                     "name": "Fry Rd and I10 H-E-B",
                     "longitude": -95.7189,
                     "latitude": 29.7898,
@@ -1431,9 +1425,8 @@
                     "city": "HOUSTON",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -1445,15 +1438,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 321,
-                            "openAppointmentSlots": 321,
+                            "openTimeslots": 269,
+                            "openAppointmentSlots": 269,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 321,
+                    "openTimeslots": 269,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 321,
+                    "openAppointmentSlots": 269,
                     "name": "Culebra and 1604 H-E-B",
                     "longitude": -98.70445,
                     "latitude": 29.49292,
@@ -1462,46 +1455,34 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Janssen",
                         "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Novavax",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Moderna_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "Senior_Flu"
                     ]
                 },
                 {
                     "zip": "77701-0",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gue2QAC",
+                    "url": null,
                     "type": "store",
                     "street": "3590 COLLEGE ST",
                     "storeNumber": 692,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 387,
-                            "openAppointmentSlots": 387,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 387,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 387,
+                    "openAppointmentSlots": 0,
                     "name": "Beaumont 6 H-E-B",
                     "longitude": -94.12834,
                     "latitude": 30.06853,
                     "fluUrl": "",
                     "city": "BEAUMONT",
-                    "availableImmunizations": [
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "Flu",
-                        "COVID-19 Pediatric_Pfizer"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78119-0",
@@ -1512,25 +1493,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 63,
-                            "openAppointmentSlots": 63,
+                            "openTimeslots": 129,
+                            "openAppointmentSlots": 129,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 63,
+                    "openTimeslots": 129,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 63,
+                    "openAppointmentSlots": 129,
                     "name": "Kenedy H-E-B",
                     "longitude": -97.85797,
                     "latitude": 28.81419,
                     "fluUrl": "",
                     "city": "KENEDY",
                     "availableImmunizations": [
-                        "Flu",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "Flu",
+                        "COVID-19 Pediatric_Pfizer"
                     ]
                 },
                 {
@@ -1542,27 +1524,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 215,
-                            "openAppointmentSlots": 215,
+                            "openTimeslots": 151,
+                            "openAppointmentSlots": 151,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 215,
+                    "openTimeslots": 151,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 215,
+                    "openAppointmentSlots": 151,
                     "name": "New Braunfels H-E-B plus!",
                     "longitude": -98.0782,
                     "latitude": 29.731,
                     "fluUrl": "",
                     "city": "NEW BRAUNFELS",
                     "availableImmunizations": [
-                        "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Novavax",
                         "Flu",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -1574,22 +1553,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 737,
-                            "openAppointmentSlots": 737,
+                            "openTimeslots": 31,
+                            "openAppointmentSlots": 31,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 737,
+                    "openTimeslots": 31,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 737,
+                    "openAppointmentSlots": 31,
                     "name": "Gattis School H-E-B plus! Hutto",
                     "longitude": -97.58284,
                     "latitude": 30.50112,
                     "fluUrl": "",
                     "city": "HUTTO",
                     "availableImmunizations": [
-                        "Flu"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -1601,27 +1581,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 388,
-                            "openAppointmentSlots": 388,
+                            "openTimeslots": 559,
+                            "openAppointmentSlots": 559,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 294,
-                    "openFluTimeslots": 94,
-                    "openFluAppointmentSlots": 94,
-                    "openAppointmentSlots": 294,
+                    "openTimeslots": 559,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 559,
                     "name": "League City Market H-E-B",
                     "longitude": -95.04131,
                     "latitude": 29.50588,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF0uQAE",
+                    "fluUrl": "",
                     "city": "LEAGUE CITY",
                     "availableImmunizations": [
                         "COVID-19 Pfizer",
-                        "COVID-19 Moderna",
-                        "Flu",
                         "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer"
+                        "Senior_Flu",
+                        "Flu",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -1671,15 +1651,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 113,
-                            "openAppointmentSlots": 113,
+                            "openTimeslots": 78,
+                            "openAppointmentSlots": 78,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 113,
+                    "openTimeslots": 78,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 113,
+                    "openAppointmentSlots": 78,
                     "name": "Clear Lake Marketplace H-E-B",
                     "longitude": -95.12473,
                     "latitude": 29.60563,
@@ -1688,8 +1668,7 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -1701,15 +1680,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 15,
-                            "openAppointmentSlots": 15,
+                            "openTimeslots": 19,
+                            "openAppointmentSlots": 19,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 15,
+                    "openTimeslots": 19,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 15,
+                    "openAppointmentSlots": 19,
                     "name": "Lakeway H-E-B",
                     "longitude": -97.96662,
                     "latitude": 30.34368,
@@ -1717,7 +1696,7 @@
                     "city": "LAKEWAY",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -1741,31 +1720,22 @@
                 },
                 {
                     "zip": "78041-2205",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gud1QAC",
+                    "url": null,
                     "type": "store",
                     "street": "210 WEST DEL MAR BOULEVARD",
                     "storeNumber": 570,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 5,
-                            "openAppointmentSlots": 5,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 5,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 5,
+                    "openAppointmentSlots": 0,
                     "name": "35 and Del Mar H-E-B",
                     "longitude": -99.49676,
                     "latitude": 27.56786,
                     "fluUrl": "",
                     "city": "LAREDO",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78572-2912",
@@ -1788,49 +1758,58 @@
                 },
                 {
                     "zip": "77375-4546",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gud3QAC",
                     "type": "store",
                     "street": "28520 TOMBALL PARKWAY",
                     "storeNumber": 574,
+                    "state": "TX",
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 66,
+                            "openAppointmentSlots": 66,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 66,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 66,
+                    "name": "Tomball Pkwy and Graham H-E-B",
+                    "longitude": -95.63218,
+                    "latitude": 30.08868,
+                    "fluUrl": "",
+                    "city": "TOMBALL",
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Novavax",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
+                    ]
+                },
+                {
+                    "zip": "77379-7234",
+                    "url": null,
+                    "type": "store",
+                    "street": "7310 LOUETTA",
+                    "storeNumber": 576,
                     "state": "TX",
                     "slotDetails": [],
                     "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
                     "openAppointmentSlots": 0,
-                    "name": "Tomball Pkwy and Graham H-E-B",
-                    "longitude": -95.63218,
-                    "latitude": 30.08868,
-                    "fluUrl": "",
-                    "city": "TOMBALL",
-                    "availableImmunizations": null
-                },
-                {
-                    "zip": "77379-7234",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gud4QAC",
-                    "type": "store",
-                    "street": "7310 LOUETTA",
-                    "storeNumber": 576,
-                    "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 14,
-                            "openAppointmentSlots": 14,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 14,
-                    "openFluTimeslots": 0,
-                    "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 14,
                     "name": "Louetta and Stuebner H-E-B",
                     "longitude": -95.5243,
                     "latitude": 30.0209,
                     "fluUrl": "",
                     "city": "SPRING",
-                    "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77043-1803",
@@ -1841,15 +1820,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 13,
-                            "openAppointmentSlots": 13,
+                            "openTimeslots": 90,
+                            "openAppointmentSlots": 90,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 13,
+                    "openTimeslots": 90,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 13,
+                    "openAppointmentSlots": 90,
                     "name": "Kempwood and Gessner H-E-B",
                     "longitude": -95.5468,
                     "latitude": 29.8226,
@@ -1857,106 +1836,67 @@
                     "city": "HOUSTON",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "Senior_Flu"
                     ]
                 },
                 {
                     "zip": "77380-1531",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gud6QAC",
+                    "url": null,
                     "type": "store",
                     "street": "9595 SIX PINES RD",
                     "storeNumber": 579,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 52,
-                            "openAppointmentSlots": 52,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 52,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 52,
+                    "openAppointmentSlots": 0,
                     "name": "Woodlands Market H-E-B",
                     "longitude": -95.46575,
                     "latitude": 30.16409,
                     "fluUrl": "",
                     "city": "THE WOODLANDS",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Moderna_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78613-7273",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gud7QAC",
+                    "url": null,
                     "type": "store",
                     "street": "2800 EAST WHITESTONE",
                     "storeNumber": 580,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 37,
-                            "openAppointmentSlots": 37,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 37,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 37,
+                    "openAppointmentSlots": 0,
                     "name": "Parmer and Whitestone H-E-B",
                     "longitude": -97.78545,
                     "latitude": 30.5328,
                     "fluUrl": "",
                     "city": "CEDAR PARK",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "76401-3928",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaDQAS",
+                    "url": null,
                     "type": "store",
                     "street": "2150 W. WASHINGTON",
                     "storeNumber": 6,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 70,
-                            "openAppointmentSlots": 70,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 70,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 70,
+                    "openAppointmentSlots": 0,
                     "name": "Stephenville H-E-B",
                     "longitude": -98.22569,
                     "latitude": 32.20975,
                     "fluUrl": "",
                     "city": "STEPHENVILLE",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78748-5992",
@@ -1967,58 +1907,50 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 351,
-                            "openAppointmentSlots": 351,
+                            "openTimeslots": 376,
+                            "openAppointmentSlots": 376,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 351,
+                    "openTimeslots": 376,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 351,
+                    "openAppointmentSlots": 376,
                     "name": "Slaughter and Manchaca H-E-B",
                     "longitude": -97.82509,
                     "latitude": 30.17524,
                     "fluUrl": "",
                     "city": "AUSTIN",
                     "availableImmunizations": [
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Ultra_Pediatric_Pfizer",
+                        "Flu",
+                        "Senior_Flu",
                         "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "COVID-19 Novavax",
-                        "COVID-19 Pediatric_Moderna",
-                        "Flu"
+                        "COVID-19 Novavax"
                     ]
                 },
                 {
                     "zip": "78744-3410",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubLQAS",
+                    "url": null,
                     "type": "store",
                     "street": "6607 SOUTH IH 35",
                     "storeNumber": 229,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 26,
-                            "openAppointmentSlots": 26,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 26,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 26,
+                    "openAppointmentSlots": 0,
                     "name": "I 35 and William Cannon H-E-B",
                     "longitude": -97.76922,
                     "latitude": 30.19107,
                     "fluUrl": "",
                     "city": "AUSTIN",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78247-1979",
@@ -2029,15 +1961,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 452,
-                            "openAppointmentSlots": 452,
+                            "openTimeslots": 471,
+                            "openAppointmentSlots": 471,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 452,
+                    "openTimeslots": 471,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 452,
+                    "openAppointmentSlots": 471,
                     "name": "Nacogdoches and O'Connor H-E-B",
                     "longitude": -98.3856,
                     "latitude": 29.56937,
@@ -2045,130 +1977,89 @@
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
                         "Flu",
+                        "Senior_Flu",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "78596-4511",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubNQAS",
+                    "url": null,
                     "type": "store",
                     "street": "1004 N. TEXAS",
                     "storeNumber": 231,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 99,
-                            "openAppointmentSlots": 99,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 99,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 99,
+                    "openAppointmentSlots": 0,
                     "name": "83 and N Texas H-E-B",
                     "longitude": -97.99096,
                     "latitude": 26.17103,
                     "fluUrl": "",
                     "city": "WESLACO",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Novavax",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
-                        "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Pediatric_Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77488-3204",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubOQAS",
+                    "url": null,
                     "type": "store",
                     "street": "1616 N ALABAMA",
                     "storeNumber": 233,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 34,
-                            "openAppointmentSlots": 34,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 34,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 34,
+                    "openAppointmentSlots": 0,
                     "name": "Wharton H-E-B",
                     "longitude": -96.08492,
                     "latitude": 29.32162,
                     "fluUrl": "",
                     "city": "WHARTON",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77450-4564",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuchQAC",
+                    "url": null,
                     "type": "store",
                     "street": "1621 MASON ROAD",
                     "storeNumber": 497,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 45,
-                            "openAppointmentSlots": 45,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 45,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 45,
+                    "openAppointmentSlots": 0,
                     "name": "Mason Rd H-E-B",
                     "longitude": -95.75102,
                     "latitude": 29.75787,
                     "fluUrl": "",
                     "city": "KATY",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77346-3128",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuciQAC",
+                    "url": null,
                     "type": "store",
                     "street": "7405 FM 1960 EAST",
                     "storeNumber": 498,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 339,
-                            "openAppointmentSlots": 339,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 199,
-                    "openFluTimeslots": 140,
-                    "openFluAppointmentSlots": 140,
-                    "openAppointmentSlots": 199,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
                     "name": "Atascocita H-E-B",
                     "longitude": -95.1642,
                     "latitude": 29.9983,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF3EQAU",
+                    "fluUrl": "",
                     "city": "HUMBLE",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77087-2558",
@@ -2179,15 +2070,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 68,
-                            "openAppointmentSlots": 68,
+                            "openTimeslots": 83,
+                            "openAppointmentSlots": 83,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 68,
+                    "openTimeslots": 83,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 68,
+                    "openAppointmentSlots": 83,
                     "name": "Gulfgate H-E-B",
                     "longitude": -95.2968,
                     "latitude": 29.6994,
@@ -2195,10 +2086,17 @@
                     "city": "HOUSTON",
                     "availableImmunizations": [
                         "Flu",
+                        "COVID-19 Moderna",
                         "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
                         "COVID-19 Novavax",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -2229,43 +2127,59 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 84,
-                            "openAppointmentSlots": 84,
+                            "openTimeslots": 108,
+                            "openAppointmentSlots": 108,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 84,
+                    "openTimeslots": 108,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 84,
+                    "openAppointmentSlots": 108,
                     "name": "Texas Avenue H-E-B",
                     "longitude": -96.3165,
                     "latitude": 30.6131,
                     "fluUrl": "",
                     "city": "COLLEGE STATION",
                     "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "Flu"
+                        "Senior_Flu"
                     ]
                 },
                 {
                     "zip": "77429-6286",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gue7QAC",
                     "type": "store",
                     "street": "14100 SPRING CYPRESS RD",
                     "storeNumber": 698,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 35,
+                            "openAppointmentSlots": 35,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 35,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 35,
                     "name": "Grant and Spring Cypress H-E-B",
                     "longitude": -95.63698,
                     "latitude": 30.00365,
                     "fluUrl": "",
                     "city": "CYPRESS",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
+                    ]
                 },
                 {
                     "zip": "78204-2427",
@@ -2276,15 +2190,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 108,
-                            "openAppointmentSlots": 108,
+                            "openTimeslots": 363,
+                            "openAppointmentSlots": 363,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 108,
+                    "openTimeslots": 363,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 108,
+                    "openAppointmentSlots": 363,
                     "name": "Nogalitos H-E-B",
                     "longitude": -98.51485,
                     "latitude": 29.39799,
@@ -2295,7 +2209,9 @@
                         "COVID-19 Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu",
+                        "COVID-19 Moderna"
                     ]
                 },
                 {
@@ -2364,54 +2280,42 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 237,
-                            "openAppointmentSlots": 237,
+                            "openTimeslots": 100,
+                            "openAppointmentSlots": 100,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 237,
+                    "openTimeslots": 100,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 237,
+                    "openAppointmentSlots": 100,
                     "name": "Spring Creek Market H-E-B",
                     "longitude": -95.38801,
                     "latitude": 30.11036,
                     "fluUrl": "",
                     "city": "SPRING",
                     "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "Flu"
                     ]
                 },
                 {
                     "zip": "78155-5131",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueLQAS",
+                    "url": null,
                     "type": "store",
                     "street": "1340 E COURT ST",
                     "storeNumber": 716,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 128,
-                            "openAppointmentSlots": 128,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 128,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 128,
+                    "openAppointmentSlots": 0,
                     "name": "Seguin H-E-B",
                     "longitude": -97.94366,
                     "latitude": 29.57065,
                     "fluUrl": "",
                     "city": "SEGUIN",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "79706-2851",
@@ -2434,35 +2338,22 @@
                 },
                 {
                     "zip": "77345-2621",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueNQAS",
+                    "url": null,
                     "type": "store",
                     "street": "4517 KINGWOOD DRIVE",
                     "storeNumber": 720,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 83,
-                            "openAppointmentSlots": 83,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 83,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 83,
+                    "openAppointmentSlots": 0,
                     "name": "Kingwood Market H-E-B",
                     "longitude": -95.18375,
                     "latitude": 30.05329,
                     "fluUrl": "",
                     "city": "KINGWOOD",
-                    "availableImmunizations": [
-                        "COVID-19 Moderna",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "Flu",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "76542-0",
@@ -2473,57 +2364,44 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 32,
-                            "openAppointmentSlots": 32,
+                            "openTimeslots": 22,
+                            "openAppointmentSlots": 22,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 32,
+                    "openTimeslots": 22,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 32,
+                    "openAppointmentSlots": 22,
                     "name": "Fort Hood Stan Schlueter H-E-B",
                     "longitude": -97.75988,
                     "latitude": 31.07989,
                     "fluUrl": "",
                     "city": "KILLEEN",
                     "availableImmunizations": [
-                        "Flu",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu"
                     ]
                 },
                 {
                     "zip": "77354-1611",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuePQAS",
+                    "url": null,
                     "type": "store",
                     "street": "7988 FM 1488",
                     "storeNumber": 722,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 112,
-                            "openAppointmentSlots": 112,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 112,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 112,
+                    "openAppointmentSlots": 0,
                     "name": "Magnolia Market H-E-B",
                     "longitude": -95.5837,
                     "latitude": 30.2217,
                     "fluUrl": "",
                     "city": "MAGNOLIA",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77407-8643",
@@ -2534,44 +2412,53 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 165,
-                            "openAppointmentSlots": 165,
+                            "openTimeslots": 297,
+                            "openAppointmentSlots": 297,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 165,
+                    "openTimeslots": 297,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 165,
+                    "openAppointmentSlots": 297,
                     "name": "Aliana Market H-E-B",
                     "longitude": -95.7137,
                     "latitude": 29.6597,
                     "fluUrl": "",
                     "city": "RICHMOND",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
                         "Flu",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "78572-9139",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucKQAS",
                     "type": "store",
                     "street": "6010 W EXPRESSWAY 83",
                     "storeNumber": 448,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 38,
+                            "openAppointmentSlots": 38,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 38,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 38,
                     "name": "Palmview H-E-B",
                     "longitude": -98.38385,
                     "latitude": 26.23538,
                     "fluUrl": "",
                     "city": "PALMVIEW",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78726-4539",
@@ -2582,15 +2469,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 14,
-                            "openAppointmentSlots": 14,
+                            "openTimeslots": 33,
+                            "openAppointmentSlots": 33,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 14,
+                    "openTimeslots": 33,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 14,
+                    "openAppointmentSlots": 33,
                     "name": "Four Points H-E-B",
                     "longitude": -97.85202,
                     "latitude": 30.40458,
@@ -2600,7 +2487,9 @@
                         "Flu",
                         "COVID-19 Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -2624,31 +2513,22 @@
                 },
                 {
                     "zip": "78405-2040",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucOQAS",
+                    "url": null,
                     "type": "store",
                     "street": "3033 SOUTH PORT ST.",
                     "storeNumber": 462,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 43,
-                            "openAppointmentSlots": 43,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 43,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 43,
+                    "openAppointmentSlots": 0,
                     "name": "S Port and Tarlton H-E-B",
                     "longitude": -97.42137,
                     "latitude": 27.76687,
                     "fluUrl": "",
                     "city": "CORPUS CHRISTI",
-                    "availableImmunizations": [
-                        "Flu",
-                        "Senior_Flu"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78248-4552",
@@ -2659,28 +2539,30 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 442,
-                            "openAppointmentSlots": 442,
+                            "openTimeslots": 247,
+                            "openAppointmentSlots": 247,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 442,
+                    "openTimeslots": 247,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 442,
+                    "openAppointmentSlots": 247,
                     "name": "Loop 1604 and Blanco Rd H-E-B plus!",
                     "longitude": -98.50968,
                     "latitude": 29.60792,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
-                        "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Novavax",
-                        "Flu",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "Flu",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Ultra_Pediatric_Pfizer"
+                        "COVID-19 Moderna",
+                        "COVID-19 Novavax",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -2692,15 +2574,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 452,
-                            "openAppointmentSlots": 452,
+                            "openTimeslots": 902,
+                            "openAppointmentSlots": 902,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 452,
+                    "openTimeslots": 902,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 452,
+                    "openAppointmentSlots": 902,
                     "name": "7th Street H-E-B",
                     "longitude": -97.71143,
                     "latitude": 30.26046,
@@ -2708,6 +2590,7 @@
                     "city": "AUSTIN",
                     "availableImmunizations": [
                         "Flu",
+                        "Senior_Flu",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
@@ -2751,34 +2634,22 @@
                 },
                 {
                     "zip": "77505-4027",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucTQAS",
+                    "url": null,
                     "type": "store",
                     "street": "6210 FAIRMONT PKWY",
                     "storeNumber": 473,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 80,
-                            "openAppointmentSlots": 80,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 80,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 80,
+                    "openAppointmentSlots": 0,
                     "name": "Fairmont Pkwy H-E-B",
                     "longitude": -95.14512,
                     "latitude": 29.6497,
                     "fluUrl": "",
                     "city": "PASADENA",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77459-4180",
@@ -2789,28 +2660,28 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 821,
-                            "openAppointmentSlots": 821,
+                            "openTimeslots": 639,
+                            "openAppointmentSlots": 639,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 821,
+                    "openTimeslots": 639,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 821,
+                    "openAppointmentSlots": 639,
                     "name": "Lake Colony H-E-B",
                     "longitude": -95.58244,
                     "latitude": 29.58032,
                     "fluUrl": "",
                     "city": "MISSOURI CITY",
                     "availableImmunizations": [
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Moderna_Updated_Booster",
                         "Flu",
                         "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -2822,15 +2693,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 90,
-                            "openAppointmentSlots": 90,
+                            "openTimeslots": 42,
+                            "openAppointmentSlots": 42,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 90,
+                    "openTimeslots": 42,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 90,
+                    "openAppointmentSlots": 42,
                     "name": "Elgin H-E-B",
                     "longitude": -97.38258,
                     "latitude": 30.34701,
@@ -2838,6 +2709,7 @@
                     "city": "ELGIN",
                     "availableImmunizations": [
                         "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
@@ -2850,26 +2722,28 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 85,
-                            "openAppointmentSlots": 85,
+                            "openTimeslots": 30,
+                            "openAppointmentSlots": 30,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 85,
+                    "openTimeslots": 30,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 85,
+                    "openAppointmentSlots": 30,
                     "name": "Tech Ridge H-E-B",
                     "longitude": -97.67201,
                     "latitude": 30.40443,
                     "fluUrl": "",
                     "city": "AUSTIN",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "Flu",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Novavax",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Moderna_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -2881,15 +2755,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 67,
-                            "openAppointmentSlots": 67,
+                            "openTimeslots": 49,
+                            "openAppointmentSlots": 49,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 67,
+                    "openTimeslots": 49,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 67,
+                    "openAppointmentSlots": 49,
                     "name": "Buda H-E-B",
                     "longitude": -97.82074,
                     "latitude": 30.08769,
@@ -2897,46 +2771,68 @@
                     "city": "BUDA",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
                     "zip": "78251-2805",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubPQAS",
                     "type": "store",
                     "street": "9255 GRISSOM RD",
                     "storeNumber": 235,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 253,
+                            "openAppointmentSlots": 253,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 253,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 253,
                     "name": "Grissom and Tezel H-E-B",
                     "longitude": -98.66574,
                     "latitude": 29.48432,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "Senior_Flu"
+                    ]
                 },
                 {
                     "zip": "78626-5400",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubRQAS",
                     "type": "store",
                     "street": "1100 SOUTH IH35",
                     "storeNumber": 237,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 12,
+                            "openAppointmentSlots": 12,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 12,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 12,
                     "name": "35 and West University H-E-B",
                     "longitude": -97.69028,
                     "latitude": 30.63446,
                     "fluUrl": "",
                     "city": "GEORGETOWN",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "Senior_Flu"
+                    ]
                 },
                 {
                     "zip": "75110-5138",
@@ -2947,15 +2843,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 16,
-                            "openAppointmentSlots": 16,
+                            "openTimeslots": 19,
+                            "openAppointmentSlots": 19,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 16,
+                    "openTimeslots": 19,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 16,
+                    "openAppointmentSlots": 19,
                     "name": "Corsicana H-E-B",
                     "longitude": -96.46827,
                     "latitude": 32.09005,
@@ -2963,8 +2859,9 @@
                     "city": "CORSICANA",
                     "availableImmunizations": [
                         "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -2976,25 +2873,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 116,
-                            "openAppointmentSlots": 116,
+                            "openTimeslots": 211,
+                            "openAppointmentSlots": 211,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 116,
+                    "openTimeslots": 211,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 116,
+                    "openAppointmentSlots": 211,
                     "name": "East Hopkins H-E-B",
                     "longitude": -97.93132,
                     "latitude": 29.88489,
                     "fluUrl": "",
                     "city": "SAN MARCOS",
                     "availableImmunizations": [
-                        "COVID-19 Moderna",
-                        "COVID-19 Moderna_Updated_Booster",
                         "Flu",
-                        "COVID-19 Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
@@ -3019,65 +2914,41 @@
                 },
                 {
                     "zip": "77802-5320",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucmQAC",
+                    "url": null,
                     "type": "store",
                     "street": "725 E VILLA MARIA RD STE 1300",
                     "storeNumber": 544,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 54,
-                            "openAppointmentSlots": 54,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 54,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 54,
+                    "openAppointmentSlots": 0,
                     "name": "Tejas Center H-E-B",
                     "longitude": -96.3513,
                     "latitude": 30.64506,
                     "fluUrl": "",
                     "city": "BRYAN",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77077-6860",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucnQAC",
+                    "url": null,
                     "type": "store",
                     "street": "11815 WESTHEIMER",
                     "storeNumber": 551,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 150,
-                            "openAppointmentSlots": 150,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 150,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 150,
+                    "openAppointmentSlots": 0,
                     "name": "Westheimer and Kirkwood H-E-B",
                     "longitude": -95.587,
                     "latitude": 29.7363,
                     "fluUrl": "",
                     "city": "HOUSTON",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "COVID-19 Moderna"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77084-2718",
@@ -3088,15 +2959,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 68,
-                            "openAppointmentSlots": 68,
+                            "openTimeslots": 210,
+                            "openAppointmentSlots": 210,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 68,
+                    "openTimeslots": 210,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 68,
+                    "openAppointmentSlots": 210,
                     "name": "Bear Creek H-E-B",
                     "longitude": -95.6457,
                     "latitude": 29.8487,
@@ -3108,7 +2979,9 @@
                         "COVID-19 Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -3151,59 +3024,41 @@
                 },
                 {
                     "zip": "78201-4407",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucrQAC",
+                    "url": null,
                     "type": "store",
                     "street": "2118 FREDERICKSBURG RD",
                     "storeNumber": 556,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 59,
-                            "openAppointmentSlots": 59,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 59,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 59,
+                    "openAppointmentSlots": 0,
                     "name": "Deco District H-E-B",
                     "longitude": -98.5261,
                     "latitude": 29.4646,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
-                    "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "76705-2874",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucsQAC",
+                    "url": null,
                     "type": "store",
                     "street": "801 NORTH I-H 35",
                     "storeNumber": 557,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 63,
-                            "openAppointmentSlots": 63,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 63,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 63,
+                    "openAppointmentSlots": 0,
                     "name": "35 and 84 H-E-B plus!",
                     "longitude": -97.10723,
                     "latitude": 31.58764,
                     "fluUrl": "",
                     "city": "BELLMEAD",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77546-5405",
@@ -3214,15 +3069,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 638,
-                            "openAppointmentSlots": 638,
+                            "openTimeslots": 703,
+                            "openAppointmentSlots": 703,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 638,
+                    "openTimeslots": 703,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 638,
+                    "openAppointmentSlots": 703,
                     "name": "Friendswood H-E-B",
                     "longitude": -95.1912,
                     "latitude": 29.5066,
@@ -3230,7 +3085,9 @@
                     "city": "FRIENDSWOOD",
                     "availableImmunizations": [
                         "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
@@ -3243,22 +3100,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 70,
-                            "openAppointmentSlots": 70,
+                            "openTimeslots": 205,
+                            "openAppointmentSlots": 205,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 70,
+                    "openTimeslots": 205,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 70,
+                    "openAppointmentSlots": 205,
                     "name": "Lake Jackson H-E-B",
                     "longitude": -95.44554,
                     "latitude": 29.04151,
                     "fluUrl": "",
                     "city": "LAKE JACKSON",
                     "availableImmunizations": [
-                        "Flu"
+                        "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -3270,15 +3129,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 69,
-                            "openAppointmentSlots": 69,
+                            "openTimeslots": 112,
+                            "openAppointmentSlots": 112,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 69,
+                    "openTimeslots": 112,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 69,
+                    "openAppointmentSlots": 112,
                     "name": "Wimberley H-E-B",
                     "longitude": -98.10174,
                     "latitude": 30.00144,
@@ -3286,7 +3145,6 @@
                     "city": "WIMBERLEY",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
@@ -3300,15 +3158,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 500,
-                            "openAppointmentSlots": 500,
+                            "openTimeslots": 240,
+                            "openAppointmentSlots": 240,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 500,
+                    "openTimeslots": 240,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 500,
+                    "openAppointmentSlots": 240,
                     "name": "H-E-B Market at Tuckerton",
                     "longitude": -95.72501,
                     "latitude": 29.92737,
@@ -3316,11 +3174,12 @@
                     "city": "CYPRESS",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pediatric_Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pfizer"
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Novavax",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -3332,15 +3191,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 180,
-                            "openAppointmentSlots": 180,
+                            "openTimeslots": 422,
+                            "openAppointmentSlots": 422,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 180,
+                    "openTimeslots": 422,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 180,
+                    "openAppointmentSlots": 422,
                     "name": "Champion Forest Market H-E-B",
                     "longitude": -95.57475,
                     "latitude": 30.0551,
@@ -3354,32 +3213,22 @@
                 },
                 {
                     "zip": "77469-2509",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueSQAS",
+                    "url": null,
                     "type": "store",
                     "street": "23500 CIRCLE OAK PARKWAY",
                     "storeNumber": 727,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 56,
-                            "openAppointmentSlots": 56,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 56,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 56,
+                    "openAppointmentSlots": 0,
                     "name": "Richmond Market H-E-B",
                     "longitude": -95.74781,
                     "latitude": 29.55142,
                     "fluUrl": "",
                     "city": "RICHMOND",
-                    "availableImmunizations": [
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77340-3723",
@@ -3390,15 +3239,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 40,
-                            "openAppointmentSlots": 40,
+                            "openTimeslots": 90,
+                            "openAppointmentSlots": 90,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 40,
+                    "openTimeslots": 90,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 40,
+                    "openAppointmentSlots": 90,
                     "name": "Huntsville H-E-B",
                     "longitude": -95.56075,
                     "latitude": 30.72274,
@@ -3407,12 +3256,10 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -3424,15 +3271,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 810,
-                            "openAppointmentSlots": 810,
+                            "openTimeslots": 433,
+                            "openAppointmentSlots": 433,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 810,
+                    "openTimeslots": 433,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 810,
+                    "openAppointmentSlots": 433,
                     "name": "Bulverde and 1604 H-E-B",
                     "longitude": -98.41746,
                     "latitude": 29.59497,
@@ -3440,43 +3287,31 @@
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
                         "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Moderna_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "Senior_Flu"
                     ]
                 },
                 {
                     "zip": "78041-5754",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubVQAS",
+                    "url": null,
                     "type": "store",
                     "street": "4801 SAN DARIO",
                     "storeNumber": 255,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 5,
-                            "openAppointmentSlots": 5,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 5,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 5,
+                    "openAppointmentSlots": 0,
                     "name": "35 and Calton H-E-B",
                     "longitude": -99.50182,
                     "latitude": 27.54172,
                     "fluUrl": "",
                     "city": "LAREDO",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78238-1986",
@@ -3506,31 +3341,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 148,
-                            "openAppointmentSlots": 148,
+                            "openTimeslots": 83,
+                            "openAppointmentSlots": 83,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 148,
+                    "openTimeslots": 83,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 148,
+                    "openAppointmentSlots": 83,
                     "name": "Central Blvd H-E-B",
                     "longitude": -97.51093,
                     "latitude": 25.92849,
                     "fluUrl": "",
                     "city": "BROWNSVILLE",
                     "availableImmunizations": [
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Novavax",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "Flu"
+                        "Flu",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -3542,15 +3369,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 1,
-                            "openAppointmentSlots": 1,
+                            "openTimeslots": 48,
+                            "openAppointmentSlots": 48,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 1,
+                    "openTimeslots": 48,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 1,
+                    "openAppointmentSlots": 48,
                     "name": "Hwy 183 and Whitestone Blvd H-E-B",
                     "longitude": -97.82911,
                     "latitude": 30.5225,
@@ -3558,7 +3385,9 @@
                     "city": "CEDAR PARK",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "Senior_Flu",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -3570,54 +3399,44 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 151,
-                            "openAppointmentSlots": 151,
+                            "openTimeslots": 52,
+                            "openAppointmentSlots": 52,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 151,
+                    "openTimeslots": 52,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 151,
+                    "openAppointmentSlots": 52,
                     "name": "North Hills H-E-B",
                     "longitude": -97.74832,
                     "latitude": 30.39868,
                     "fluUrl": "",
                     "city": "AUSTIN",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
                         "Flu",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "78411-5301",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubaQAC",
+                    "url": null,
                     "type": "store",
                     "street": "5425 S.P.I.D. AT STAPLES",
                     "storeNumber": 270,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 69,
-                            "openAppointmentSlots": 69,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 69,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 69,
+                    "openAppointmentSlots": 0,
                     "name": "Moore Plaza H-E-B",
                     "longitude": -97.37238,
                     "latitude": 27.70605,
                     "fluUrl": "",
                     "city": "CORPUS CHRISTI",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78624-4146",
@@ -3628,15 +3447,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 31,
-                            "openAppointmentSlots": 31,
+                            "openTimeslots": 40,
+                            "openAppointmentSlots": 40,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 31,
+                    "openTimeslots": 40,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 31,
+                    "openAppointmentSlots": 40,
                     "name": "Fredericksburg H-E-B",
                     "longitude": -98.87538,
                     "latitude": 30.27006,
@@ -3644,7 +3463,9 @@
                     "city": "FREDERICKSBURG",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -3675,28 +3496,29 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 286,
-                            "openAppointmentSlots": 286,
+                            "openTimeslots": 226,
+                            "openAppointmentSlots": 226,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 286,
+                    "openTimeslots": 226,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 286,
+                    "openAppointmentSlots": 226,
                     "name": "Riverpark H-E-B",
                     "longitude": -95.6815,
                     "latitude": 29.5636,
                     "fluUrl": "",
                     "city": "SUGAR LAND",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Novavax",
                         "Flu",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Moderna_Updated_Booster"
+                        "COVID-19 Moderna",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "Senior_Flu",
+                        "COVID-19 Novavax"
                     ]
                 },
                 {
@@ -3708,15 +3530,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 147,
-                            "openAppointmentSlots": 147,
+                            "openTimeslots": 58,
+                            "openAppointmentSlots": 58,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 147,
+                    "openTimeslots": 58,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 147,
+                    "openAppointmentSlots": 58,
                     "name": "Sawdust Rd and 45 H-E-B",
                     "longitude": -95.44512,
                     "latitude": 30.12684,
@@ -3724,12 +3546,13 @@
                     "city": "SPRING",
                     "availableImmunizations": [
                         "Flu",
+                        "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "COVID-19 Moderna",
                         "Senior_Flu"
                     ]
                 },
@@ -3742,25 +3565,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 360,
-                            "openAppointmentSlots": 360,
+                            "openTimeslots": 125,
+                            "openAppointmentSlots": 125,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 360,
+                    "openTimeslots": 125,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 360,
+                    "openAppointmentSlots": 125,
                     "name": "Leon Springs H-E-B",
                     "longitude": -98.63218,
                     "latitude": 29.6659,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
                         "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -3791,15 +3616,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 39,
-                            "openAppointmentSlots": 39,
+                            "openTimeslots": 90,
+                            "openAppointmentSlots": 90,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 39,
+                    "openTimeslots": 90,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 39,
+                    "openAppointmentSlots": 90,
                     "name": "Perrin Beitel and Thousand Oaks H-E-B",
                     "longitude": -98.4082,
                     "latitude": 29.5491,
@@ -3807,7 +3632,6 @@
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
@@ -3861,15 +3685,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 32,
-                            "openAppointmentSlots": 32,
+                            "openTimeslots": 40,
+                            "openAppointmentSlots": 40,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 32,
+                    "openTimeslots": 40,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 32,
+                    "openAppointmentSlots": 40,
                     "name": "Bay City H-E-B",
                     "longitude": -95.95804,
                     "latitude": 28.98306,
@@ -3965,15 +3789,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 37,
-                            "openAppointmentSlots": 37,
+                            "openTimeslots": 48,
+                            "openAppointmentSlots": 48,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 37,
+                    "openTimeslots": 48,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 37,
+                    "openAppointmentSlots": 48,
                     "name": "Kyle H-E-B plus!",
                     "longitude": -97.86258,
                     "latitude": 30.01533,
@@ -3983,14 +3807,14 @@
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
                         "COVID-19 Novavax",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -4002,15 +3826,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 121,
-                            "openAppointmentSlots": 121,
+                            "openTimeslots": 14,
+                            "openAppointmentSlots": 14,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 121,
+                    "openTimeslots": 14,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 121,
+                    "openAppointmentSlots": 14,
                     "name": "Burleson H-E-B plus!",
                     "longitude": -97.34901,
                     "latitude": 32.52083,
@@ -4018,10 +3842,10 @@
                     "city": "BURLESON",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
@@ -4034,15 +3858,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 424,
-                            "openAppointmentSlots": 424,
+                            "openTimeslots": 318,
+                            "openAppointmentSlots": 318,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 424,
+                    "openTimeslots": 318,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 424,
+                    "openAppointmentSlots": 318,
                     "name": "Lytle H-E-B plus!",
                     "longitude": -98.78924,
                     "latitude": 29.23224,
@@ -4052,8 +3876,11 @@
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -4065,15 +3892,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 140,
-                            "openAppointmentSlots": 140,
+                            "openTimeslots": 161,
+                            "openAppointmentSlots": 161,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 140,
+                    "openTimeslots": 161,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 140,
+                    "openAppointmentSlots": 161,
                     "name": "Cypress Market H-E-B",
                     "longitude": -95.6765,
                     "latitude": 29.95569,
@@ -4095,15 +3922,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 26,
-                            "openAppointmentSlots": 26,
+                            "openTimeslots": 67,
+                            "openAppointmentSlots": 67,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 26,
+                    "openTimeslots": 67,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 26,
+                    "openAppointmentSlots": 67,
                     "name": "Anderson Mill H-E-B plus!",
                     "longitude": -97.82626,
                     "latitude": 30.45495,
@@ -4113,7 +3940,11 @@
                         "Flu",
                         "COVID-19 Pfizer",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -4125,15 +3956,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 84,
-                            "openAppointmentSlots": 84,
+                            "openTimeslots": 77,
+                            "openAppointmentSlots": 77,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 84,
+                    "openTimeslots": 77,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 84,
+                    "openAppointmentSlots": 77,
                     "name": "Trimmier H-E-B plus!",
                     "longitude": -97.7338,
                     "latitude": 31.0909,
@@ -4145,7 +3976,13 @@
                         "COVID-19 Pfizer",
                         "COVID-19 Novavax",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Senior_Flu",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -4157,15 +3994,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 18,
-                            "openAppointmentSlots": 18,
+                            "openTimeslots": 41,
+                            "openAppointmentSlots": 41,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 18,
+                    "openTimeslots": 41,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 18,
+                    "openAppointmentSlots": 41,
                     "name": "Bastrop H-E-B plus!",
                     "longitude": -97.33458,
                     "latitude": 30.10981,
@@ -4173,10 +4010,11 @@
                     "city": "BASTROP",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
                         "COVID-19 Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -4226,15 +4064,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 48,
-                            "openAppointmentSlots": 48,
+                            "openTimeslots": 155,
+                            "openAppointmentSlots": 155,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 48,
+                    "openTimeslots": 155,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 48,
+                    "openAppointmentSlots": 155,
                     "name": "Austin Highway H-E-B",
                     "longitude": -98.43132,
                     "latitude": 29.4937,
@@ -4242,7 +4080,9 @@
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -4254,23 +4094,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 36,
-                            "openAppointmentSlots": 36,
+                            "openTimeslots": 70,
+                            "openAppointmentSlots": 70,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 36,
+                    "openTimeslots": 70,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 36,
+                    "openAppointmentSlots": 70,
                     "name": "Zapata Highway H-E-B",
                     "longitude": -99.47479,
                     "latitude": 27.47673,
                     "fluUrl": "",
                     "city": "LAREDO",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
                         "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
@@ -4302,24 +4144,22 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 152,
-                            "openAppointmentSlots": 152,
+                            "openTimeslots": 55,
+                            "openAppointmentSlots": 55,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 152,
+                    "openTimeslots": 55,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 152,
+                    "openAppointmentSlots": 55,
                     "name": "Sherwood & FM 2288 H-E-B",
                     "longitude": -100.51103,
                     "latitude": 31.43158,
                     "fluUrl": "",
                     "city": "SAN ANGELO",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "Flu",
-                        "COVID-19 Moderna"
+                        "Flu"
                     ]
                 },
                 {
@@ -4331,15 +4171,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 48,
-                            "openAppointmentSlots": 48,
+                            "openTimeslots": 89,
+                            "openAppointmentSlots": 89,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 48,
+                    "openTimeslots": 89,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 48,
+                    "openAppointmentSlots": 89,
                     "name": "Cross Creek Ranch H-E-B",
                     "longitude": -95.84788,
                     "latitude": 29.71936,
@@ -4347,8 +4187,8 @@
                     "city": "KATY",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -4360,15 +4200,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 102,
-                            "openAppointmentSlots": 102,
+                            "openTimeslots": 71,
+                            "openAppointmentSlots": 71,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 102,
+                    "openTimeslots": 71,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 102,
+                    "openAppointmentSlots": 71,
                     "name": "The Heights H-E-B",
                     "longitude": -95.40865,
                     "latitude": 29.80735,
@@ -4376,8 +4216,9 @@
                     "city": "HOUSTON",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "Senior_Flu",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -4389,15 +4230,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 31,
-                            "openAppointmentSlots": 31,
+                            "openTimeslots": 74,
+                            "openAppointmentSlots": 74,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 31,
+                    "openTimeslots": 74,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 31,
+                    "openAppointmentSlots": 74,
                     "name": "Bellaire Market H-E-B",
                     "longitude": -95.46938,
                     "latitude": 29.70764,
@@ -4414,39 +4255,28 @@
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
                     "zip": "77523-0",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuebQAC",
+                    "url": null,
                     "type": "store",
                     "street": "13401 I-10 EAST",
                     "storeNumber": 741,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 78,
-                            "openAppointmentSlots": 78,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 78,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 78,
+                    "openAppointmentSlots": 0,
                     "name": "Mont Belvieu H-E-B",
                     "longitude": -94.84973,
                     "latitude": 29.82755,
                     "fluUrl": "",
                     "city": "MONT BELVIEU",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78114-1851",
@@ -4476,58 +4306,51 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 917,
-                            "openAppointmentSlots": 917,
+                            "openTimeslots": 920,
+                            "openAppointmentSlots": 920,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 917,
+                    "openTimeslots": 920,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 917,
+                    "openAppointmentSlots": 920,
                     "name": "McCreless Market H-E-B plus!",
                     "longitude": -98.46115,
                     "latitude": 29.37828,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster",
                         "Flu",
-                        "COVID-19 Pediatric_Pfizer",
+                        "Senior_Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Novavax"
                     ]
                 },
                 {
                     "zip": "77573-6750",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaMQAS",
+                    "url": null,
                     "type": "store",
                     "street": "2955 SOUTH GULF FREEWAY",
                     "storeNumber": 28,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 185,
-                            "openAppointmentSlots": 185,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 185,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 185,
+                    "openAppointmentSlots": 0,
                     "name": "Bay Colony H-E-B",
                     "longitude": -95.0926,
                     "latitude": 29.4677,
                     "fluUrl": "",
                     "city": "LEAGUE CITY",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78746-5256",
@@ -4557,24 +4380,31 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 144,
-                            "openAppointmentSlots": 144,
+                            "openTimeslots": 31,
+                            "openAppointmentSlots": 31,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 144,
+                    "openTimeslots": 31,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 144,
+                    "openAppointmentSlots": 31,
                     "name": "Spicewood Springs H-E-B",
                     "longitude": -97.7713,
                     "latitude": 30.43494,
                     "fluUrl": "",
                     "city": "AUSTIN",
                     "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Novavax",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "Flu"
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -4586,15 +4416,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 475,
-                            "openAppointmentSlots": 475,
+                            "openTimeslots": 320,
+                            "openAppointmentSlots": 320,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 475,
+                    "openTimeslots": 320,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 475,
+                    "openAppointmentSlots": 320,
                     "name": "Gattis School H-E-B Round Rock",
                     "longitude": -97.61475,
                     "latitude": 30.49721,
@@ -4602,10 +4432,10 @@
                     "city": "ROUND ROCK",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -4629,36 +4459,22 @@
                 },
                 {
                     "zip": "78209-2217",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubiQAC",
+                    "url": null,
                     "type": "store",
                     "street": "1955 NACOGDOCHES",
                     "storeNumber": 372,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 101,
-                            "openAppointmentSlots": 101,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 101,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 101,
+                    "openAppointmentSlots": 0,
                     "name": "Oak Park H-E-B",
                     "longitude": -98.45759,
                     "latitude": 29.50774,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
-                    "availableImmunizations": [
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "Flu",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78681-3922",
@@ -4669,15 +4485,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 1894,
-                            "openAppointmentSlots": 1894,
+                            "openTimeslots": 896,
+                            "openAppointmentSlots": 896,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 1894,
+                    "openTimeslots": 896,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 1894,
+                    "openAppointmentSlots": 896,
                     "name": "620 and O'Connor H-E-B",
                     "longitude": -97.72218,
                     "latitude": 30.50028,
@@ -4685,12 +4501,13 @@
                     "city": "ROUND ROCK",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
                         "COVID-19 Janssen",
                         "COVID-19 Novavax",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -4702,15 +4519,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 306,
-                            "openAppointmentSlots": 306,
+                            "openTimeslots": 79,
+                            "openAppointmentSlots": 79,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 306,
+                    "openTimeslots": 79,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 306,
+                    "openAppointmentSlots": 79,
                     "name": "New Braunfels H-E-B at Walnut",
                     "longitude": -98.12631,
                     "latitude": 29.68903,
@@ -4718,43 +4535,31 @@
                     "city": "NEW BRAUNFELS",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Janssen",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
                     "zip": "76548-1347",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GublQAC",
+                    "url": null,
                     "type": "store",
                     "street": "601 INDIAN TRAIL",
                     "storeNumber": 381,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 113,
-                            "openAppointmentSlots": 113,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 113,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 113,
+                    "openAppointmentSlots": 0,
                     "name": "Harker Heights H-E-B",
                     "longitude": -97.65511,
                     "latitude": 31.07905,
                     "fluUrl": "",
                     "city": "HARKER HEIGHTS",
-                    "availableImmunizations": [
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "79707-5714",
@@ -4765,25 +4570,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 179,
-                            "openAppointmentSlots": 179,
+                            "openTimeslots": 96,
+                            "openAppointmentSlots": 96,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 179,
+                    "openTimeslots": 96,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 179,
+                    "openAppointmentSlots": 96,
                     "name": "West Wadley H-E-B",
                     "longitude": -102.12562,
                     "latitude": 32.01955,
                     "fluUrl": "",
                     "city": "MIDLAND",
                     "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
+                        "Flu",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
@@ -4796,15 +4599,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 107,
-                            "openAppointmentSlots": 107,
+                            "openTimeslots": 390,
+                            "openAppointmentSlots": 390,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 107,
+                    "openTimeslots": 390,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 107,
+                    "openAppointmentSlots": 390,
                     "name": "Montgomery at Walzem",
                     "longitude": -98.37092,
                     "latitude": 29.5105,
@@ -4813,8 +4616,10 @@
                     "availableImmunizations": [
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
                         "Flu"
                     ]
                 },
@@ -4827,23 +4632,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 64,
-                            "openAppointmentSlots": 64,
+                            "openTimeslots": 168,
+                            "openAppointmentSlots": 168,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 64,
+                    "openTimeslots": 168,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 64,
+                    "openAppointmentSlots": 168,
                     "name": "Olmos Park H-E-B",
                     "longitude": -98.497,
                     "latitude": 29.4707,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -4867,38 +4674,22 @@
                 },
                 {
                     "zip": "78727-3901",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubqQAC",
+                    "url": null,
                     "type": "store",
                     "street": "6001 WEST PARMER LANE",
                     "storeNumber": 388,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 45,
-                            "openAppointmentSlots": 45,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 15,
-                    "openFluTimeslots": 30,
-                    "openFluAppointmentSlots": 30,
-                    "openAppointmentSlots": 15,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 0,
                     "name": "Parmer and McNeil H-E-B",
                     "longitude": -97.74278,
                     "latitude": 30.44181,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2MQAU",
+                    "fluUrl": "",
                     "city": "AUSTIN",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77642-7403",
@@ -4909,15 +4700,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 128,
-                            "openAppointmentSlots": 128,
+                            "openTimeslots": 130,
+                            "openAppointmentSlots": 130,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 128,
+                    "openTimeslots": 130,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 128,
+                    "openAppointmentSlots": 130,
                     "name": "Mid County H-E-B",
                     "longitude": -93.9758,
                     "latitude": 29.966,
@@ -4926,10 +4717,14 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
                         "COVID-19 Novavax",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -4960,15 +4755,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 172,
-                            "openAppointmentSlots": 172,
+                            "openTimeslots": 45,
+                            "openAppointmentSlots": 45,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 172,
+                    "openTimeslots": 45,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 172,
+                    "openAppointmentSlots": 45,
                     "name": "Leander H-E-B plus!",
                     "longitude": -97.8582,
                     "latitude": 30.58369,
@@ -4982,36 +4777,22 @@
                 },
                 {
                     "zip": "77521-9638",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuecQAC",
+                    "url": null,
                     "type": "store",
                     "street": "6430 GARTH ROAD",
                     "storeNumber": 742,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 170,
-                            "openAppointmentSlots": 170,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 170,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 170,
+                    "openAppointmentSlots": 0,
                     "name": "Baytown H-E-B",
                     "longitude": -94.9788,
                     "latitude": 29.79503,
                     "fluUrl": "",
                     "city": "BAYTOWN",
-                    "availableImmunizations": [
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "Flu"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77007-0",
@@ -5022,15 +4803,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 309,
-                            "openAppointmentSlots": 309,
+                            "openTimeslots": 413,
+                            "openAppointmentSlots": 413,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 309,
+                    "openTimeslots": 413,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 309,
+                    "openAppointmentSlots": 413,
                     "name": "Buffalo Heights H-E-B On Washington Ave",
                     "longitude": -95.39658,
                     "latitude": 29.76901,
@@ -5038,11 +4819,11 @@
                     "city": "HOUSTON",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
                         "COVID-19 Moderna",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -5054,15 +4835,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 62,
-                            "openAppointmentSlots": 62,
+                            "openTimeslots": 76,
+                            "openAppointmentSlots": 76,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 62,
+                    "openTimeslots": 76,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 62,
+                    "openAppointmentSlots": 76,
                     "name": "Meyerland Market H-E-B",
                     "longitude": -95.46406,
                     "latitude": 29.68854,
@@ -5071,9 +4852,7 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -5085,15 +4864,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 87,
-                            "openAppointmentSlots": 87,
+                            "openTimeslots": 14,
+                            "openAppointmentSlots": 14,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 87,
+                    "openTimeslots": 14,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 87,
+                    "openAppointmentSlots": 14,
                     "name": "Jones Crossing H-E-B",
                     "longitude": -96.32324,
                     "latitude": 30.58444,
@@ -5101,10 +4880,11 @@
                     "city": "COLLEGE STATION",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
                         "COVID-19 Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -5154,15 +4934,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 30,
-                            "openAppointmentSlots": 30,
+                            "openTimeslots": 76,
+                            "openAppointmentSlots": 76,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 30,
+                    "openTimeslots": 76,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 30,
+                    "openAppointmentSlots": 76,
                     "name": "South Congress H-E-B",
                     "longitude": -97.7516,
                     "latitude": 30.23963,
@@ -5170,8 +4950,8 @@
                     "city": "AUSTIN",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -5183,15 +4963,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 248,
-                            "openAppointmentSlots": 248,
+                            "openTimeslots": 114,
+                            "openAppointmentSlots": 114,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 248,
+                    "openTimeslots": 114,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 248,
+                    "openAppointmentSlots": 114,
                     "name": "Beaumont H-E-B plus!",
                     "longitude": -94.1685,
                     "latitude": 30.10501,
@@ -5199,9 +4979,13 @@
                     "city": "BEAUMONT",
                     "availableImmunizations": [
                         "Flu",
+                        "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -5213,15 +4997,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 103,
-                            "openAppointmentSlots": 103,
+                            "openTimeslots": 88,
+                            "openAppointmentSlots": 88,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 103,
+                    "openTimeslots": 88,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 103,
+                    "openAppointmentSlots": 88,
                     "name": "West Ave and Jackson Keller H-E-B",
                     "longitude": -98.52574,
                     "latitude": 29.51639,
@@ -5230,7 +5014,7 @@
                     "availableImmunizations": [
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "Flu"
+                        "COVID-19 Ultra_Pediatric_Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -5242,23 +5026,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 169,
-                            "openAppointmentSlots": 169,
+                            "openTimeslots": 106,
+                            "openAppointmentSlots": 106,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 169,
+                    "openTimeslots": 106,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 169,
+                    "openAppointmentSlots": 106,
                     "name": "De Zavala H-E-B",
                     "longitude": -98.5889,
                     "latitude": 29.56222,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
                         "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
@@ -5271,15 +5055,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 389,
-                            "openAppointmentSlots": 389,
+                            "openTimeslots": 333,
+                            "openAppointmentSlots": 333,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 389,
+                    "openTimeslots": 333,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 389,
+                    "openAppointmentSlots": 333,
                     "name": "281 and 1604 H-E-B",
                     "longitude": -98.46828,
                     "latitude": 29.60772,
@@ -5287,8 +5071,7 @@
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -5300,19 +5083,19 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 649,
-                            "openAppointmentSlots": 649,
+                            "openTimeslots": 240,
+                            "openAppointmentSlots": 240,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 392,
-                    "openFluTimeslots": 257,
-                    "openFluAppointmentSlots": 257,
-                    "openAppointmentSlots": 392,
+                    "openTimeslots": 240,
+                    "openFluTimeslots": 0,
+                    "openFluAppointmentSlots": 0,
+                    "openAppointmentSlots": 240,
                     "name": "Thousand Oaks H-E-B",
                     "longitude": -98.44108,
                     "latitude": 29.57781,
-                    "fluUrl": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000kF2QQAU",
+                    "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
                         "Flu",
@@ -5321,35 +5104,22 @@
                 },
                 {
                     "zip": "78363-3872",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubvQAC",
+                    "url": null,
                     "type": "store",
                     "street": "409 E. KLEBERG",
                     "storeNumber": 401,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 67,
-                            "openAppointmentSlots": 67,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 67,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 67,
+                    "openAppointmentSlots": 0,
                     "name": "Kingsville H-E-B",
                     "longitude": -97.86453,
                     "latitude": 27.51658,
                     "fluUrl": "",
                     "city": "KINGSVILLE",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77382-2772",
@@ -5360,15 +5130,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 31,
-                            "openAppointmentSlots": 31,
+                            "openTimeslots": 34,
+                            "openAppointmentSlots": 34,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 31,
+                    "openTimeslots": 34,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 31,
+                    "openAppointmentSlots": 34,
                     "name": "Indian Springs H-E-B",
                     "longitude": -95.53672,
                     "latitude": 30.17791,
@@ -5377,43 +5147,29 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "Senior_Flu"
                     ]
                 },
                 {
                     "zip": "77301-1220",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudKQAS",
+                    "url": null,
                     "type": "store",
                     "street": "2108 NORTH FRAZIER",
                     "storeNumber": 595,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 127,
-                            "openAppointmentSlots": 127,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 127,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 127,
+                    "openAppointmentSlots": 0,
                     "name": "N Frazier At Loop 336 H-E-B",
                     "longitude": -95.46548,
                     "latitude": 30.33593,
                     "fluUrl": "",
                     "city": "CONROE",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77494-8100",
@@ -5424,15 +5180,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 80,
-                            "openAppointmentSlots": 80,
+                            "openTimeslots": 95,
+                            "openAppointmentSlots": 95,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 80,
+                    "openTimeslots": 95,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 80,
+                    "openAppointmentSlots": 95,
                     "name": "Grand Parkway H-E-B plus!",
                     "longitude": -95.7739,
                     "latitude": 29.7144,
@@ -5440,9 +5196,11 @@
                     "city": "KATY",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer",
+                        "COVID-19 Moderna",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -5454,15 +5212,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 7,
-                            "openAppointmentSlots": 7,
+                            "openTimeslots": 4,
+                            "openAppointmentSlots": 4,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 7,
+                    "openTimeslots": 4,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 7,
+                    "openAppointmentSlots": 4,
                     "name": "Buffalo Market H-E-B On Buffalo Speedway",
                     "longitude": -95.4271,
                     "latitude": 29.7261,
@@ -5470,7 +5228,9 @@
                     "city": "HOUSTON",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -5482,28 +5242,28 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 49,
-                            "openAppointmentSlots": 49,
+                            "openTimeslots": 13,
+                            "openAppointmentSlots": 13,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 49,
+                    "openTimeslots": 13,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 49,
+                    "openAppointmentSlots": 13,
                     "name": "Spring Market H-E-B",
                     "longitude": -95.44894,
                     "latitude": 30.07042,
                     "fluUrl": "",
                     "city": "SPRING",
                     "availableImmunizations": [
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster",
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -5515,25 +5275,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 71,
-                            "openAppointmentSlots": 71,
+                            "openTimeslots": 135,
+                            "openAppointmentSlots": 135,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 71,
+                    "openTimeslots": 135,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 71,
+                    "openAppointmentSlots": 135,
                     "name": "Dripping Springs H-E-B",
                     "longitude": -98.08146,
                     "latitude": 30.18968,
                     "fluUrl": "",
                     "city": "DRIPPING SPRINGS",
                     "availableImmunizations": [
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
                         "Flu",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Senior_Flu",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -5564,22 +5325,22 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 267,
-                            "openAppointmentSlots": 267,
+                            "openTimeslots": 87,
+                            "openAppointmentSlots": 87,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 267,
+                    "openTimeslots": 87,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 267,
+                    "openAppointmentSlots": 87,
                     "name": "H-E-B Market at Gosling",
                     "longitude": -95.50178,
                     "latitude": 30.07179,
                     "fluUrl": "",
                     "city": "SPRING",
                     "availableImmunizations": [
-                        "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
@@ -5630,57 +5391,44 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 234,
-                            "openAppointmentSlots": 234,
+                            "openTimeslots": 147,
+                            "openAppointmentSlots": 147,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 234,
+                    "openTimeslots": 147,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 234,
+                    "openAppointmentSlots": 147,
                     "name": "MacGregor Market H-E-B",
                     "longitude": -95.37644,
                     "latitude": 29.71432,
                     "fluUrl": "",
                     "city": "HOUSTON",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
                         "Flu",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Moderna"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "77385-0",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuekQAC",
+                    "url": null,
                     "type": "store",
                     "street": "10200 HIGHWAY 242",
                     "storeNumber": 757,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 136,
-                            "openAppointmentSlots": 136,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 136,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 136,
+                    "openAppointmentSlots": 0,
                     "name": "Harper's Trace H-E-B",
                     "longitude": -95.42563,
                     "latitude": 30.20692,
                     "fluUrl": "",
                     "city": "CONROE",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77339-0",
@@ -5691,15 +5439,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
+                            "openTimeslots": 1,
+                            "openAppointmentSlots": 1,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 50,
+                    "openTimeslots": 1,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 50,
+                    "openAppointmentSlots": 1,
                     "name": "H-E-B Market at Northpark",
                     "longitude": -95.25033,
                     "latitude": 30.06864,
@@ -5709,43 +5457,30 @@
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
                     "zip": "78253-0",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuemQAC",
+                    "url": null,
                     "type": "store",
                     "street": "14325 POTRANCO RD.",
                     "storeNumber": 771,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 54,
-                            "openAppointmentSlots": 54,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 54,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 54,
+                    "openAppointmentSlots": 0,
                     "name": "211 and Potranco H-E-B",
                     "longitude": -98.77966,
                     "latitude": 29.42367,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Moderna_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "79424-0",
@@ -5756,15 +5491,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 66,
-                            "openAppointmentSlots": 66,
+                            "openTimeslots": 14,
+                            "openAppointmentSlots": 14,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 66,
+                    "openTimeslots": 14,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 66,
+                    "openAppointmentSlots": 14,
                     "name": "Lubbock H-E-B",
                     "longitude": -101.90638,
                     "latitude": 33.48958,
@@ -5772,13 +5507,13 @@
                     "city": "LUBBOCK",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
                         "COVID-19 Novavax",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -5790,15 +5525,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 72,
-                            "openAppointmentSlots": 72,
+                            "openTimeslots": 105,
+                            "openAppointmentSlots": 105,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 72,
+                    "openTimeslots": 105,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 72,
+                    "openAppointmentSlots": 105,
                     "name": "Big Spring H-E-B",
                     "longitude": -101.47211,
                     "latitude": 32.23493,
@@ -5808,7 +5543,9 @@
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -5820,15 +5557,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 234,
-                            "openAppointmentSlots": 234,
+                            "openTimeslots": 178,
+                            "openAppointmentSlots": 178,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 234,
+                    "openTimeslots": 178,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 234,
+                    "openAppointmentSlots": 178,
                     "name": "Sherwood Avenue N H-E-B",
                     "longitude": -100.47977,
                     "latitude": 31.44511,
@@ -5837,8 +5574,11 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -5850,54 +5590,44 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 87,
-                            "openAppointmentSlots": 87,
+                            "openTimeslots": 218,
+                            "openAppointmentSlots": 218,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 87,
+                    "openTimeslots": 218,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 87,
+                    "openAppointmentSlots": 218,
                     "name": "Blackhawk H-E-B",
                     "longitude": -95.24868,
                     "latitude": 29.60234,
                     "fluUrl": "",
                     "city": "HOUSTON",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu",
                         "COVID-19 Moderna_Updated_Booster",
-                        "Flu"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "78418-4426",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaXQAS",
+                    "url": null,
                     "type": "store",
                     "street": "1145 WALDRON ROAD",
                     "storeNumber": 57,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 57,
-                            "openAppointmentSlots": 57,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 57,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 57,
+                    "openAppointmentSlots": 0,
                     "name": "Flour Bluff H-E-B plus!",
                     "longitude": -97.28288,
                     "latitude": 27.66767,
                     "fluUrl": "",
                     "city": "CORPUS CHRISTI",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77584-2191",
@@ -5908,15 +5638,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 93,
-                            "openAppointmentSlots": 93,
+                            "openTimeslots": 48,
+                            "openAppointmentSlots": 48,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 93,
+                    "openTimeslots": 48,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 93,
+                    "openAppointmentSlots": 48,
                     "name": "Pearland H-E-B plus!",
                     "longitude": -95.39002,
                     "latitude": 29.55932,
@@ -5927,12 +5657,7 @@
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
-                        "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Novavax",
-                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Moderna_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
@@ -5945,15 +5670,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 80,
-                            "openAppointmentSlots": 80,
+                            "openTimeslots": 110,
+                            "openAppointmentSlots": 110,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 80,
+                    "openTimeslots": 110,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 80,
+                    "openAppointmentSlots": 110,
                     "name": "19th and Meridian H-E-B",
                     "longitude": -97.17255,
                     "latitude": 31.5804,
@@ -5964,7 +5689,8 @@
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -5976,15 +5702,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 75,
-                            "openAppointmentSlots": 75,
+                            "openTimeslots": 68,
+                            "openAppointmentSlots": 68,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 75,
+                    "openTimeslots": 68,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 75,
+                    "openAppointmentSlots": 68,
                     "name": "Slaughter and Escarpment H-E-B",
                     "longitude": -97.87642,
                     "latitude": 30.20247,
@@ -6042,43 +5768,60 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 22,
-                            "openAppointmentSlots": 22,
+                            "openTimeslots": 111,
+                            "openAppointmentSlots": 111,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 22,
+                    "openTimeslots": 111,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 22,
+                    "openAppointmentSlots": 111,
                     "name": "Bee Cave H-E-B",
                     "longitude": -97.93238,
                     "latitude": 30.30489,
                     "fluUrl": "",
                     "city": "BEE CAVE",
                     "availableImmunizations": [
+                        "COVID-19 Moderna_Updated_Booster",
                         "Flu",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "78227-1652",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudQQAS",
                     "type": "store",
                     "street": "8219 MARBACH",
                     "storeNumber": 613,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 396,
+                            "openAppointmentSlots": 396,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 396,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 396,
                     "name": "Marbach and 410 H-E-B plus!",
                     "longitude": -98.65227,
                     "latitude": 29.41837,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Janssen",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
+                    ]
                 },
                 {
                     "zip": "77044-6087",
@@ -6089,15 +5832,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 103,
-                            "openAppointmentSlots": 103,
+                            "openTimeslots": 216,
+                            "openAppointmentSlots": 216,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 103,
+                    "openTimeslots": 216,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 103,
+                    "openAppointmentSlots": 216,
                     "name": "Summerwood Market H-E-B",
                     "longitude": -95.19697,
                     "latitude": 29.92325,
@@ -6107,75 +5850,53 @@
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
                         "COVID-19 Novavax",
                         "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
                     "zip": "77494-5904",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudSQAS",
+                    "url": null,
                     "type": "store",
                     "street": "25675 NELSON WAY",
                     "storeNumber": 615,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 103,
-                            "openAppointmentSlots": 103,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 103,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 103,
+                    "openAppointmentSlots": 0,
                     "name": "Katy Market H-E-B",
                     "longitude": -95.82005,
                     "latitude": 29.77644,
                     "fluUrl": "",
                     "city": "KATY",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78240-2136",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudTQAS",
+                    "url": null,
                     "type": "store",
                     "street": "5910 BABCOCK RD",
                     "storeNumber": 618,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 40,
-                            "openAppointmentSlots": 40,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 40,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 40,
+                    "openAppointmentSlots": 0,
                     "name": "Babcock H-E-B",
                     "longitude": -98.60198,
                     "latitude": 29.5271,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77845-4638",
@@ -6186,15 +5907,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 183,
-                            "openAppointmentSlots": 183,
+                            "openTimeslots": 190,
+                            "openAppointmentSlots": 190,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 183,
+                    "openTimeslots": 190,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 183,
+                    "openAppointmentSlots": 190,
                     "name": "Tower Point Market H-E-B",
                     "longitude": -96.26315,
                     "latitude": 30.55969,
@@ -6202,27 +5923,42 @@
                     "city": "COLLEGE STATION",
                     "availableImmunizations": [
                         "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "78061-6630",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudVQAS",
                     "type": "store",
                     "street": "225 SOUTH IH 35",
                     "storeNumber": 620,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 70,
+                            "openAppointmentSlots": 70,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 70,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 70,
                     "name": "Pearsall H-E-B",
                     "longitude": -99.11446,
                     "latitude": 28.89503,
                     "fluUrl": "",
                     "city": "PEARSALL",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
+                    ]
                 },
                 {
                     "zip": "78712-0",
@@ -6233,15 +5969,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 112,
-                            "openAppointmentSlots": 112,
+                            "openTimeslots": 74,
+                            "openAppointmentSlots": 74,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 112,
+                    "openTimeslots": 74,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 112,
+                    "openAppointmentSlots": 74,
                     "name": "H-E-B Pharmacy at the UTHTB",
                     "longitude": -97.73507,
                     "latitude": 30.27747,
@@ -6249,6 +5985,7 @@
                     "city": "AUSTIN",
                     "availableImmunizations": [
                         "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
@@ -6262,15 +5999,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 119,
-                            "openAppointmentSlots": 119,
+                            "openTimeslots": 159,
+                            "openAppointmentSlots": 159,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 119,
+                    "openTimeslots": 159,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 119,
+                    "openAppointmentSlots": 159,
                     "name": "Abilene H-E-B",
                     "longitude": -99.75934,
                     "latitude": 32.43348,
@@ -6279,11 +6016,11 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
                         "COVID-19 Novavax",
                         "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -6314,15 +6051,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 30,
-                            "openAppointmentSlots": 30,
+                            "openTimeslots": 123,
+                            "openAppointmentSlots": 123,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 30,
+                    "openTimeslots": 123,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 30,
+                    "openAppointmentSlots": 123,
                     "name": "Boerne H-E-B plus!",
                     "longitude": -98.73481,
                     "latitude": 29.78173,
@@ -6330,7 +6067,8 @@
                     "city": "BOERNE",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -6342,28 +6080,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 92,
-                            "openAppointmentSlots": 92,
+                            "openTimeslots": 58,
+                            "openAppointmentSlots": 58,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 92,
+                    "openTimeslots": 58,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 92,
+                    "openAppointmentSlots": 58,
                     "name": "Bulverde H-E-B plus!",
                     "longitude": -98.43022,
                     "latitude": 29.79882,
                     "fluUrl": "",
                     "city": "SPRING BRANCH",
                     "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Novavax",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -6375,15 +6112,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 297,
-                            "openAppointmentSlots": 297,
+                            "openTimeslots": 83,
+                            "openAppointmentSlots": 83,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 297,
+                    "openTimeslots": 83,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 297,
+                    "openAppointmentSlots": 83,
                     "name": "Bandera and 1604 H-E-B plus!",
                     "longitude": -98.66444,
                     "latitude": 29.55498,
@@ -6391,8 +6128,11 @@
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
                         "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -6425,7 +6165,8 @@
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -6437,15 +6178,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 162,
-                            "openAppointmentSlots": 162,
+                            "openTimeslots": 108,
+                            "openAppointmentSlots": 108,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 162,
+                    "openTimeslots": 108,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 162,
+                    "openAppointmentSlots": 108,
                     "name": "Sugar Land Market H-E-B",
                     "longitude": -95.64596,
                     "latitude": 29.60871,
@@ -6484,27 +6225,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 69,
-                            "openAppointmentSlots": 69,
+                            "openTimeslots": 48,
+                            "openAppointmentSlots": 48,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 69,
+                    "openTimeslots": 48,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 69,
+                    "openAppointmentSlots": 48,
                     "name": "Spring Green Market H-E-B",
                     "longitude": -95.81427,
                     "latitude": 29.69558,
                     "fluUrl": "",
                     "city": "RICHMOND",
                     "availableImmunizations": [
-                        "Flu",
                         "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -6516,15 +6257,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 217,
-                            "openAppointmentSlots": 217,
+                            "openTimeslots": 324,
+                            "openAppointmentSlots": 324,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 217,
+                    "openTimeslots": 324,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 217,
+                    "openAppointmentSlots": 324,
                     "name": "New Braunfels H-E-B at Hwy 46",
                     "longitude": -98.16041,
                     "latitude": 29.71309,
@@ -6533,7 +6274,7 @@
                     "availableImmunizations": [
                         "COVID-19 Pfizer_Updated_Booster",
                         "Flu",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -6545,15 +6286,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 569,
-                            "openAppointmentSlots": 569,
+                            "openTimeslots": 500,
+                            "openAppointmentSlots": 500,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 569,
+                    "openTimeslots": 500,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 569,
+                    "openAppointmentSlots": 500,
                     "name": "Zarzamora and Military H-E-B plus!",
                     "longitude": -98.5339,
                     "latitude": 29.35787,
@@ -6561,11 +6302,9 @@
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Moderna",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -6577,24 +6316,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 194,
-                            "openAppointmentSlots": 194,
+                            "openTimeslots": 31,
+                            "openAppointmentSlots": 31,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 194,
+                    "openTimeslots": 31,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 194,
+                    "openAppointmentSlots": 31,
                     "name": "Potranco and 1604 H-E-B plus!",
                     "longitude": -98.70445,
                     "latitude": 29.43536,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
+                        "Flu",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "Flu"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -6606,15 +6345,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 76,
-                            "openAppointmentSlots": 76,
+                            "openTimeslots": 220,
+                            "openAppointmentSlots": 220,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 76,
+                    "openTimeslots": 220,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 76,
+                    "openAppointmentSlots": 220,
                     "name": "Kerrville H-E-B On Main Street",
                     "longitude": -99.14287,
                     "latitude": 30.05056,
@@ -6622,38 +6361,29 @@
                     "city": "KERRVILLE",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
                     "zip": "78741-3037",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaiQAC",
+                    "url": null,
                     "type": "store",
                     "street": "2508 EAST RIVERSIDE DRIVE",
                     "storeNumber": 91,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 77,
-                            "openAppointmentSlots": 77,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 77,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 77,
+                    "openAppointmentSlots": 0,
                     "name": "Riverside H-E-B plus!",
                     "longitude": -97.72401,
                     "latitude": 30.23547,
                     "fluUrl": "",
                     "city": "AUSTIN",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77904-1767",
@@ -6683,15 +6413,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 297,
-                            "openAppointmentSlots": 297,
+                            "openTimeslots": 254,
+                            "openAppointmentSlots": 254,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 297,
+                    "openTimeslots": 254,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 297,
+                    "openAppointmentSlots": 254,
                     "name": "Bunker Hill H-E-B",
                     "longitude": -95.53206,
                     "latitude": 29.78485,
@@ -6699,12 +6429,15 @@
                     "city": "HOUSTON",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pediatric_Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster",
+                        "Senior_Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
                         "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Novavax",
+                        "COVID-19 Pediatric_Moderna",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
@@ -6717,15 +6450,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 74,
-                            "openAppointmentSlots": 74,
+                            "openTimeslots": 78,
+                            "openAppointmentSlots": 78,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 74,
+                    "openTimeslots": 78,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 74,
+                    "openAppointmentSlots": 78,
                     "name": "Sienna Market H-E-B",
                     "longitude": -95.53497,
                     "latitude": 29.53928,
@@ -6740,35 +6473,22 @@
                 },
                 {
                     "zip": "78550-7708",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuauQAC",
+                    "url": null,
                     "type": "store",
                     "street": "1213 S. COMMERCE",
                     "storeNumber": 136,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 46,
-                            "openAppointmentSlots": 46,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 46,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 46,
+                    "openAppointmentSlots": 0,
                     "name": "Southland and 12th St H-E-B",
                     "longitude": -97.68171,
                     "latitude": 26.18251,
                     "fluUrl": "",
                     "city": "HARLINGEN",
-                    "availableImmunizations": [
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Janssen",
-                        "Flu",
-                        "COVID-19 Moderna_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78413-3966",
@@ -6798,81 +6518,61 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 388,
-                            "openAppointmentSlots": 388,
+                            "openTimeslots": 170,
+                            "openAppointmentSlots": 170,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 388,
+                    "openTimeslots": 170,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 388,
+                    "openAppointmentSlots": 170,
                     "name": "Ed Bluestein H-E-B",
                     "longitude": -97.66465,
                     "latitude": 30.31211,
                     "fluUrl": "",
                     "city": "AUSTIN",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
                         "Flu"
                     ]
                 },
                 {
                     "zip": "78232-3714",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaxQAC",
+                    "url": null,
                     "type": "store",
                     "street": "15000 SAN PEDRO",
                     "storeNumber": 164,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 57,
-                            "openAppointmentSlots": 57,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 57,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 57,
+                    "openAppointmentSlots": 0,
                     "name": "Brook Hollow H-E-B",
                     "longitude": -98.47734,
                     "latitude": 29.5774,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78572-8354",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuakQAC",
+                    "url": null,
                     "type": "store",
                     "street": "2409 EAST EXPRESSWAY 83",
                     "storeNumber": 94,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 18,
-                            "openAppointmentSlots": 18,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 18,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 18,
+                    "openAppointmentSlots": 0,
                     "name": "Mission H-E-B plus!",
                     "longitude": -98.28628,
                     "latitude": 26.19755,
                     "fluUrl": "",
                     "city": "MISSION",
-                    "availableImmunizations": [
-                        "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Ultra_Pediatric_Pfizer"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78045-6596",
@@ -6883,15 +6583,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 23,
-                            "openAppointmentSlots": 23,
+                            "openTimeslots": 26,
+                            "openAppointmentSlots": 26,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 23,
+                    "openTimeslots": 26,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 23,
+                    "openAppointmentSlots": 26,
                     "name": "Laredo H-E-B plus!",
                     "longitude": -99.47435,
                     "latitude": 27.60863,
@@ -6902,8 +6602,8 @@
                         "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -6934,15 +6634,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 176,
-                            "openAppointmentSlots": 176,
+                            "openTimeslots": 225,
+                            "openAppointmentSlots": 225,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 176,
+                    "openTimeslots": 225,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 176,
+                    "openAppointmentSlots": 225,
                     "name": "Vintage Park Market H-E-B",
                     "longitude": -95.57661,
                     "latitude": 29.9967,
@@ -6950,10 +6650,10 @@
                     "city": "HOUSTON",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -6965,15 +6665,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 516,
-                            "openAppointmentSlots": 516,
+                            "openTimeslots": 341,
+                            "openAppointmentSlots": 341,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 516,
+                    "openTimeslots": 341,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 516,
+                    "openAppointmentSlots": 341,
                     "name": "Alon Market H-E-B",
                     "longitude": -98.53463,
                     "latitude": 29.55254,
@@ -6982,39 +6682,27 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Moderna_Updated_Booster"
+                        "Senior_Flu"
                     ]
                 },
                 {
                     "zip": "78745-5008",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucCQAS",
+                    "url": null,
                     "type": "store",
                     "street": "6900 BRODIE LANE",
                     "storeNumber": 428,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 8,
-                            "openAppointmentSlots": 8,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 8,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 8,
+                    "openAppointmentSlots": 0,
                     "name": "Brodie Lane H-E-B",
                     "longitude": -97.83076,
                     "latitude": 30.21489,
                     "fluUrl": "",
                     "city": "AUSTIN",
-                    "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "Flu"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78539-7312",
@@ -7044,55 +6732,45 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 191,
-                            "openAppointmentSlots": 191,
+                            "openTimeslots": 271,
+                            "openAppointmentSlots": 271,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 191,
+                    "openTimeslots": 271,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 191,
+                    "openAppointmentSlots": 271,
                     "name": "Montrose Market H-E-B",
                     "longitude": -95.40284,
                     "latitude": 29.7379,
                     "fluUrl": "",
                     "city": "HOUSTON",
                     "availableImmunizations": [
+                        "Senior_Flu",
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Janssen"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "76049-7428",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudcQAC",
+                    "url": null,
                     "type": "store",
                     "street": "3804 US HWY 377",
                     "storeNumber": 631,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 294,
-                            "openAppointmentSlots": 294,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 294,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 294,
+                    "openAppointmentSlots": 0,
                     "name": "Granbury H-E-B",
                     "longitude": -97.73026,
                     "latitude": 32.45528,
                     "fluUrl": "",
                     "city": "GRANBURY",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77384-3943",
@@ -7103,15 +6781,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 184,
-                            "openAppointmentSlots": 184,
+                            "openTimeslots": 165,
+                            "openAppointmentSlots": 165,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 184,
+                    "openTimeslots": 165,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 184,
+                    "openAppointmentSlots": 165,
                     "name": "North Woodlands Market H-E-B",
                     "longitude": -95.51296,
                     "latitude": 30.22918,
@@ -7119,6 +6797,7 @@
                     "city": "THE WOODLANDS",
                     "availableImmunizations": [
                         "Flu",
+                        "Senior_Flu",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster"
                     ]
@@ -7265,15 +6944,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 56,
-                            "openAppointmentSlots": 56,
+                            "openTimeslots": 70,
+                            "openAppointmentSlots": 70,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 56,
+                    "openTimeslots": 70,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 56,
+                    "openAppointmentSlots": 70,
                     "name": "Morgan and Grimes H-E-B",
                     "longitude": -97.67639,
                     "latitude": 26.20337,
@@ -7282,12 +6961,16 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna",
                         "COVID-19 Novavax",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -7318,25 +7001,22 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 83,
-                            "openAppointmentSlots": 83,
+                            "openTimeslots": 71,
+                            "openAppointmentSlots": 71,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 83,
+                    "openTimeslots": 71,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 83,
+                    "openAppointmentSlots": 71,
                     "name": "San Pedro and Oblate H-E-B",
                     "longitude": -98.4995,
                     "latitude": 29.50282,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "COVID-19 Pfizer"
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -7367,15 +7047,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 422,
-                            "openAppointmentSlots": 422,
+                            "openTimeslots": 184,
+                            "openAppointmentSlots": 184,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 422,
+                    "openTimeslots": 184,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 422,
+                    "openAppointmentSlots": 184,
                     "name": "Lamar and Rundberg H-E-B",
                     "longitude": -97.69689,
                     "latitude": 30.36357,
@@ -7383,44 +7063,33 @@
                     "city": "AUSTIN",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
                         "COVID-19 Novavax",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Moderna_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "Senior_Flu"
                     ]
                 },
                 {
                     "zip": "78410-2612",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gub3QAC",
+                    "url": null,
                     "type": "store",
                     "street": "11100 LEOPARD",
                     "storeNumber": 184,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 12,
-                            "openAppointmentSlots": 12,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 12,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 12,
+                    "openAppointmentSlots": 0,
                     "name": "Leopard and Violet H-E-B",
                     "longitude": -97.58473,
                     "latitude": 27.84494,
                     "fluUrl": "",
                     "city": "CORPUS CHRISTI",
-                    "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78041-5435",
@@ -7462,31 +7131,22 @@
                 },
                 {
                     "zip": "78220-2530",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuapQAC",
+                    "url": null,
                     "type": "store",
                     "street": "1015 S.W.W. WHITE ROAD",
                     "storeNumber": 106,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 87,
-                            "openAppointmentSlots": 87,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 87,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 87,
+                    "openAppointmentSlots": 0,
                     "name": "W. W. White H-E-B",
                     "longitude": -98.40568,
                     "latitude": 29.41476,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "75119-4519",
@@ -7497,15 +7157,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 49,
-                            "openAppointmentSlots": 49,
+                            "openTimeslots": 91,
+                            "openAppointmentSlots": 91,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 49,
+                    "openTimeslots": 91,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 49,
+                    "openAppointmentSlots": 91,
                     "name": "Ennis H-E-B",
                     "longitude": -96.63251,
                     "latitude": 32.32542,
@@ -7513,11 +7173,10 @@
                     "city": "ENNIS",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Janssen",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -7529,15 +7188,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 100,
-                            "openAppointmentSlots": 100,
+                            "openTimeslots": 124,
+                            "openAppointmentSlots": 124,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 100,
+                    "openTimeslots": 124,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 100,
+                    "openAppointmentSlots": 124,
                     "name": "281 and Evans Road H-E-B plus!",
                     "longitude": -98.45756,
                     "latitude": 29.63886,
@@ -7545,38 +7204,29 @@
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
                     "zip": "77433-4288",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudlQAC",
+                    "url": null,
                     "type": "store",
                     "street": "28550 US- 290",
                     "storeNumber": 656,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 2512,
-                            "openAppointmentSlots": 2512,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 2512,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 2512,
+                    "openAppointmentSlots": 0,
                     "name": "Fairfield Market H-E-B",
                     "longitude": -95.74599,
                     "latitude": 29.9925,
                     "fluUrl": "",
                     "city": "CYPRESS",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77065-4814",
@@ -7587,23 +7237,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 292,
-                            "openAppointmentSlots": 292,
+                            "openTimeslots": 1091,
+                            "openAppointmentSlots": 1091,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 292,
+                    "openTimeslots": 1091,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 292,
+                    "openAppointmentSlots": 1091,
                     "name": "Jones and West H-E-B",
                     "longitude": -95.5859,
                     "latitude": 29.91104,
                     "fluUrl": "",
                     "city": "HOUSTON",
                     "availableImmunizations": [
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "COVID-19 Pfizer",
                         "Flu",
+                        "Senior_Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "COVID-19 Moderna",
                         "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
@@ -7616,25 +7270,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 138,
-                            "openAppointmentSlots": 138,
+                            "openTimeslots": 194,
+                            "openAppointmentSlots": 194,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 138,
+                    "openTimeslots": 194,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 138,
+                    "openAppointmentSlots": 194,
                     "name": "The Market at Stone Oak",
                     "longitude": -98.50062,
                     "latitude": 29.662,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
-                        "Flu",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "Flu"
                     ]
                 },
                 {
@@ -7646,15 +7299,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 27,
-                            "openAppointmentSlots": 27,
+                            "openTimeslots": 36,
+                            "openAppointmentSlots": 36,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 27,
+                    "openTimeslots": 36,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 27,
+                    "openAppointmentSlots": 36,
                     "name": "Lakeline H-E-B plus!",
                     "longitude": -97.8034,
                     "latitude": 30.47786,
@@ -7662,7 +7315,8 @@
                     "city": "AUSTIN",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -7674,36 +7328,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 350,
-                            "openAppointmentSlots": 350,
-                            "manufacturer": "Moderna"
-                        },
-                        {
-                            "openTimeslots": 391,
-                            "openAppointmentSlots": 391,
-                            "manufacturer": "Pfizer"
-                        },
-                        {
-                            "openTimeslots": 1039,
-                            "openAppointmentSlots": 1039,
+                            "openTimeslots": 534,
+                            "openAppointmentSlots": 534,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 1780,
+                    "openTimeslots": 534,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 1780,
+                    "openAppointmentSlots": 534,
                     "name": "Conroe Market H-E-B",
                     "longitude": -95.49817,
                     "latitude": 30.32647,
                     "fluUrl": "",
                     "city": "CONROE",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer",
+                        "Flu",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna",
-                        "Flu"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -7715,15 +7357,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 410,
-                            "openAppointmentSlots": 410,
+                            "openTimeslots": 231,
+                            "openAppointmentSlots": 231,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 410,
+                    "openTimeslots": 231,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 410,
+                    "openAppointmentSlots": 231,
                     "name": "Texas City H-E-B",
                     "longitude": -94.94893,
                     "latitude": 29.39535,
@@ -7731,10 +7373,10 @@
                     "city": "TEXAS CITY",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -7765,29 +7407,29 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 376,
-                            "openAppointmentSlots": 376,
+                            "openTimeslots": 216,
+                            "openAppointmentSlots": 216,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 376,
+                    "openTimeslots": 216,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 376,
+                    "openAppointmentSlots": 216,
                     "name": "Broadway Central Market",
                     "longitude": -98.46408,
                     "latitude": 29.47069,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
+                        "Flu",
+                        "Senior_Flu",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "Flu",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer"
+                        "COVID-19 Janssen"
                     ]
                 },
                 {
@@ -7811,32 +7453,22 @@
                 },
                 {
                     "zip": "78834-2028",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudsQAC",
+                    "url": null,
                     "type": "store",
                     "street": "2030 N. 1ST STREET",
                     "storeNumber": 671,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 29,
-                            "openAppointmentSlots": 29,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 29,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 29,
+                    "openAppointmentSlots": 0,
                     "name": "Carrizo Springs H-E-B",
                     "longitude": -99.85102,
                     "latitude": 28.53642,
                     "fluUrl": "",
                     "city": "CARRIZO SPRINGS",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "76711-2119",
@@ -7847,33 +7479,31 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 205,
-                            "openAppointmentSlots": 205,
+                            "openTimeslots": 133,
+                            "openAppointmentSlots": 133,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 205,
+                    "openTimeslots": 133,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 205,
+                    "openAppointmentSlots": 133,
                     "name": "Valley Mills H-E-B plus!",
                     "longitude": -97.13916,
                     "latitude": 31.52508,
                     "fluUrl": "",
                     "city": "WACO",
                     "availableImmunizations": [
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
-                        "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Pediatric_Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Janssen",
                         "COVID-19 Novavax",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -7885,15 +7515,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 50,
-                            "openAppointmentSlots": 50,
+                            "openTimeslots": 7,
+                            "openAppointmentSlots": 7,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 50,
+                    "openTimeslots": 7,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 50,
+                    "openAppointmentSlots": 7,
                     "name": "University Blvd H-E-B",
                     "longitude": -97.68859,
                     "latitude": 30.56107,
@@ -7902,7 +7532,6 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
@@ -7910,7 +7539,8 @@
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -7922,25 +7552,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 40,
-                            "openAppointmentSlots": 40,
+                            "openTimeslots": 92,
+                            "openAppointmentSlots": 92,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 40,
+                    "openTimeslots": 92,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 40,
+                    "openAppointmentSlots": 92,
                     "name": "Palmhurst H-E-B",
                     "longitude": -98.31816,
                     "latitude": 26.25684,
                     "fluUrl": "",
                     "city": "PALMHURST",
                     "availableImmunizations": [
+                        "Flu",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "Flu"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -7952,15 +7582,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 98,
-                            "openAppointmentSlots": 98,
+                            "openTimeslots": 100,
+                            "openAppointmentSlots": 100,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 98,
+                    "openTimeslots": 100,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 98,
+                    "openAppointmentSlots": 100,
                     "name": "Pearland Market H-E-B",
                     "longitude": -95.26499,
                     "latitude": 29.55812,
@@ -7970,9 +7600,10 @@
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Senior_Flu",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -8022,27 +7653,28 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 104,
-                            "openAppointmentSlots": 104,
+                            "openTimeslots": 100,
+                            "openAppointmentSlots": 100,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 104,
+                    "openTimeslots": 100,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 104,
+                    "openAppointmentSlots": 100,
                     "name": "H-E-B Frisco",
                     "longitude": -96.84583,
                     "latitude": 33.15458,
                     "fluUrl": "",
                     "city": "FRISCO",
                     "availableImmunizations": [
+                        "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Janssen",
                         "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Novavax",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 }
@@ -8052,31 +7684,31 @@
             "Content-Type",
             "binary/octet-stream",
             "Content-Length",
-            "173376",
+            "164382",
             "Connection",
             "close",
             "Last-Modified",
-            "Tue, 25 Oct 2022 16:44:21 GMT",
+            "Mon, 12 Dec 2022 22:42:46 GMT",
             "Accept-Ranges",
             "bytes",
             "Server",
             "AmazonS3",
             "Date",
-            "Tue, 25 Oct 2022 16:45:20 GMT",
+            "Mon, 12 Dec 2022 22:48:13 GMT",
             "Cache-Control",
             "max-age:0",
             "ETag",
-            "\"67847a393bf3338ea5111bc942b1aa59\"",
+            "\"baccfcca4bbeff9a5079bc53006e2aad\"",
             "Vary",
             "Accept-Encoding",
             "X-Cache",
             "RefreshHit from cloudfront",
             "Via",
-            "1.1 21e2c668bb54ebb4456425e394c3356a.cloudfront.net (CloudFront)",
+            "1.1 442d080ad536f368b087d8fa4ff33ee6.cloudfront.net (CloudFront)",
             "X-Amz-Cf-Pop",
-            "SFO20-C1",
+            "SFO5-P2",
             "X-Amz-Cf-Id",
-            "M0ku-xN7TYES3ZCiYi4gg5jXiwnj7UjK7G2ixsXfuvdt_0Sp2n_VwA=="
+            "ExfQJsWpFjN6RFf1BhHSum8G-VQZ0sO9HhJ5C32MaQYw5DxE5khwDA=="
         ],
         "responseIsBinary": false
     }


### PR DESCRIPTION
H-E-B started surfacing new vaccine codes for bivalent moderna infant vaccines a couple hours ago. Fixes https://sentry.io/organizations/usdr/issues/3804009429.