### PR TITLE
Support bivalent infant Pfizer from H-E-B

### DIFF
--- a/loader/src/sources/heb/index.js
+++ b/loader/src/sources/heb/index.js
@@ -56,6 +56,14 @@ const IMMUNIZATION_TYPES = {
     manufacturer: "ultra_pediatric_pfizer",
     product: VaccineProduct.pfizerAge0_4,
   },
+  "COVID-19 Ultra_Pediatric_Pfizer_Updated_Booster": {
+    manufacturer: "ultra_pediatric_pfizer",
+    product: VaccineProduct.pfizerBa4Ba5Age0_4,
+  },
+  "COVID-19 Ultra_Pediatric_Pfizer_Updated_Dose3": {
+    manufacturer: "ultra_pediatric_pfizer",
+    product: VaccineProduct.pfizerBa4Ba5Age0_4,
+  },
   "COVID-19 Moderna": {
     manufacturer: "moderna",
     product: VaccineProduct.moderna,

--- a/loader/test/fixtures/nock/h-e-b_should_output_valid_data.json
+++ b/loader/test/fixtures/nock/h-e-b_should_output_valid_data.json
@@ -2,7 +2,7 @@
     {
         "scope": "https://heb-ecom-covid-vaccine.hebdigital-prd.com:443",
         "method": "GET",
-        "path": "/vaccine_locations.json?v=480604202775.56006",
+        "path": "/vaccine_locations.json?v=571656451333.9834",
         "body": "",
         "status": 200,
         "response": {
@@ -16,15 +16,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 24,
-                            "openAppointmentSlots": 24,
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 24,
+                    "openTimeslots": 20,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 24,
+                    "openAppointmentSlots": 20,
                     "name": "Round Rock H-E-B plus!",
                     "longitude": -97.65978,
                     "latitude": 30.5177,
@@ -32,7 +32,8 @@
                     "city": "ROUND ROCK",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -63,15 +64,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 94,
-                            "openAppointmentSlots": 94,
+                            "openTimeslots": 35,
+                            "openAppointmentSlots": 35,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 94,
+                    "openTimeslots": 35,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 94,
+                    "openAppointmentSlots": 35,
                     "name": "Marble Falls H-E-B",
                     "longitude": -98.27972,
                     "latitude": 30.58301,
@@ -79,9 +80,9 @@
                     "city": "MARBLE FALLS",
                     "availableImmunizations": [
                         "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
                         "Senior_Flu",
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "Flu"
                     ]
                 },
                 {
@@ -93,15 +94,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 473,
-                            "openAppointmentSlots": 473,
+                            "openTimeslots": 270,
+                            "openAppointmentSlots": 270,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 473,
+                    "openTimeslots": 270,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 473,
+                    "openAppointmentSlots": 270,
                     "name": "Wells Branch H-E-B",
                     "longitude": -97.66419,
                     "latitude": 30.44263,
@@ -121,24 +122,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 94,
-                            "openAppointmentSlots": 94,
+                            "openTimeslots": 89,
+                            "openAppointmentSlots": 89,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 94,
+                    "openTimeslots": 89,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 94,
+                    "openAppointmentSlots": 89,
                     "name": "Louis Henna Blvd H-E-B",
                     "longitude": -97.65938,
                     "latitude": 30.48179,
                     "fluUrl": "",
                     "city": "ROUND ROCK",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster",
                         "Flu",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -150,15 +152,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 61,
-                            "openAppointmentSlots": 61,
+                            "openTimeslots": 150,
+                            "openAppointmentSlots": 150,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 61,
+                    "openTimeslots": 150,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 61,
+                    "openAppointmentSlots": 150,
                     "name": "H-E-B at Ronald Reagan Blvd",
                     "longitude": -97.82446,
                     "latitude": 30.63307,
@@ -166,15 +168,17 @@
                     "city": "GEORGETOWN",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "Senior_Flu",
-                        "COVID-19 Pediatric_Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
-                        "COVID-19 Novavax",
+                        "Senior_Flu",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "COVID-19 Ultra_Pediatric_Pfizer_Updated_Dose3",
+                        "COVID-19 Ultra_Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Novavax",
+                        "COVID-19 Ultra_Pediatric_Pfizer"
                     ]
                 },
                 {
@@ -224,15 +228,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 213,
-                            "openAppointmentSlots": 213,
+                            "openTimeslots": 85,
+                            "openAppointmentSlots": 85,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 213,
+                    "openTimeslots": 85,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 213,
+                    "openAppointmentSlots": 85,
                     "name": "El Dorado H-E-B",
                     "longitude": -95.14874,
                     "latitude": 29.55117,
@@ -257,15 +261,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 240,
-                            "openAppointmentSlots": 240,
+                            "openTimeslots": 177,
+                            "openAppointmentSlots": 177,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 240,
+                    "openTimeslots": 177,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 240,
+                    "openAppointmentSlots": 177,
                     "name": "H-E-B Magnolia Place",
                     "longitude": -95.68208,
                     "latitude": 30.22109,
@@ -279,33 +283,22 @@
                 },
                 {
                     "zip": "78045-2802",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucLQAS",
+                    "url": null,
                     "type": "store",
                     "street": "7811 MCPHERSON RD.",
                     "storeNumber": 449,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 1,
-                            "openAppointmentSlots": 1,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 1,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 1,
+                    "openAppointmentSlots": 0,
                     "name": "McPherson Rd H-E-B",
                     "longitude": -99.4733,
                     "latitude": 27.5754,
                     "fluUrl": "",
                     "city": "LAREDO",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "Senior_Flu"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78355-4365",
@@ -335,15 +328,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 39,
-                            "openAppointmentSlots": 39,
+                            "openTimeslots": 11,
+                            "openAppointmentSlots": 11,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 39,
+                    "openTimeslots": 11,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 39,
+                    "openAppointmentSlots": 11,
                     "name": "Burnet Rd H-E-B",
                     "longitude": -97.74016,
                     "latitude": 30.33374,
@@ -351,30 +344,38 @@
                     "city": "AUSTIN",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Moderna_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "78237-3134",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubAQAS",
                     "type": "store",
                     "street": "721 CASTROVILLE RD",
                     "storeNumber": 205,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 24,
+                            "openAppointmentSlots": 24,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 24,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 24,
                     "name": "Las Palmas H-E-B",
                     "longitude": -98.55132,
                     "latitude": 29.41734,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78040-5343",
@@ -385,15 +386,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 19,
-                            "openAppointmentSlots": 19,
+                            "openTimeslots": 34,
+                            "openAppointmentSlots": 34,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 19,
+                    "openTimeslots": 34,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 19,
+                    "openAppointmentSlots": 34,
                     "name": "Guadalupe and Stone H-E-B",
                     "longitude": -99.48344,
                     "latitude": 27.50656,
@@ -401,7 +402,8 @@
                     "city": "LAREDO",
                     "availableImmunizations": [
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "Flu"
                     ]
                 },
                 {
@@ -470,15 +472,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 78,
-                            "openAppointmentSlots": 78,
+                            "openTimeslots": 32,
+                            "openAppointmentSlots": 32,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 78,
+                    "openTimeslots": 32,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 78,
+                    "openAppointmentSlots": 32,
                     "name": "Parmer and Mopac H-E-B",
                     "longitude": -97.70326,
                     "latitude": 30.41883,
@@ -540,15 +542,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 226,
-                            "openAppointmentSlots": 226,
+                            "openTimeslots": 123,
+                            "openAppointmentSlots": 123,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 226,
+                    "openTimeslots": 123,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 226,
+                    "openAppointmentSlots": 123,
                     "name": "Alameda / Texan Trail (Medical District)",
                     "longitude": -97.3912,
                     "latitude": 27.75745,
@@ -569,27 +571,27 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 988,
-                            "openAppointmentSlots": 988,
+                            "openTimeslots": 1011,
+                            "openAppointmentSlots": 1011,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 988,
+                    "openTimeslots": 1011,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 988,
+                    "openAppointmentSlots": 1011,
                     "name": "Brenham H-E-B",
                     "longitude": -96.39591,
                     "latitude": 30.14381,
                     "fluUrl": "",
                     "city": "BRENHAM",
                     "availableImmunizations": [
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Moderna_Updated_Booster",
                         "Flu",
                         "COVID-19 Pfizer",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -613,22 +615,36 @@
                 },
                 {
                     "zip": "78945-2655",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Guc3QAC",
                     "type": "store",
                     "street": "450 E. TRAVIS",
                     "storeNumber": 416,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 30,
+                            "openAppointmentSlots": 30,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 30,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 30,
                     "name": "La Grange H-E-B",
                     "longitude": -96.87264,
                     "latitude": 29.9073,
                     "fluUrl": "",
                     "city": "LA GRANGE",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
+                    ]
                 },
                 {
                     "zip": "78840-4658",
@@ -734,22 +750,21 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 211,
-                            "openAppointmentSlots": 211,
+                            "openTimeslots": 58,
+                            "openAppointmentSlots": 58,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 211,
+                    "openTimeslots": 58,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 211,
+                    "openAppointmentSlots": 58,
                     "name": "Hancock Center H-E-B",
                     "longitude": -97.71973,
                     "latitude": 30.30057,
                     "fluUrl": "",
                     "city": "AUSTIN",
                     "availableImmunizations": [
-                        "Flu",
                         "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Moderna_Updated_Booster"
                     ]
@@ -763,15 +778,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 68,
-                            "openAppointmentSlots": 68,
+                            "openTimeslots": 16,
+                            "openAppointmentSlots": 16,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 68,
+                    "openTimeslots": 16,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 68,
+                    "openAppointmentSlots": 16,
                     "name": "Waxahachie H-E-B",
                     "longitude": -96.83983,
                     "latitude": 32.41159,
@@ -797,15 +812,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 353,
-                            "openAppointmentSlots": 353,
+                            "openTimeslots": 262,
+                            "openAppointmentSlots": 262,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 353,
+                    "openTimeslots": 262,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 353,
+                    "openAppointmentSlots": 262,
                     "name": "Military and Pleasanton H-E-B",
                     "longitude": -98.50277,
                     "latitude": 29.35666,
@@ -831,15 +846,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 553,
-                            "openAppointmentSlots": 553,
+                            "openTimeslots": 386,
+                            "openAppointmentSlots": 386,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 553,
+                    "openTimeslots": 386,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 553,
+                    "openAppointmentSlots": 386,
                     "name": "Blanco and West Ave H-E-B",
                     "longitude": -98.51025,
                     "latitude": 29.54526,
@@ -848,7 +863,6 @@
                     "availableImmunizations": [
                         "COVID-19 Pfizer",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster",
                         "Flu"
                     ]
                 },
@@ -861,15 +875,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 496,
-                            "openAppointmentSlots": 496,
+                            "openTimeslots": 465,
+                            "openAppointmentSlots": 465,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 496,
+                    "openTimeslots": 465,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 496,
+                    "openAppointmentSlots": 465,
                     "name": "Pflugerville H-E-B",
                     "longitude": -97.6133,
                     "latitude": 30.4373,
@@ -896,15 +910,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 155,
-                            "openAppointmentSlots": 155,
+                            "openTimeslots": 41,
+                            "openAppointmentSlots": 41,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 155,
+                    "openTimeslots": 41,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 155,
+                    "openAppointmentSlots": 41,
                     "name": "I10 and Wurzbach H-E-B",
                     "longitude": -98.5595,
                     "latitude": 29.5336,
@@ -912,10 +926,10 @@
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
@@ -947,15 +961,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 22,
-                            "openAppointmentSlots": 22,
+                            "openTimeslots": 5,
+                            "openAppointmentSlots": 5,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 22,
+                    "openTimeslots": 5,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 22,
+                    "openAppointmentSlots": 5,
                     "name": "Williams Drive H-E-B",
                     "longitude": -97.71873,
                     "latitude": 30.68312,
@@ -977,15 +991,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 21,
-                            "openAppointmentSlots": 21,
+                            "openTimeslots": 44,
+                            "openAppointmentSlots": 44,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 21,
+                    "openTimeslots": 44,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 21,
+                    "openAppointmentSlots": 44,
                     "name": "Elsa H-E-B",
                     "longitude": -97.99272,
                     "latitude": 26.29384,
@@ -993,8 +1007,8 @@
                     "city": "ELSA",
                     "availableImmunizations": [
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "Flu"
+                        "Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -1006,32 +1020,33 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 556,
-                            "openAppointmentSlots": 556,
+                            "openTimeslots": 528,
+                            "openAppointmentSlots": 528,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 556,
+                    "openTimeslots": 528,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 556,
+                    "openAppointmentSlots": 528,
                     "name": "Valley Hi H-E-B",
                     "longitude": -98.64021,
                     "latitude": 29.38099,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "Senior_Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
                         "COVID-19 Novavax",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Moderna_Updated_Booster"
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Ultra_Pediatric_Moderna_Updated_Booster",
+                        "Flu",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -1062,23 +1077,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 12,
-                            "openAppointmentSlots": 12,
+                            "openTimeslots": 58,
+                            "openAppointmentSlots": 58,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 12,
+                    "openTimeslots": 58,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 12,
+                    "openAppointmentSlots": 58,
                     "name": "Creekside Park H-E-B",
                     "longitude": -95.55072,
                     "latitude": 30.14362,
                     "fluUrl": "",
                     "city": "TOMBALL",
                     "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster",
+                        "Senior_Flu",
                         "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
@@ -1091,15 +1108,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 315,
-                            "openAppointmentSlots": 315,
+                            "openTimeslots": 228,
+                            "openAppointmentSlots": 228,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 315,
+                    "openTimeslots": 228,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 315,
+                    "openAppointmentSlots": 228,
                     "name": "San Felipe H-E-B",
                     "longitude": -95.48512,
                     "latitude": 29.74797,
@@ -1141,15 +1158,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 186,
-                            "openAppointmentSlots": 186,
+                            "openTimeslots": 73,
+                            "openAppointmentSlots": 73,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 186,
+                    "openTimeslots": 73,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 186,
+                    "openAppointmentSlots": 73,
                     "name": "Bandera and Guilbeau H-E-B",
                     "longitude": -98.64364,
                     "latitude": 29.51985,
@@ -1172,15 +1189,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 260,
-                            "openAppointmentSlots": 260,
+                            "openTimeslots": 121,
+                            "openAppointmentSlots": 121,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 260,
+                    "openTimeslots": 121,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 260,
+                    "openAppointmentSlots": 121,
                     "name": "Oak Hill H-E-B",
                     "longitude": -97.88755,
                     "latitude": 30.22696,
@@ -1258,15 +1275,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 120,
-                            "openAppointmentSlots": 120,
+                            "openTimeslots": 48,
+                            "openAppointmentSlots": 48,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 120,
+                    "openTimeslots": 48,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 120,
+                    "openAppointmentSlots": 48,
                     "name": "Military and Goliad H-E-B",
                     "longitude": -98.4362,
                     "latitude": 29.35194,
@@ -1305,7 +1322,9 @@
                     "city": "LOCKHART",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -1348,22 +1367,36 @@
                 },
                 {
                     "zip": "78374-2816",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuccQAC",
                     "type": "store",
                     "street": "1600 WILDCAT DRIVE",
                     "storeNumber": 488,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 64,
+                            "openAppointmentSlots": 64,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 64,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 64,
                     "name": "Portland H-E-B",
                     "longitude": -97.31836,
                     "latitude": 27.88722,
                     "fluUrl": "",
                     "city": "PORTLAND",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
+                    ]
                 },
                 {
                     "zip": "78521-2216",
@@ -1374,15 +1407,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 51,
-                            "openAppointmentSlots": 51,
+                            "openTimeslots": 40,
+                            "openAppointmentSlots": 40,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 51,
+                    "openTimeslots": 40,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 51,
+                    "openAppointmentSlots": 40,
                     "name": "Boca Chica H-E-B",
                     "longitude": -97.48722,
                     "latitude": 25.92214,
@@ -1409,23 +1442,21 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 126,
-                            "openAppointmentSlots": 126,
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 126,
+                    "openTimeslots": 20,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 126,
+                    "openAppointmentSlots": 20,
                     "name": "Fry Rd and I10 H-E-B",
                     "longitude": -95.7189,
                     "latitude": 29.7898,
                     "fluUrl": "",
                     "city": "HOUSTON",
                     "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
@@ -1438,15 +1469,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 269,
-                            "openAppointmentSlots": 269,
+                            "openTimeslots": 106,
+                            "openAppointmentSlots": 106,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 269,
+                    "openTimeslots": 106,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 269,
+                    "openAppointmentSlots": 106,
                     "name": "Culebra and 1604 H-E-B",
                     "longitude": -98.70445,
                     "latitude": 29.49292,
@@ -1493,26 +1524,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 129,
-                            "openAppointmentSlots": 129,
+                            "openTimeslots": 75,
+                            "openAppointmentSlots": 75,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 129,
+                    "openTimeslots": 75,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 129,
+                    "openAppointmentSlots": 75,
                     "name": "Kenedy H-E-B",
                     "longitude": -97.85797,
                     "latitude": 28.81419,
                     "fluUrl": "",
                     "city": "KENEDY",
                     "availableImmunizations": [
+                        "Flu",
                         "COVID-19 Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "Flu",
-                        "COVID-19 Pediatric_Pfizer"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -1524,15 +1554,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 151,
-                            "openAppointmentSlots": 151,
+                            "openTimeslots": 54,
+                            "openAppointmentSlots": 54,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 151,
+                    "openTimeslots": 54,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 151,
+                    "openAppointmentSlots": 54,
                     "name": "New Braunfels H-E-B plus!",
                     "longitude": -98.0782,
                     "latitude": 29.731,
@@ -1553,15 +1583,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 31,
-                            "openAppointmentSlots": 31,
+                            "openTimeslots": 6,
+                            "openAppointmentSlots": 6,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 31,
+                    "openTimeslots": 6,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 31,
+                    "openAppointmentSlots": 6,
                     "name": "Gattis School H-E-B plus! Hutto",
                     "longitude": -97.58284,
                     "latitude": 30.50112,
@@ -1581,15 +1611,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 559,
-                            "openAppointmentSlots": 559,
+                            "openTimeslots": 552,
+                            "openAppointmentSlots": 552,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 559,
+                    "openTimeslots": 552,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 559,
+                    "openAppointmentSlots": 552,
                     "name": "League City Market H-E-B",
                     "longitude": -95.04131,
                     "latitude": 29.50588,
@@ -1597,10 +1627,10 @@
                     "city": "LEAGUE CITY",
                     "availableImmunizations": [
                         "COVID-19 Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Moderna_Updated_Booster",
                         "Senior_Flu",
                         "Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
@@ -1644,32 +1674,22 @@
                 },
                 {
                     "zip": "77059-2511",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueIQAS",
+                    "url": null,
                     "type": "store",
                     "street": "3501 CLEAR LAKE CITY BLVD",
                     "storeNumber": 713,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 78,
-                            "openAppointmentSlots": 78,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 78,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 78,
+                    "openAppointmentSlots": 0,
                     "name": "Clear Lake Marketplace H-E-B",
                     "longitude": -95.12473,
                     "latitude": 29.60563,
                     "fluUrl": "",
                     "city": "HOUSTON",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78734-6238",
@@ -1680,15 +1700,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 19,
-                            "openAppointmentSlots": 19,
+                            "openTimeslots": 8,
+                            "openAppointmentSlots": 8,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 19,
+                    "openTimeslots": 8,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 19,
+                    "openAppointmentSlots": 8,
                     "name": "Lakeway H-E-B",
                     "longitude": -97.96662,
                     "latitude": 30.34368,
@@ -1765,15 +1785,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 66,
-                            "openAppointmentSlots": 66,
+                            "openTimeslots": 21,
+                            "openAppointmentSlots": 21,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 66,
+                    "openTimeslots": 21,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 66,
+                    "openAppointmentSlots": 21,
                     "name": "Tomball Pkwy and Graham H-E-B",
                     "longitude": -95.63218,
                     "latitude": 30.08868,
@@ -1787,7 +1807,6 @@
                         "COVID-19 Pediatric_Moderna",
                         "COVID-19 Novavax",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster",
                         "Senior_Flu"
                     ]
@@ -1820,15 +1839,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 90,
-                            "openAppointmentSlots": 90,
+                            "openTimeslots": 52,
+                            "openAppointmentSlots": 52,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 90,
+                    "openTimeslots": 52,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 90,
+                    "openAppointmentSlots": 52,
                     "name": "Kempwood and Gessner H-E-B",
                     "longitude": -95.5468,
                     "latitude": 29.8226,
@@ -1907,50 +1926,58 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 376,
-                            "openAppointmentSlots": 376,
+                            "openTimeslots": 222,
+                            "openAppointmentSlots": 222,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 376,
+                    "openTimeslots": 222,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 376,
+                    "openAppointmentSlots": 222,
                     "name": "Slaughter and Manchaca H-E-B",
                     "longitude": -97.82509,
                     "latitude": 30.17524,
                     "fluUrl": "",
                     "city": "AUSTIN",
                     "availableImmunizations": [
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
                         "Flu",
                         "Senior_Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Novavax"
                     ]
                 },
                 {
                     "zip": "78744-3410",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubLQAS",
                     "type": "store",
                     "street": "6607 SOUTH IH 35",
                     "storeNumber": 229,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 18,
+                            "openAppointmentSlots": 18,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 18,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 18,
                     "name": "I 35 and William Cannon H-E-B",
                     "longitude": -97.76922,
                     "latitude": 30.19107,
                     "fluUrl": "",
                     "city": "AUSTIN",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78247-1979",
@@ -1961,25 +1988,25 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 471,
-                            "openAppointmentSlots": 471,
+                            "openTimeslots": 182,
+                            "openAppointmentSlots": 182,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 471,
+                    "openTimeslots": 182,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 471,
+                    "openAppointmentSlots": 182,
                     "name": "Nacogdoches and O'Connor H-E-B",
                     "longitude": -98.3856,
                     "latitude": 29.56937,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
-                        "Flu",
-                        "Senior_Flu",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
+                        "Flu",
+                        "Senior_Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster"
@@ -2070,15 +2097,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 83,
-                            "openAppointmentSlots": 83,
+                            "openTimeslots": 46,
+                            "openAppointmentSlots": 46,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 83,
+                    "openTimeslots": 46,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 83,
+                    "openAppointmentSlots": 46,
                     "name": "Gulfgate H-E-B",
                     "longitude": -95.2968,
                     "latitude": 29.6994,
@@ -2101,22 +2128,35 @@
                 },
                 {
                     "zip": "77072-5000",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuckQAC",
                     "type": "store",
                     "street": "10100 BEECHNUT",
                     "storeNumber": 541,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 102,
+                            "openAppointmentSlots": 102,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 102,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 102,
                     "name": "Beechnut H-E-B",
                     "longitude": -95.5604,
                     "latitude": 29.6896,
                     "fluUrl": "",
                     "city": "HOUSTON",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Senior_Flu"
+                    ]
                 },
                 {
                     "zip": "77840-3914",
@@ -2127,15 +2167,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 108,
-                            "openAppointmentSlots": 108,
+                            "openTimeslots": 118,
+                            "openAppointmentSlots": 118,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 108,
+                    "openTimeslots": 118,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 108,
+                    "openAppointmentSlots": 118,
                     "name": "Texas Avenue H-E-B",
                     "longitude": -96.3165,
                     "latitude": 30.6131,
@@ -2150,36 +2190,22 @@
                 },
                 {
                     "zip": "77429-6286",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gue7QAC",
+                    "url": null,
                     "type": "store",
                     "street": "14100 SPRING CYPRESS RD",
                     "storeNumber": 698,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 35,
-                            "openAppointmentSlots": 35,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 35,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 35,
+                    "openAppointmentSlots": 0,
                     "name": "Grant and Spring Cypress H-E-B",
                     "longitude": -95.63698,
                     "latitude": 30.00365,
                     "fluUrl": "",
                     "city": "CYPRESS",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "Senior_Flu"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78204-2427",
@@ -2190,15 +2216,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 363,
-                            "openAppointmentSlots": 363,
+                            "openTimeslots": 423,
+                            "openAppointmentSlots": 423,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 363,
+                    "openTimeslots": 423,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 363,
+                    "openAppointmentSlots": 423,
                     "name": "Nogalitos H-E-B",
                     "longitude": -98.51485,
                     "latitude": 29.39799,
@@ -2280,15 +2306,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 100,
-                            "openAppointmentSlots": 100,
+                            "openTimeslots": 40,
+                            "openAppointmentSlots": 40,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 100,
+                    "openTimeslots": 40,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 100,
+                    "openAppointmentSlots": 40,
                     "name": "Spring Creek Market H-E-B",
                     "longitude": -95.38801,
                     "latitude": 30.11036,
@@ -2364,23 +2390,21 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 22,
-                            "openAppointmentSlots": 22,
+                            "openTimeslots": 6,
+                            "openAppointmentSlots": 6,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 22,
+                    "openTimeslots": 6,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 22,
+                    "openAppointmentSlots": 6,
                     "name": "Fort Hood Stan Schlueter H-E-B",
                     "longitude": -97.75988,
                     "latitude": 31.07989,
                     "fluUrl": "",
                     "city": "KILLEEN",
                     "availableImmunizations": [
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster",
                         "Flu"
                     ]
                 },
@@ -2412,15 +2436,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 297,
-                            "openAppointmentSlots": 297,
+                            "openTimeslots": 146,
+                            "openAppointmentSlots": 146,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 297,
+                    "openTimeslots": 146,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 297,
+                    "openAppointmentSlots": 146,
                     "name": "Aliana Market H-E-B",
                     "longitude": -95.7137,
                     "latitude": 29.6597,
@@ -2441,15 +2465,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 38,
-                            "openAppointmentSlots": 38,
+                            "openTimeslots": 13,
+                            "openAppointmentSlots": 13,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 38,
+                    "openTimeslots": 13,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 38,
+                    "openAppointmentSlots": 13,
                     "name": "Palmview H-E-B",
                     "longitude": -98.38385,
                     "latitude": 26.23538,
@@ -2469,15 +2493,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 33,
-                            "openAppointmentSlots": 33,
+                            "openTimeslots": 21,
+                            "openAppointmentSlots": 21,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 33,
+                    "openTimeslots": 21,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 33,
+                    "openAppointmentSlots": 21,
                     "name": "Four Points H-E-B",
                     "longitude": -97.85202,
                     "latitude": 30.40458,
@@ -2539,29 +2563,29 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 247,
-                            "openAppointmentSlots": 247,
+                            "openTimeslots": 273,
+                            "openAppointmentSlots": 273,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 247,
+                    "openTimeslots": 273,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 247,
+                    "openAppointmentSlots": 273,
                     "name": "Loop 1604 and Blanco Rd H-E-B plus!",
                     "longitude": -98.50968,
                     "latitude": 29.60792,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
+                        "COVID-19 Ultra_Pediatric_Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
                         "Flu",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Moderna",
-                        "COVID-19 Novavax",
                         "COVID-19 Pfizer",
+                        "COVID-19 Novavax",
                         "COVID-19 Pediatric_Moderna_Updated_Booster",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
@@ -2574,15 +2598,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 902,
-                            "openAppointmentSlots": 902,
+                            "openTimeslots": 684,
+                            "openAppointmentSlots": 684,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 902,
+                    "openTimeslots": 684,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 902,
+                    "openAppointmentSlots": 684,
                     "name": "7th Street H-E-B",
                     "longitude": -97.71143,
                     "latitude": 30.26046,
@@ -2693,15 +2717,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 42,
-                            "openAppointmentSlots": 42,
+                            "openTimeslots": 15,
+                            "openAppointmentSlots": 15,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 42,
+                    "openTimeslots": 15,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 42,
+                    "openAppointmentSlots": 15,
                     "name": "Elgin H-E-B",
                     "longitude": -97.38258,
                     "latitude": 30.34701,
@@ -2722,15 +2746,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 30,
-                            "openAppointmentSlots": 30,
+                            "openTimeslots": 27,
+                            "openAppointmentSlots": 27,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 30,
+                    "openTimeslots": 27,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 30,
+                    "openAppointmentSlots": 27,
                     "name": "Tech Ridge H-E-B",
                     "longitude": -97.67201,
                     "latitude": 30.40443,
@@ -2755,15 +2779,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 49,
-                            "openAppointmentSlots": 49,
+                            "openTimeslots": 39,
+                            "openAppointmentSlots": 39,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 49,
+                    "openTimeslots": 39,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 49,
+                    "openAppointmentSlots": 39,
                     "name": "Buda H-E-B",
                     "longitude": -97.82074,
                     "latitude": 30.08769,
@@ -2771,7 +2795,6 @@
                     "city": "BUDA",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
@@ -2787,15 +2810,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 253,
-                            "openAppointmentSlots": 253,
+                            "openTimeslots": 591,
+                            "openAppointmentSlots": 591,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 253,
+                    "openTimeslots": 591,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 253,
+                    "openAppointmentSlots": 591,
                     "name": "Grissom and Tezel H-E-B",
                     "longitude": -98.66574,
                     "latitude": 29.48432,
@@ -2803,36 +2826,30 @@
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
                         "Flu",
-                        "Senior_Flu"
+                        "Senior_Flu",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "78626-5400",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubRQAS",
+                    "url": null,
                     "type": "store",
                     "street": "1100 SOUTH IH35",
                     "storeNumber": 237,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 12,
-                            "openAppointmentSlots": 12,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 12,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 12,
+                    "openAppointmentSlots": 0,
                     "name": "35 and West University H-E-B",
                     "longitude": -97.69028,
                     "latitude": 30.63446,
                     "fluUrl": "",
                     "city": "GEORGETOWN",
-                    "availableImmunizations": [
-                        "Flu",
-                        "Senior_Flu"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "75110-5138",
@@ -2843,15 +2860,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 19,
-                            "openAppointmentSlots": 19,
+                            "openTimeslots": 1,
+                            "openAppointmentSlots": 1,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 19,
+                    "openTimeslots": 1,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 19,
+                    "openAppointmentSlots": 1,
                     "name": "Corsicana H-E-B",
                     "longitude": -96.46827,
                     "latitude": 32.09005,
@@ -2873,24 +2890,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 211,
-                            "openAppointmentSlots": 211,
+                            "openTimeslots": 424,
+                            "openAppointmentSlots": 424,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 211,
+                    "openTimeslots": 424,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 211,
+                    "openAppointmentSlots": 424,
                     "name": "East Hopkins H-E-B",
                     "longitude": -97.93132,
                     "latitude": 29.88489,
                     "fluUrl": "",
                     "city": "SAN MARCOS",
                     "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster",
                         "Flu",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -2933,22 +2950,31 @@
                 },
                 {
                     "zip": "77077-6860",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GucnQAC",
                     "type": "store",
                     "street": "11815 WESTHEIMER",
                     "storeNumber": 551,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 84,
+                            "openAppointmentSlots": 84,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 84,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 84,
                     "name": "Westheimer and Kirkwood H-E-B",
                     "longitude": -95.587,
                     "latitude": 29.7363,
                     "fluUrl": "",
                     "city": "HOUSTON",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Senior_Flu",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77084-2718",
@@ -2959,15 +2985,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 210,
-                            "openAppointmentSlots": 210,
+                            "openTimeslots": 155,
+                            "openAppointmentSlots": 155,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 210,
+                    "openTimeslots": 155,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 210,
+                    "openAppointmentSlots": 155,
                     "name": "Bear Creek H-E-B",
                     "longitude": -95.6457,
                     "latitude": 29.8487,
@@ -3069,15 +3095,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 703,
-                            "openAppointmentSlots": 703,
+                            "openTimeslots": 496,
+                            "openAppointmentSlots": 496,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 703,
+                    "openTimeslots": 496,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 703,
+                    "openAppointmentSlots": 496,
                     "name": "Friendswood H-E-B",
                     "longitude": -95.1912,
                     "latitude": 29.5066,
@@ -3100,24 +3126,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 205,
-                            "openAppointmentSlots": 205,
+                            "openTimeslots": 91,
+                            "openAppointmentSlots": 91,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 205,
+                    "openTimeslots": 91,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 205,
+                    "openAppointmentSlots": 91,
                     "name": "Lake Jackson H-E-B",
                     "longitude": -95.44554,
                     "latitude": 29.04151,
                     "fluUrl": "",
                     "city": "LAKE JACKSON",
                     "availableImmunizations": [
-                        "Flu",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Flu"
                     ]
                 },
                 {
@@ -3129,15 +3155,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 112,
-                            "openAppointmentSlots": 112,
+                            "openTimeslots": 50,
+                            "openAppointmentSlots": 50,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 112,
+                    "openTimeslots": 50,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 112,
+                    "openAppointmentSlots": 50,
                     "name": "Wimberley H-E-B",
                     "longitude": -98.10174,
                     "latitude": 30.00144,
@@ -3158,15 +3184,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 240,
-                            "openAppointmentSlots": 240,
+                            "openTimeslots": 173,
+                            "openAppointmentSlots": 173,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 240,
+                    "openTimeslots": 173,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 240,
+                    "openAppointmentSlots": 173,
                     "name": "H-E-B Market at Tuckerton",
                     "longitude": -95.72501,
                     "latitude": 29.92737,
@@ -3176,9 +3202,6 @@
                         "Flu",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Novavax",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Moderna_Updated_Booster"
                     ]
                 },
@@ -3191,15 +3214,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 422,
-                            "openAppointmentSlots": 422,
+                            "openTimeslots": 303,
+                            "openAppointmentSlots": 303,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 422,
+                    "openTimeslots": 303,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 422,
+                    "openAppointmentSlots": 303,
                     "name": "Champion Forest Market H-E-B",
                     "longitude": -95.57475,
                     "latitude": 30.0551,
@@ -3213,22 +3236,38 @@
                 },
                 {
                     "zip": "77469-2509",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GueSQAS",
                     "type": "store",
                     "street": "23500 CIRCLE OAK PARKWAY",
                     "storeNumber": 727,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 27,
+                            "openAppointmentSlots": 27,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 27,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 27,
                     "name": "Richmond Market H-E-B",
                     "longitude": -95.74781,
                     "latitude": 29.55142,
                     "fluUrl": "",
                     "city": "RICHMOND",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Janssen",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
+                    ]
                 },
                 {
                     "zip": "77340-3723",
@@ -3239,15 +3278,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 90,
-                            "openAppointmentSlots": 90,
+                            "openTimeslots": 35,
+                            "openAppointmentSlots": 35,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 90,
+                    "openTimeslots": 35,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 90,
+                    "openAppointmentSlots": 35,
                     "name": "Huntsville H-E-B",
                     "longitude": -95.56075,
                     "latitude": 30.72274,
@@ -3271,15 +3310,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 433,
-                            "openAppointmentSlots": 433,
+                            "openTimeslots": 317,
+                            "openAppointmentSlots": 317,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 433,
+                    "openTimeslots": 317,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 433,
+                    "openAppointmentSlots": 317,
                     "name": "Bulverde and 1604 H-E-B",
                     "longitude": -98.41746,
                     "latitude": 29.59497,
@@ -3296,22 +3335,30 @@
                 },
                 {
                     "zip": "78041-5754",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubVQAS",
                     "type": "store",
                     "street": "4801 SAN DARIO",
                     "storeNumber": 255,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 5,
+                            "openAppointmentSlots": 5,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 5,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 5,
                     "name": "35 and Calton H-E-B",
                     "longitude": -99.50182,
                     "latitude": 27.54172,
                     "fluUrl": "",
                     "city": "LAREDO",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78238-1986",
@@ -3341,23 +3388,31 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 83,
-                            "openAppointmentSlots": 83,
+                            "openTimeslots": 107,
+                            "openAppointmentSlots": 107,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 83,
+                    "openTimeslots": 107,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 83,
+                    "openAppointmentSlots": 107,
                     "name": "Central Blvd H-E-B",
                     "longitude": -97.51093,
                     "latitude": 25.92849,
                     "fluUrl": "",
                     "city": "BROWNSVILLE",
                     "availableImmunizations": [
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "COVID-19 Ultra_Pediatric_Moderna_Updated_Booster",
                         "Flu",
-                        "Senior_Flu"
+                        "Senior_Flu",
+                        "COVID-19 Pediatric_Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer"
                     ]
                 },
                 {
@@ -3369,15 +3424,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 48,
-                            "openAppointmentSlots": 48,
+                            "openTimeslots": 97,
+                            "openAppointmentSlots": 97,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 48,
+                    "openTimeslots": 97,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 48,
+                    "openAppointmentSlots": 97,
                     "name": "Hwy 183 and Whitestone Blvd H-E-B",
                     "longitude": -97.82911,
                     "latitude": 30.5225,
@@ -3387,6 +3442,7 @@
                         "Flu",
                         "COVID-19 Moderna_Updated_Booster",
                         "Senior_Flu",
+                        "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
@@ -3399,15 +3455,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 52,
-                            "openAppointmentSlots": 52,
+                            "openTimeslots": 80,
+                            "openAppointmentSlots": 80,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 52,
+                    "openTimeslots": 80,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 52,
+                    "openAppointmentSlots": 80,
                     "name": "North Hills H-E-B",
                     "longitude": -97.74832,
                     "latitude": 30.39868,
@@ -3447,15 +3503,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 40,
-                            "openAppointmentSlots": 40,
+                            "openTimeslots": 14,
+                            "openAppointmentSlots": 14,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 40,
+                    "openTimeslots": 14,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 40,
+                    "openAppointmentSlots": 14,
                     "name": "Fredericksburg H-E-B",
                     "longitude": -98.87538,
                     "latitude": 30.27006,
@@ -3464,7 +3520,6 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster",
                         "Senior_Flu"
                     ]
                 },
@@ -3496,15 +3551,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 226,
-                            "openAppointmentSlots": 226,
+                            "openTimeslots": 107,
+                            "openAppointmentSlots": 107,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 226,
+                    "openTimeslots": 107,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 226,
+                    "openAppointmentSlots": 107,
                     "name": "Riverpark H-E-B",
                     "longitude": -95.6815,
                     "latitude": 29.5636,
@@ -3513,12 +3568,10 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "COVID-19 Moderna",
-                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pediatric_Moderna_Updated_Booster",
                         "Senior_Flu",
-                        "COVID-19 Novavax"
+                        "COVID-19 Novavax",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -3530,15 +3583,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 58,
-                            "openAppointmentSlots": 58,
+                            "openTimeslots": 43,
+                            "openAppointmentSlots": 43,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 58,
+                    "openTimeslots": 43,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 58,
+                    "openAppointmentSlots": 43,
                     "name": "Sawdust Rd and 45 H-E-B",
                     "longitude": -95.44512,
                     "latitude": 30.12684,
@@ -3547,8 +3600,6 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Moderna_Updated_Booster",
@@ -3565,15 +3616,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 125,
-                            "openAppointmentSlots": 125,
+                            "openTimeslots": 91,
+                            "openAppointmentSlots": 91,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 125,
+                    "openTimeslots": 91,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 125,
+                    "openAppointmentSlots": 91,
                     "name": "Leon Springs H-E-B",
                     "longitude": -98.63218,
                     "latitude": 29.6659,
@@ -3616,15 +3667,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 90,
-                            "openAppointmentSlots": 90,
+                            "openTimeslots": 39,
+                            "openAppointmentSlots": 39,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 90,
+                    "openTimeslots": 39,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 90,
+                    "openAppointmentSlots": 39,
                     "name": "Perrin Beitel and Thousand Oaks H-E-B",
                     "longitude": -98.4082,
                     "latitude": 29.5491,
@@ -3685,15 +3736,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 40,
-                            "openAppointmentSlots": 40,
+                            "openTimeslots": 58,
+                            "openAppointmentSlots": 58,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 40,
+                    "openTimeslots": 58,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 40,
+                    "openAppointmentSlots": 58,
                     "name": "Bay City H-E-B",
                     "longitude": -95.95804,
                     "latitude": 28.98306,
@@ -3789,15 +3840,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 48,
-                            "openAppointmentSlots": 48,
+                            "openTimeslots": 19,
+                            "openAppointmentSlots": 19,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 48,
+                    "openTimeslots": 19,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 48,
+                    "openAppointmentSlots": 19,
                     "name": "Kyle H-E-B plus!",
                     "longitude": -97.86258,
                     "latitude": 30.01533,
@@ -3826,15 +3877,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 14,
-                            "openAppointmentSlots": 14,
+                            "openTimeslots": 143,
+                            "openAppointmentSlots": 143,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 14,
+                    "openTimeslots": 143,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 14,
+                    "openAppointmentSlots": 143,
                     "name": "Burleson H-E-B plus!",
                     "longitude": -97.34901,
                     "latitude": 32.52083,
@@ -3842,11 +3893,13 @@
                     "city": "BURLESON",
                     "availableImmunizations": [
                         "Flu",
+                        "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -3858,15 +3911,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 318,
-                            "openAppointmentSlots": 318,
+                            "openTimeslots": 320,
+                            "openAppointmentSlots": 320,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 318,
+                    "openTimeslots": 320,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 318,
+                    "openAppointmentSlots": 320,
                     "name": "Lytle H-E-B plus!",
                     "longitude": -98.78924,
                     "latitude": 29.23224,
@@ -3892,15 +3945,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 161,
-                            "openAppointmentSlots": 161,
+                            "openTimeslots": 92,
+                            "openAppointmentSlots": 92,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 161,
+                    "openTimeslots": 92,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 161,
+                    "openAppointmentSlots": 92,
                     "name": "Cypress Market H-E-B",
                     "longitude": -95.6765,
                     "latitude": 29.95569,
@@ -3922,15 +3975,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 67,
-                            "openAppointmentSlots": 67,
+                            "openTimeslots": 33,
+                            "openAppointmentSlots": 33,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 67,
+                    "openTimeslots": 33,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 67,
+                    "openAppointmentSlots": 33,
                     "name": "Anderson Mill H-E-B plus!",
                     "longitude": -97.82626,
                     "latitude": 30.45495,
@@ -3938,13 +3991,12 @@
                     "city": "AUSTIN",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "Senior_Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Moderna_Updated_Booster"
+                        "Senior_Flu",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -3956,15 +4008,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 77,
-                            "openAppointmentSlots": 77,
+                            "openTimeslots": 28,
+                            "openAppointmentSlots": 28,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 77,
+                    "openTimeslots": 28,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 77,
+                    "openAppointmentSlots": 28,
                     "name": "Trimmier H-E-B plus!",
                     "longitude": -97.7338,
                     "latitude": 31.0909,
@@ -3994,15 +4046,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 41,
-                            "openAppointmentSlots": 41,
+                            "openTimeslots": 17,
+                            "openAppointmentSlots": 17,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 41,
+                    "openTimeslots": 17,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 41,
+                    "openAppointmentSlots": 17,
                     "name": "Bastrop H-E-B plus!",
                     "longitude": -97.33458,
                     "latitude": 30.10981,
@@ -4011,8 +4063,6 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Pfizer",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster",
                         "Senior_Flu"
                     ]
@@ -4064,15 +4114,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 155,
-                            "openAppointmentSlots": 155,
+                            "openTimeslots": 212,
+                            "openAppointmentSlots": 212,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 155,
+                    "openTimeslots": 212,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 155,
+                    "openAppointmentSlots": 212,
                     "name": "Austin Highway H-E-B",
                     "longitude": -98.43132,
                     "latitude": 29.4937,
@@ -4082,7 +4132,8 @@
                         "Flu",
                         "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer"
                     ]
                 },
                 {
@@ -4094,15 +4145,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 70,
-                            "openAppointmentSlots": 70,
+                            "openTimeslots": 40,
+                            "openAppointmentSlots": 40,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 70,
+                    "openTimeslots": 40,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 70,
+                    "openAppointmentSlots": 40,
                     "name": "Zapata Highway H-E-B",
                     "longitude": -99.47479,
                     "latitude": 27.47673,
@@ -4144,15 +4195,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 55,
-                            "openAppointmentSlots": 55,
+                            "openTimeslots": 14,
+                            "openAppointmentSlots": 14,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 55,
+                    "openTimeslots": 14,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 55,
+                    "openAppointmentSlots": 14,
                     "name": "Sherwood & FM 2288 H-E-B",
                     "longitude": -100.51103,
                     "latitude": 31.43158,
@@ -4171,15 +4222,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 89,
-                            "openAppointmentSlots": 89,
+                            "openTimeslots": 29,
+                            "openAppointmentSlots": 29,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 89,
+                    "openTimeslots": 29,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 89,
+                    "openAppointmentSlots": 29,
                     "name": "Cross Creek Ranch H-E-B",
                     "longitude": -95.84788,
                     "latitude": 29.71936,
@@ -4200,15 +4251,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 71,
-                            "openAppointmentSlots": 71,
+                            "openTimeslots": 23,
+                            "openAppointmentSlots": 23,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 71,
+                    "openTimeslots": 23,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 71,
+                    "openAppointmentSlots": 23,
                     "name": "The Heights H-E-B",
                     "longitude": -95.40865,
                     "latitude": 29.80735,
@@ -4230,15 +4281,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 74,
-                            "openAppointmentSlots": 74,
+                            "openTimeslots": 162,
+                            "openAppointmentSlots": 162,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 74,
+                    "openTimeslots": 162,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 74,
+                    "openAppointmentSlots": 162,
                     "name": "Bellaire Market H-E-B",
                     "longitude": -95.46938,
                     "latitude": 29.70764,
@@ -4248,7 +4299,6 @@
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
                         "COVID-19 Novavax",
@@ -4306,15 +4356,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 920,
-                            "openAppointmentSlots": 920,
+                            "openTimeslots": 743,
+                            "openAppointmentSlots": 743,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 920,
+                    "openTimeslots": 743,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 920,
+                    "openAppointmentSlots": 743,
                     "name": "McCreless Market H-E-B plus!",
                     "longitude": -98.46115,
                     "latitude": 29.37828,
@@ -4373,39 +4423,22 @@
                 },
                 {
                     "zip": "78750-3222",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuaOQAS",
+                    "url": null,
                     "type": "store",
                     "street": "12860 RESEARCH BLVD",
                     "storeNumber": 31,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 31,
-                            "openAppointmentSlots": 31,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 31,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 31,
+                    "openAppointmentSlots": 0,
                     "name": "Spicewood Springs H-E-B",
                     "longitude": -97.7713,
                     "latitude": 30.43494,
                     "fluUrl": "",
                     "city": "AUSTIN",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
-                        "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Novavax",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "Senior_Flu"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "78664-4642",
@@ -4416,15 +4449,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 320,
-                            "openAppointmentSlots": 320,
+                            "openTimeslots": 307,
+                            "openAppointmentSlots": 307,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 320,
+                    "openTimeslots": 307,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 320,
+                    "openAppointmentSlots": 307,
                     "name": "Gattis School H-E-B Round Rock",
                     "longitude": -97.61475,
                     "latitude": 30.49721,
@@ -4485,15 +4518,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 896,
-                            "openAppointmentSlots": 896,
+                            "openTimeslots": 352,
+                            "openAppointmentSlots": 352,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 896,
+                    "openTimeslots": 352,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 896,
+                    "openAppointmentSlots": 352,
                     "name": "620 and O'Connor H-E-B",
                     "longitude": -97.72218,
                     "latitude": 30.50028,
@@ -4519,15 +4552,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 79,
-                            "openAppointmentSlots": 79,
+                            "openTimeslots": 173,
+                            "openAppointmentSlots": 173,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 79,
+                    "openTimeslots": 173,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 79,
+                    "openAppointmentSlots": 173,
                     "name": "New Braunfels H-E-B at Walnut",
                     "longitude": -98.12631,
                     "latitude": 29.68903,
@@ -4570,24 +4603,22 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 96,
-                            "openAppointmentSlots": 96,
+                            "openTimeslots": 9,
+                            "openAppointmentSlots": 9,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 96,
+                    "openTimeslots": 9,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 96,
+                    "openAppointmentSlots": 9,
                     "name": "West Wadley H-E-B",
                     "longitude": -102.12562,
                     "latitude": 32.01955,
                     "fluUrl": "",
                     "city": "MIDLAND",
                     "availableImmunizations": [
-                        "COVID-19 Moderna_Updated_Booster",
-                        "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -4599,15 +4630,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 390,
-                            "openAppointmentSlots": 390,
+                            "openTimeslots": 291,
+                            "openAppointmentSlots": 291,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 390,
+                    "openTimeslots": 291,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 390,
+                    "openAppointmentSlots": 291,
                     "name": "Montgomery at Walzem",
                     "longitude": -98.37092,
                     "latitude": 29.5105,
@@ -4632,15 +4663,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 168,
-                            "openAppointmentSlots": 168,
+                            "openTimeslots": 110,
+                            "openAppointmentSlots": 110,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 168,
+                    "openTimeslots": 110,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 168,
+                    "openAppointmentSlots": 110,
                     "name": "Olmos Park H-E-B",
                     "longitude": -98.497,
                     "latitude": 29.4707,
@@ -4674,22 +4705,39 @@
                 },
                 {
                     "zip": "78727-3901",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GubqQAC",
                     "type": "store",
                     "street": "6001 WEST PARMER LANE",
                     "storeNumber": 388,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 52,
+                            "openAppointmentSlots": 52,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 52,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 52,
                     "name": "Parmer and McNeil H-E-B",
                     "longitude": -97.74278,
                     "latitude": 30.44181,
                     "fluUrl": "",
                     "city": "AUSTIN",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Senior_Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77642-7403",
@@ -4700,15 +4748,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 130,
-                            "openAppointmentSlots": 130,
+                            "openTimeslots": 86,
+                            "openAppointmentSlots": 86,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 130,
+                    "openTimeslots": 86,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 130,
+                    "openAppointmentSlots": 86,
                     "name": "Mid County H-E-B",
                     "longitude": -93.9758,
                     "latitude": 29.966,
@@ -4755,15 +4803,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 45,
-                            "openAppointmentSlots": 45,
+                            "openTimeslots": 48,
+                            "openAppointmentSlots": 48,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 45,
+                    "openTimeslots": 48,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 45,
+                    "openAppointmentSlots": 48,
                     "name": "Leander H-E-B plus!",
                     "longitude": -97.8582,
                     "latitude": 30.58369,
@@ -4803,15 +4851,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 413,
-                            "openAppointmentSlots": 413,
+                            "openTimeslots": 233,
+                            "openAppointmentSlots": 233,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 413,
+                    "openTimeslots": 233,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 413,
+                    "openAppointmentSlots": 233,
                     "name": "Buffalo Heights H-E-B On Washington Ave",
                     "longitude": -95.39658,
                     "latitude": 29.76901,
@@ -4820,8 +4868,8 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
-                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
@@ -4835,15 +4883,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 76,
-                            "openAppointmentSlots": 76,
+                            "openTimeslots": 26,
+                            "openAppointmentSlots": 26,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 76,
+                    "openTimeslots": 26,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 76,
+                    "openAppointmentSlots": 26,
                     "name": "Meyerland Market H-E-B",
                     "longitude": -95.46406,
                     "latitude": 29.68854,
@@ -4864,15 +4912,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 14,
-                            "openAppointmentSlots": 14,
+                            "openTimeslots": 66,
+                            "openAppointmentSlots": 66,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 14,
+                    "openTimeslots": 66,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 14,
+                    "openAppointmentSlots": 66,
                     "name": "Jones Crossing H-E-B",
                     "longitude": -96.32324,
                     "latitude": 30.58444,
@@ -4880,9 +4928,7 @@
                     "city": "COLLEGE STATION",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster",
                         "Senior_Flu"
                     ]
@@ -4934,15 +4980,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 76,
-                            "openAppointmentSlots": 76,
+                            "openTimeslots": 55,
+                            "openAppointmentSlots": 55,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 76,
+                    "openTimeslots": 55,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 76,
+                    "openAppointmentSlots": 55,
                     "name": "South Congress H-E-B",
                     "longitude": -97.7516,
                     "latitude": 30.23963,
@@ -4950,8 +4996,7 @@
                     "city": "AUSTIN",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -4963,15 +5008,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 114,
-                            "openAppointmentSlots": 114,
+                            "openTimeslots": 84,
+                            "openAppointmentSlots": 84,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 114,
+                    "openTimeslots": 84,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 114,
+                    "openAppointmentSlots": 84,
                     "name": "Beaumont H-E-B plus!",
                     "longitude": -94.1685,
                     "latitude": 30.10501,
@@ -4997,23 +5042,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 88,
-                            "openAppointmentSlots": 88,
+                            "openTimeslots": 150,
+                            "openAppointmentSlots": 150,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 88,
+                    "openTimeslots": 150,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 88,
+                    "openAppointmentSlots": 150,
                     "name": "West Ave and Jackson Keller H-E-B",
                     "longitude": -98.52574,
                     "latitude": 29.51639,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
-                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Ultra_Pediatric_Moderna_Updated_Booster"
                     ]
                 },
@@ -5026,15 +5071,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 106,
-                            "openAppointmentSlots": 106,
+                            "openTimeslots": 35,
+                            "openAppointmentSlots": 35,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 106,
+                    "openTimeslots": 35,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 106,
+                    "openAppointmentSlots": 35,
                     "name": "De Zavala H-E-B",
                     "longitude": -98.5889,
                     "latitude": 29.56222,
@@ -5055,15 +5100,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 333,
-                            "openAppointmentSlots": 333,
+                            "openTimeslots": 292,
+                            "openAppointmentSlots": 292,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 333,
+                    "openTimeslots": 292,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 333,
+                    "openAppointmentSlots": 292,
                     "name": "281 and 1604 H-E-B",
                     "longitude": -98.46828,
                     "latitude": 29.60772,
@@ -5071,7 +5116,8 @@
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pfizer"
                     ]
                 },
                 {
@@ -5083,15 +5129,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 240,
-                            "openAppointmentSlots": 240,
+                            "openTimeslots": 177,
+                            "openAppointmentSlots": 177,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 240,
+                    "openTimeslots": 177,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 240,
+                    "openAppointmentSlots": 177,
                     "name": "Thousand Oaks H-E-B",
                     "longitude": -98.44108,
                     "latitude": 29.57781,
@@ -5130,15 +5176,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 34,
-                            "openAppointmentSlots": 34,
+                            "openTimeslots": 2,
+                            "openAppointmentSlots": 2,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 34,
+                    "openTimeslots": 2,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 34,
+                    "openAppointmentSlots": 2,
                     "name": "Indian Springs H-E-B",
                     "longitude": -95.53672,
                     "latitude": 30.17791,
@@ -5146,30 +5192,41 @@
                     "city": "THE WOODLANDS",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Moderna",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
                         "Senior_Flu"
                     ]
                 },
                 {
                     "zip": "77301-1220",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudKQAS",
                     "type": "store",
                     "street": "2108 NORTH FRAZIER",
                     "storeNumber": 595,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 77,
+                            "openAppointmentSlots": 77,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 77,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 77,
                     "name": "N Frazier At Loop 336 H-E-B",
                     "longitude": -95.46548,
                     "latitude": 30.33593,
                     "fluUrl": "",
                     "city": "CONROE",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Senior_Flu"
+                    ]
                 },
                 {
                     "zip": "77494-8100",
@@ -5180,58 +5237,47 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 95,
-                            "openAppointmentSlots": 95,
+                            "openTimeslots": 47,
+                            "openAppointmentSlots": 47,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 95,
+                    "openTimeslots": 47,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 95,
+                    "openAppointmentSlots": 47,
                     "name": "Grand Parkway H-E-B plus!",
                     "longitude": -95.7739,
                     "latitude": 29.7144,
                     "fluUrl": "",
                     "city": "KATY",
                     "availableImmunizations": [
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
                         "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
                         "Senior_Flu"
                     ]
                 },
                 {
                     "zip": "77005-4210",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudMQAS",
+                    "url": null,
                     "type": "store",
                     "street": "5225 BUFFALO SPEEDWAY",
                     "storeNumber": 599,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 4,
-                            "openAppointmentSlots": 4,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 4,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 4,
+                    "openAppointmentSlots": 0,
                     "name": "Buffalo Market H-E-B On Buffalo Speedway",
                     "longitude": -95.4271,
                     "latitude": 29.7261,
                     "fluUrl": "",
                     "city": "HOUSTON",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "Senior_Flu"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "77388-3412",
@@ -5242,15 +5288,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 13,
-                            "openAppointmentSlots": 13,
+                            "openTimeslots": 20,
+                            "openAppointmentSlots": 20,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 13,
+                    "openTimeslots": 20,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 13,
+                    "openAppointmentSlots": 20,
                     "name": "Spring Market H-E-B",
                     "longitude": -95.44894,
                     "latitude": 30.07042,
@@ -5259,9 +5305,7 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster",
                         "Senior_Flu"
                     ]
@@ -5275,15 +5319,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 135,
-                            "openAppointmentSlots": 135,
+                            "openTimeslots": 64,
+                            "openAppointmentSlots": 64,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 135,
+                    "openTimeslots": 64,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 135,
+                    "openAppointmentSlots": 64,
                     "name": "Dripping Springs H-E-B",
                     "longitude": -98.08146,
                     "latitude": 30.18968,
@@ -5325,15 +5369,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 87,
-                            "openAppointmentSlots": 87,
+                            "openTimeslots": 33,
+                            "openAppointmentSlots": 33,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 87,
+                    "openTimeslots": 33,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 87,
+                    "openAppointmentSlots": 33,
                     "name": "H-E-B Market at Gosling",
                     "longitude": -95.50178,
                     "latitude": 30.07179,
@@ -5391,15 +5435,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 147,
-                            "openAppointmentSlots": 147,
+                            "openTimeslots": 76,
+                            "openAppointmentSlots": 76,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 147,
+                    "openTimeslots": 76,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 147,
+                    "openAppointmentSlots": 76,
                     "name": "MacGregor Market H-E-B",
                     "longitude": -95.37644,
                     "latitude": 29.71432,
@@ -5439,28 +5483,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 1,
-                            "openAppointmentSlots": 1,
+                            "openTimeslots": 26,
+                            "openAppointmentSlots": 26,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 1,
+                    "openTimeslots": 26,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 1,
+                    "openAppointmentSlots": 26,
                     "name": "H-E-B Market at Northpark",
                     "longitude": -95.25033,
                     "latitude": 30.06864,
                     "fluUrl": "",
                     "city": "KINGWOOD",
                     "availableImmunizations": [
-                        "Flu",
                         "COVID-19 Moderna",
                         "COVID-19 Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "Senior_Flu"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -5484,37 +5526,22 @@
                 },
                 {
                     "zip": "79424-0",
-                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GuenQAC",
+                    "url": null,
                     "type": "store",
                     "street": "4405 114TH STREET",
                     "storeNumber": 772,
                     "state": "TX",
-                    "slotDetails": [
-                        {
-                            "openTimeslots": 14,
-                            "openAppointmentSlots": 14,
-                            "manufacturer": "Multiple"
-                        }
-                    ],
-                    "openTimeslots": 14,
+                    "slotDetails": [],
+                    "openTimeslots": 0,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 14,
+                    "openAppointmentSlots": 0,
                     "name": "Lubbock H-E-B",
                     "longitude": -101.90638,
                     "latitude": 33.48958,
                     "fluUrl": "",
                     "city": "LUBBOCK",
-                    "availableImmunizations": [
-                        "Flu",
-                        "COVID-19 Pediatric_Pfizer",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
-                        "COVID-19 Pediatric_Moderna",
-                        "COVID-19 Novavax",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Moderna_Updated_Booster",
-                        "Senior_Flu"
-                    ]
+                    "availableImmunizations": null
                 },
                 {
                     "zip": "79720-5437",
@@ -5525,15 +5552,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 105,
-                            "openAppointmentSlots": 105,
+                            "openTimeslots": 54,
+                            "openAppointmentSlots": 54,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 105,
+                    "openTimeslots": 54,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 105,
+                    "openAppointmentSlots": 54,
                     "name": "Big Spring H-E-B",
                     "longitude": -101.47211,
                     "latitude": 32.23493,
@@ -5557,15 +5584,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 178,
-                            "openAppointmentSlots": 178,
+                            "openTimeslots": 65,
+                            "openAppointmentSlots": 65,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 178,
+                    "openTimeslots": 65,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 178,
+                    "openAppointmentSlots": 65,
                     "name": "Sherwood Avenue N H-E-B",
                     "longitude": -100.47977,
                     "latitude": 31.44511,
@@ -5607,7 +5634,8 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -5638,15 +5666,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 48,
-                            "openAppointmentSlots": 48,
+                            "openTimeslots": 109,
+                            "openAppointmentSlots": 109,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 48,
+                    "openTimeslots": 109,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 48,
+                    "openAppointmentSlots": 109,
                     "name": "Pearland H-E-B plus!",
                     "longitude": -95.39002,
                     "latitude": 29.55932,
@@ -5658,7 +5686,8 @@
                         "COVID-19 Pfizer",
                         "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -5670,15 +5699,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 110,
-                            "openAppointmentSlots": 110,
+                            "openTimeslots": 52,
+                            "openAppointmentSlots": 52,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 110,
+                    "openTimeslots": 52,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 110,
+                    "openAppointmentSlots": 52,
                     "name": "19th and Meridian H-E-B",
                     "longitude": -97.17255,
                     "latitude": 31.5804,
@@ -5702,15 +5731,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 68,
-                            "openAppointmentSlots": 68,
+                            "openTimeslots": 30,
+                            "openAppointmentSlots": 30,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 68,
+                    "openTimeslots": 30,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 68,
+                    "openAppointmentSlots": 30,
                     "name": "Slaughter and Escarpment H-E-B",
                     "longitude": -97.87642,
                     "latitude": 30.20247,
@@ -5768,24 +5797,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 111,
-                            "openAppointmentSlots": 111,
+                            "openTimeslots": 9,
+                            "openAppointmentSlots": 9,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 111,
+                    "openTimeslots": 9,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 111,
+                    "openAppointmentSlots": 9,
                     "name": "Bee Cave H-E-B",
                     "longitude": -97.93238,
                     "latitude": 30.30489,
                     "fluUrl": "",
                     "city": "BEE CAVE",
                     "availableImmunizations": [
-                        "COVID-19 Moderna_Updated_Booster",
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -5797,15 +5826,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 396,
-                            "openAppointmentSlots": 396,
+                            "openTimeslots": 175,
+                            "openAppointmentSlots": 175,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 396,
+                    "openTimeslots": 175,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 396,
+                    "openAppointmentSlots": 175,
                     "name": "Marbach and 410 H-E-B plus!",
                     "longitude": -98.65227,
                     "latitude": 29.41837,
@@ -5832,15 +5861,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 216,
-                            "openAppointmentSlots": 216,
+                            "openTimeslots": 178,
+                            "openAppointmentSlots": 178,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 216,
+                    "openTimeslots": 178,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 216,
+                    "openAppointmentSlots": 178,
                     "name": "Summerwood Market H-E-B",
                     "longitude": -95.19697,
                     "latitude": 29.92325,
@@ -5857,27 +5886,42 @@
                         "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Moderna_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "Senior_Flu"
+                        "Senior_Flu",
+                        "COVID-19 Ultra_Pediatric_Moderna_Updated_Booster"
                     ]
                 },
                 {
                     "zip": "77494-5904",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudSQAS",
                     "type": "store",
                     "street": "25675 NELSON WAY",
                     "storeNumber": 615,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 174,
+                            "openAppointmentSlots": 174,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 174,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 174,
                     "name": "Katy Market H-E-B",
                     "longitude": -95.82005,
                     "latitude": 29.77644,
                     "fluUrl": "",
                     "city": "KATY",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "78240-2136",
@@ -5936,15 +5980,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 70,
-                            "openAppointmentSlots": 70,
+                            "openTimeslots": 54,
+                            "openAppointmentSlots": 54,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 70,
+                    "openTimeslots": 54,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 70,
+                    "openAppointmentSlots": 54,
                     "name": "Pearsall H-E-B",
                     "longitude": -99.11446,
                     "latitude": 28.89503,
@@ -5969,15 +6013,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 74,
-                            "openAppointmentSlots": 74,
+                            "openTimeslots": 22,
+                            "openAppointmentSlots": 22,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 74,
+                    "openTimeslots": 22,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 74,
+                    "openAppointmentSlots": 22,
                     "name": "H-E-B Pharmacy at the UTHTB",
                     "longitude": -97.73507,
                     "latitude": 30.27747,
@@ -5999,15 +6043,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 159,
-                            "openAppointmentSlots": 159,
+                            "openTimeslots": 98,
+                            "openAppointmentSlots": 98,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 159,
+                    "openTimeslots": 98,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 159,
+                    "openAppointmentSlots": 98,
                     "name": "Abilene H-E-B",
                     "longitude": -99.75934,
                     "latitude": 32.43348,
@@ -6020,7 +6064,8 @@
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Moderna_Updated_Booster",
-                        "Senior_Flu"
+                        "Senior_Flu",
+                        "COVID-19 Pfizer"
                     ]
                 },
                 {
@@ -6051,15 +6096,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 123,
-                            "openAppointmentSlots": 123,
+                            "openTimeslots": 77,
+                            "openAppointmentSlots": 77,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 123,
+                    "openTimeslots": 77,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 123,
+                    "openAppointmentSlots": 77,
                     "name": "Boerne H-E-B plus!",
                     "longitude": -98.73481,
                     "latitude": 29.78173,
@@ -6067,8 +6112,7 @@
                     "city": "BOERNE",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -6080,15 +6124,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 58,
-                            "openAppointmentSlots": 58,
+                            "openTimeslots": 103,
+                            "openAppointmentSlots": 103,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 58,
+                    "openTimeslots": 103,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 58,
+                    "openAppointmentSlots": 103,
                     "name": "Bulverde H-E-B plus!",
                     "longitude": -98.43022,
                     "latitude": 29.79882,
@@ -6100,7 +6144,10 @@
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Pediatric_Moderna"
                     ]
                 },
                 {
@@ -6112,15 +6159,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 83,
-                            "openAppointmentSlots": 83,
+                            "openTimeslots": 25,
+                            "openAppointmentSlots": 25,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 83,
+                    "openTimeslots": 25,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 83,
+                    "openAppointmentSlots": 25,
                     "name": "Bandera and 1604 H-E-B plus!",
                     "longitude": -98.66444,
                     "latitude": 29.55498,
@@ -6144,15 +6191,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 175,
-                            "openAppointmentSlots": 175,
+                            "openTimeslots": 89,
+                            "openAppointmentSlots": 89,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 175,
+                    "openTimeslots": 89,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 175,
+                    "openAppointmentSlots": 89,
                     "name": "San Benito H-E-B",
                     "longitude": -97.63395,
                     "latitude": 26.14392,
@@ -6178,15 +6225,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 108,
-                            "openAppointmentSlots": 108,
+                            "openTimeslots": 150,
+                            "openAppointmentSlots": 150,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 108,
+                    "openTimeslots": 150,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 108,
+                    "openAppointmentSlots": 150,
                     "name": "Sugar Land Market H-E-B",
                     "longitude": -95.64596,
                     "latitude": 29.60871,
@@ -6225,15 +6272,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 48,
-                            "openAppointmentSlots": 48,
+                            "openTimeslots": 17,
+                            "openAppointmentSlots": 17,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 48,
+                    "openTimeslots": 17,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 48,
+                    "openAppointmentSlots": 17,
                     "name": "Spring Green Market H-E-B",
                     "longitude": -95.81427,
                     "latitude": 29.69558,
@@ -6241,11 +6288,12 @@
                     "city": "RICHMOND",
                     "availableImmunizations": [
                         "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Pediatric_Moderna_Updated_Booster"
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -6257,24 +6305,24 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 324,
-                            "openAppointmentSlots": 324,
+                            "openTimeslots": 130,
+                            "openAppointmentSlots": 130,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 324,
+                    "openTimeslots": 130,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 324,
+                    "openAppointmentSlots": 130,
                     "name": "New Braunfels H-E-B at Hwy 46",
                     "longitude": -98.16041,
                     "latitude": 29.71309,
                     "fluUrl": "",
                     "city": "NEW BRAUNFELS",
                     "availableImmunizations": [
-                        "COVID-19 Pfizer_Updated_Booster",
+                        "COVID-19 Moderna_Updated_Booster",
                         "Flu",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -6286,15 +6334,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 500,
-                            "openAppointmentSlots": 500,
+                            "openTimeslots": 244,
+                            "openAppointmentSlots": 244,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 500,
+                    "openTimeslots": 244,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 500,
+                    "openAppointmentSlots": 244,
                     "name": "Zarzamora and Military H-E-B plus!",
                     "longitude": -98.5339,
                     "latitude": 29.35787,
@@ -6316,15 +6364,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 31,
-                            "openAppointmentSlots": 31,
+                            "openTimeslots": 18,
+                            "openAppointmentSlots": 18,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 31,
+                    "openTimeslots": 18,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 31,
+                    "openAppointmentSlots": 18,
                     "name": "Potranco and 1604 H-E-B plus!",
                     "longitude": -98.70445,
                     "latitude": 29.43536,
@@ -6345,15 +6393,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 220,
-                            "openAppointmentSlots": 220,
+                            "openTimeslots": 155,
+                            "openAppointmentSlots": 155,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 220,
+                    "openTimeslots": 155,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 220,
+                    "openAppointmentSlots": 155,
                     "name": "Kerrville H-E-B On Main Street",
                     "longitude": -99.14287,
                     "latitude": 30.05056,
@@ -6413,15 +6461,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 254,
-                            "openAppointmentSlots": 254,
+                            "openTimeslots": 130,
+                            "openAppointmentSlots": 130,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 254,
+                    "openTimeslots": 130,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 254,
+                    "openAppointmentSlots": 130,
                     "name": "Bunker Hill H-E-B",
                     "longitude": -95.53206,
                     "latitude": 29.78485,
@@ -6450,15 +6498,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 78,
-                            "openAppointmentSlots": 78,
+                            "openTimeslots": 31,
+                            "openAppointmentSlots": 31,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 78,
+                    "openTimeslots": 31,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 78,
+                    "openAppointmentSlots": 31,
                     "name": "Sienna Market H-E-B",
                     "longitude": -95.53497,
                     "latitude": 29.53928,
@@ -6583,15 +6631,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 26,
-                            "openAppointmentSlots": 26,
+                            "openTimeslots": 37,
+                            "openAppointmentSlots": 37,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 26,
+                    "openTimeslots": 37,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 26,
+                    "openAppointmentSlots": 37,
                     "name": "Laredo H-E-B plus!",
                     "longitude": -99.47435,
                     "latitude": 27.60863,
@@ -6599,11 +6647,11 @@
                     "city": "LAREDO",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Ultra_Pediatric_Pfizer",
-                        "COVID-19 Pediatric_Moderna",
                         "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "Senior_Flu"
+                        "COVID-19 Ultra_Pediatric_Pfizer",
+                        "COVID-19 Pediatric_Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -6634,15 +6682,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 225,
-                            "openAppointmentSlots": 225,
+                            "openTimeslots": 352,
+                            "openAppointmentSlots": 352,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 225,
+                    "openTimeslots": 352,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 225,
+                    "openAppointmentSlots": 352,
                     "name": "Vintage Park Market H-E-B",
                     "longitude": -95.57661,
                     "latitude": 29.9967,
@@ -6653,7 +6701,9 @@
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "Senior_Flu"
+                        "Senior_Flu",
+                        "COVID-19 Moderna",
+                        "COVID-19 Pediatric_Pfizer"
                     ]
                 },
                 {
@@ -6665,15 +6715,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 341,
-                            "openAppointmentSlots": 341,
+                            "openTimeslots": 128,
+                            "openAppointmentSlots": 128,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 341,
+                    "openTimeslots": 128,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 341,
+                    "openAppointmentSlots": 128,
                     "name": "Alon Market H-E-B",
                     "longitude": -98.53463,
                     "latitude": 29.55254,
@@ -6732,15 +6782,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 271,
-                            "openAppointmentSlots": 271,
+                            "openTimeslots": 97,
+                            "openAppointmentSlots": 97,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 271,
+                    "openTimeslots": 97,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 271,
+                    "openAppointmentSlots": 97,
                     "name": "Montrose Market H-E-B",
                     "longitude": -95.40284,
                     "latitude": 29.7379,
@@ -6781,15 +6831,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 165,
-                            "openAppointmentSlots": 165,
+                            "openTimeslots": 60,
+                            "openAppointmentSlots": 60,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 165,
+                    "openTimeslots": 60,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 165,
+                    "openAppointmentSlots": 60,
                     "name": "North Woodlands Market H-E-B",
                     "longitude": -95.51296,
                     "latitude": 30.22918,
@@ -6944,15 +6994,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 70,
-                            "openAppointmentSlots": 70,
+                            "openTimeslots": 37,
+                            "openAppointmentSlots": 37,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 70,
+                    "openTimeslots": 37,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 70,
+                    "openAppointmentSlots": 37,
                     "name": "Morgan and Grimes H-E-B",
                     "longitude": -97.67639,
                     "latitude": 26.20337,
@@ -6970,7 +7020,8 @@
                         "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Moderna_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "Senior_Flu"
+                        "Senior_Flu",
+                        "COVID-19 Ultra_Pediatric_Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -7001,22 +7052,23 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 71,
-                            "openAppointmentSlots": 71,
+                            "openTimeslots": 53,
+                            "openAppointmentSlots": 53,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 71,
+                    "openTimeslots": 53,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 71,
+                    "openAppointmentSlots": 53,
                     "name": "San Pedro and Oblate H-E-B",
                     "longitude": -98.4995,
                     "latitude": 29.50282,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -7047,15 +7099,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 184,
-                            "openAppointmentSlots": 184,
+                            "openTimeslots": 173,
+                            "openAppointmentSlots": 173,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 184,
+                    "openTimeslots": 173,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 184,
+                    "openAppointmentSlots": 173,
                     "name": "Lamar and Rundberg H-E-B",
                     "longitude": -97.69689,
                     "latitude": 30.36357,
@@ -7069,7 +7121,8 @@
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
                         "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "Senior_Flu"
+                        "Senior_Flu",
+                        "COVID-19 Moderna"
                     ]
                 },
                 {
@@ -7093,22 +7146,34 @@
                 },
                 {
                     "zip": "78041-5435",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000Gub4QAC",
                     "type": "store",
                     "street": "2310 E SAUNDERS ST",
                     "storeNumber": 186,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 54,
+                            "openAppointmentSlots": 54,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 54,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 54,
                     "name": "Saunders St H-E-B",
                     "longitude": -99.47131,
                     "latitude": 27.53071,
                     "fluUrl": "",
                     "city": "LAREDO",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "Flu",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster",
+                        "Senior_Flu"
+                    ]
                 },
                 {
                     "zip": "78745-0",
@@ -7157,15 +7222,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 91,
-                            "openAppointmentSlots": 91,
+                            "openTimeslots": 70,
+                            "openAppointmentSlots": 70,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 91,
+                    "openTimeslots": 70,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 91,
+                    "openAppointmentSlots": 70,
                     "name": "Ennis H-E-B",
                     "longitude": -96.63251,
                     "latitude": 32.32542,
@@ -7188,15 +7253,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 124,
-                            "openAppointmentSlots": 124,
+                            "openTimeslots": 48,
+                            "openAppointmentSlots": 48,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 124,
+                    "openTimeslots": 48,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 124,
+                    "openAppointmentSlots": 48,
                     "name": "281 and Evans Road H-E-B plus!",
                     "longitude": -98.45756,
                     "latitude": 29.63886,
@@ -7211,22 +7276,33 @@
                 },
                 {
                     "zip": "77433-4288",
-                    "url": null,
+                    "url": "https://heb.secure.force.com/FlexibleScheduler/FSAppointment?event_ID=a8h4P000000GudlQAC",
                     "type": "store",
                     "street": "28550 US- 290",
                     "storeNumber": 656,
                     "state": "TX",
-                    "slotDetails": [],
-                    "openTimeslots": 0,
+                    "slotDetails": [
+                        {
+                            "openTimeslots": 600,
+                            "openAppointmentSlots": 600,
+                            "manufacturer": "Multiple"
+                        }
+                    ],
+                    "openTimeslots": 600,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 0,
+                    "openAppointmentSlots": 600,
                     "name": "Fairfield Market H-E-B",
                     "longitude": -95.74599,
                     "latitude": 29.9925,
                     "fluUrl": "",
                     "city": "CYPRESS",
-                    "availableImmunizations": null
+                    "availableImmunizations": [
+                        "COVID-19 Moderna",
+                        "COVID-19 Pfizer",
+                        "COVID-19 Moderna_Updated_Booster",
+                        "COVID-19 Pfizer_Updated_Booster"
+                    ]
                 },
                 {
                     "zip": "77065-4814",
@@ -7237,15 +7313,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 1091,
-                            "openAppointmentSlots": 1091,
+                            "openTimeslots": 1238,
+                            "openAppointmentSlots": 1238,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 1091,
+                    "openTimeslots": 1238,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 1091,
+                    "openAppointmentSlots": 1238,
                     "name": "Jones and West H-E-B",
                     "longitude": -95.5859,
                     "latitude": 29.91104,
@@ -7270,15 +7346,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 194,
-                            "openAppointmentSlots": 194,
+                            "openTimeslots": 77,
+                            "openAppointmentSlots": 77,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 194,
+                    "openTimeslots": 77,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 194,
+                    "openAppointmentSlots": 77,
                     "name": "The Market at Stone Oak",
                     "longitude": -98.50062,
                     "latitude": 29.662,
@@ -7286,8 +7362,8 @@
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster",
-                        "Flu"
+                        "Flu",
+                        "COVID-19 Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -7299,15 +7375,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 36,
-                            "openAppointmentSlots": 36,
+                            "openTimeslots": 7,
+                            "openAppointmentSlots": 7,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 36,
+                    "openTimeslots": 7,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 36,
+                    "openAppointmentSlots": 7,
                     "name": "Lakeline H-E-B plus!",
                     "longitude": -97.8034,
                     "latitude": 30.47786,
@@ -7315,8 +7391,7 @@
                     "city": "AUSTIN",
                     "availableImmunizations": [
                         "Flu",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna_Updated_Booster"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -7328,15 +7403,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 534,
-                            "openAppointmentSlots": 534,
+                            "openTimeslots": 404,
+                            "openAppointmentSlots": 404,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 534,
+                    "openTimeslots": 404,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 534,
+                    "openAppointmentSlots": 404,
                     "name": "Conroe Market H-E-B",
                     "longitude": -95.49817,
                     "latitude": 30.32647,
@@ -7357,15 +7432,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 231,
-                            "openAppointmentSlots": 231,
+                            "openTimeslots": 232,
+                            "openAppointmentSlots": 232,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 231,
+                    "openTimeslots": 232,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 231,
+                    "openAppointmentSlots": 232,
                     "name": "Texas City H-E-B",
                     "longitude": -94.94893,
                     "latitude": 29.39535,
@@ -7407,29 +7482,26 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 216,
-                            "openAppointmentSlots": 216,
+                            "openTimeslots": 84,
+                            "openAppointmentSlots": 84,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 216,
+                    "openTimeslots": 84,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 216,
+                    "openAppointmentSlots": 84,
                     "name": "Broadway Central Market",
                     "longitude": -98.46408,
                     "latitude": 29.47069,
                     "fluUrl": "",
                     "city": "SAN ANTONIO",
                     "availableImmunizations": [
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
                         "Flu",
                         "Senior_Flu",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
                         "COVID-19 Moderna_Updated_Booster",
-                        "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Moderna",
-                        "COVID-19 Pfizer",
-                        "COVID-19 Janssen"
+                        "COVID-19 Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -7479,15 +7551,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 133,
-                            "openAppointmentSlots": 133,
+                            "openTimeslots": 47,
+                            "openAppointmentSlots": 47,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 133,
+                    "openTimeslots": 47,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 133,
+                    "openAppointmentSlots": 47,
                     "name": "Valley Mills H-E-B plus!",
                     "longitude": -97.13916,
                     "latitude": 31.52508,
@@ -7503,7 +7575,8 @@
                         "COVID-19 Ultra_Pediatric_Pfizer",
                         "COVID-19 Pediatric_Moderna",
                         "COVID-19 Pediatric_Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "COVID-19 Ultra_Pediatric_Moderna_Updated_Booster"
                     ]
                 },
                 {
@@ -7515,15 +7588,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 7,
-                            "openAppointmentSlots": 7,
+                            "openTimeslots": 58,
+                            "openAppointmentSlots": 58,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 7,
+                    "openTimeslots": 58,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 7,
+                    "openAppointmentSlots": 58,
                     "name": "University Blvd H-E-B",
                     "longitude": -97.68859,
                     "latitude": 30.56107,
@@ -7532,15 +7605,13 @@
                     "availableImmunizations": [
                         "Flu",
                         "COVID-19 Moderna",
-                        "COVID-19 Pediatric_Pfizer",
                         "COVID-19 Ultra_Pediatric_Pfizer",
-                        "COVID-19 Pediatric_Moderna",
                         "COVID-19 Novavax",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "COVID-19 Pediatric_Moderna_Updated_Booster",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
-                        "Senior_Flu"
+                        "Senior_Flu",
+                        "COVID-19 Ultra_Pediatric_Moderna_Updated_Booster",
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
                     ]
                 },
                 {
@@ -7552,15 +7623,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 92,
-                            "openAppointmentSlots": 92,
+                            "openTimeslots": 25,
+                            "openAppointmentSlots": 25,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 92,
+                    "openTimeslots": 25,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 92,
+                    "openAppointmentSlots": 25,
                     "name": "Palmhurst H-E-B",
                     "longitude": -98.31816,
                     "latitude": 26.25684,
@@ -7582,15 +7653,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 100,
-                            "openAppointmentSlots": 100,
+                            "openTimeslots": 39,
+                            "openAppointmentSlots": 39,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 100,
+                    "openTimeslots": 39,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 100,
+                    "openAppointmentSlots": 39,
                     "name": "Pearland Market H-E-B",
                     "longitude": -95.26499,
                     "latitude": 29.55812,
@@ -7602,8 +7673,8 @@
                         "COVID-19 Pfizer",
                         "COVID-19 Moderna_Updated_Booster",
                         "COVID-19 Pfizer_Updated_Booster",
-                        "Senior_Flu",
-                        "COVID-19 Pediatric_Pfizer_Updated_Booster"
+                        "COVID-19 Pediatric_Pfizer_Updated_Booster",
+                        "Senior_Flu"
                     ]
                 },
                 {
@@ -7653,15 +7724,15 @@
                     "state": "TX",
                     "slotDetails": [
                         {
-                            "openTimeslots": 100,
-                            "openAppointmentSlots": 100,
+                            "openTimeslots": 40,
+                            "openAppointmentSlots": 40,
                             "manufacturer": "Multiple"
                         }
                     ],
-                    "openTimeslots": 100,
+                    "openTimeslots": 40,
                     "openFluTimeslots": 0,
                     "openFluAppointmentSlots": 0,
-                    "openAppointmentSlots": 100,
+                    "openAppointmentSlots": 40,
                     "name": "H-E-B Frisco",
                     "longitude": -96.84583,
                     "latitude": 33.15458,
@@ -7684,31 +7755,31 @@
             "Content-Type",
             "binary/octet-stream",
             "Content-Length",
-            "164382",
+            "166238",
             "Connection",
             "close",
             "Last-Modified",
-            "Mon, 12 Dec 2022 22:42:46 GMT",
+            "Thu, 15 Dec 2022 21:14:58 GMT",
             "Accept-Ranges",
             "bytes",
             "Server",
             "AmazonS3",
             "Date",
-            "Mon, 12 Dec 2022 22:48:13 GMT",
+            "Thu, 15 Dec 2022 21:18:12 GMT",
             "Cache-Control",
             "max-age:0",
             "ETag",
-            "\"baccfcca4bbeff9a5079bc53006e2aad\"",
+            "\"816f81aebc1913b11815389e7c618f85\"",
             "Vary",
             "Accept-Encoding",
             "X-Cache",
             "RefreshHit from cloudfront",
             "Via",
-            "1.1 442d080ad536f368b087d8fa4ff33ee6.cloudfront.net (CloudFront)",
+            "1.1 0d60533443ead16cd68819273caf966e.cloudfront.net (CloudFront)",
             "X-Amz-Cf-Pop",
-            "SFO5-P2",
+            "SFO5-C1",
             "X-Amz-Cf-Id",
-            "ExfQJsWpFjN6RFf1BhHSum8G-VQZ0sO9HhJ5C32MaQYw5DxE5khwDA=="
+            "XYuAFqZRpPrls3o3SSbWoDwY9L6b7SOjpqtQ3yrZ5jS_FXNUNQLDEg=="
         ],
         "responseIsBinary": false
     }


### PR DESCRIPTION
H-E-B just added bivalent infant vaccines from Pfizer, although they have a real weird suffix: `_Updated_Dose3` (where all the other types use `_Updated_Booster`). I've added support for this, and, just in case they change it to match the others, also for `_Updated_Booster`.

Fixes https://sentry.io/organizations/usdr/issues/3811243951.