### PR TITLE
Add Docker layer caching in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,19 @@ jobs:
       - name: Cache Docker layers
         uses: actions/cache@v3
         with:
-          path: /tmp/.buildx-cache
+          path: /tmp/.buildx-cache-base
+          # Use the commit SHA in the key since there's no file that makes sense
+          # to hash for a unique key.
+          key: ${{ runner.os }}-buildx-base-${{ github.ref }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-base-${{ github.ref }}-${{ github.sha }}
+            ${{ runner.os }}-buildx-base-${{ github.ref }}-
+            ${{ runner.os }}-buildx-base-
+
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache-${{ matrix.target }}
           # Use the commit SHA in the key since there's no file that makes sense
           # to hash for a unique key.
           key: ${{ runner.os }}-buildx-${{ matrix.target }}-${{ github.ref }}-${{ github.sha }}
@@ -211,6 +223,24 @@ jobs:
         #   # install: true
         #   buildkitd-flags: --debug
 
+      - name: Build base
+        uses: docker/build-push-action@v3
+        with:
+          context: "."
+          tags: "dev/univaf-base:latest"
+          target: "base"
+          build-args: |
+            RELEASE=${{ env.IMAGE_TAG }}
+          # The caching mechanism will add a new copy of the cache to the
+          # destination directory, so we write the cache out to a new, clean
+          # directory and then overwrite the old cache directory with it after.
+          # (See next action.)
+          cache-from: "type=local,src=/tmp/.buildx-cache-base"
+          cache-to: "type=local,dest=/tmp/.buildx-cache-base-new,mode=max"
+          push: false
+          # Make the image available to Docker CLI commands in the next steps.
+          load: true
+
       - name: Build ${{ matrix.repository }}
         uses: docker/build-push-action@v3
         with:
@@ -223,22 +253,26 @@ jobs:
           # destination directory, so we write the cache out to a new, clean
           # directory and then overwrite the old cache directory with it after.
           # (See next action.)
-          cache-from: "type=local,src=/tmp/.buildx-cache"
-          cache-to: "type=local,dest=/tmp/.buildx-cache-new,mode=max,compression=zstd"
+          cache-from: |
+            type=local,src=/tmp/.buildx-cache-base
+            type=local,src=/tmp/.buildx-cache-${{ matrix.target }}
+          cache-to: "type=local,dest=/tmp/.buildx-cache-${{ matrix.target }}-new,mode=max"
           push: false
           # Make the image available to Docker CLI commands in the next steps.
           load: true
 
       - name: Overwrite Old Cache
         run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          rm -rf /tmp/.buildx-cache-base
+          mv /tmp/.buildx-cache-base-new /tmp/.buildx-cache-base
+          rm -rf /tmp/.buildx-cache-${{ matrix.target }}
+          mv /tmp/.buildx-cache-${{ matrix.target }}-new /tmp/.buildx-cache-${{ matrix.target }}
 
-      - name: Inspect Outgoing Cache
-        run: |
-          ls -lah /tmp/.buildx-cache
-          cat /tmp/.buildx-cache/index.json | jq
-          ls -lah /tmp/.buildx-cache/blobs/sha256
+      # - name: Inspect Outgoing Cache
+      #   run: |
+      #     ls -lah /tmp/.buildx-cache
+      #     cat /tmp/.buildx-cache/index.json | jq
+      #     ls -lah /tmp/.buildx-cache/blobs/sha256
 
       - name: Report Image Details
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,8 +210,7 @@ jobs:
           echo "Built image \`${IMAGE_NAME}\`: ${SIZE_MB} MB" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Configure AWS credentials
-        # XXX: Testing pushing with the new configuration
-        # if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -219,14 +218,12 @@ jobs:
           aws-region: us-west-2
 
       - name: Login to Amazon ECR
-        # XXX: Testing pushing with the new configuration
-        # if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
       - name: Tag and push ${{ matrix.repository }} latest
-        # XXX: Testing pushing with the new configuration
-        # if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,9 @@ jobs:
 
       - name: Inspect Incoming Cache
         run: |
-          ls -la /tmp/.buildx-cache
+          ls -lah /tmp/.buildx-cache
+          jq /tmp/.buildx-cache/index.json
+          ls -lah /tmp/.buildx-cache/*
 
       # Sets up a docker driver that supports caching.
       - name: Set up Docker Buildx
@@ -235,7 +237,9 @@ jobs:
 
       - name: Inspect Outgoing Cache
         run: |
-          ls -la /tmp/.buildx-cache
+          ls -lah /tmp/.buildx-cache
+          jq /tmp/.buildx-cache/index.json
+          ls -lah /tmp/.buildx-cache/*
 
       - name: Report Image Details
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,6 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Build ${{ matrix.repository }}
-        id: build-image
         uses: docker/build-push-action@v3
         with:
           target: "${{ matrix.target }}"
@@ -196,6 +195,7 @@ jobs:
             RELEASE="${{ env.IMAGE_TAG }}"
           tags: "${{ env.IMAGE_NAME }}"
           push: false
+          load: true
           cache-from: type=gha
           cache-to: type=gha,mode=max,compression=zstd
 
@@ -204,10 +204,10 @@ jobs:
           SIZE=$(
             docker image inspect \
               --format '{{ .VirtualSize }}' \
-              "${{ steps.build-image.outputs.imageid }}"
+              "${IMAGE_NAME}"
           )
           SIZE_MB=$((SIZE / 1024 / 1024))
-          echo "Built image \`${{ steps.build-image.outputs.imageid }}\`: ${SIZE_MB} MB" >> "$GITHUB_STEP_SUMMARY"
+          echo "Built image \`${IMAGE_NAME}\`: ${SIZE_MB} MB" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Configure AWS credentials
         if: github.ref == 'refs/heads/main'
@@ -228,7 +228,7 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |
           PUBLISH_NAME="$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
-          docker tag "${{ steps.build-image.outputs.imageid }}" "${PUBLISH_NAME}"
+          docker tag "${IMAGE_NAME}" "${PUBLISH_NAME}"
           docker push "${PUBLISH_NAME}"
 
   deploy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
       - name: Inspect Incoming Cache
         run: |
           ls -lah /tmp/.buildx-cache
-          jq /tmp/.buildx-cache/index.json
+          cat /tmp/.buildx-cache/index.json | jq
           ls -lah /tmp/.buildx-cache/*
 
       # Sets up a docker driver that supports caching.
@@ -238,7 +238,7 @@ jobs:
       - name: Inspect Outgoing Cache
         run: |
           ls -lah /tmp/.buildx-cache
-          jq /tmp/.buildx-cache/index.json
+          cat /tmp/.buildx-cache/index.json | jq
           ls -lah /tmp/.buildx-cache/*
 
       - name: Report Image Details

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,10 @@ jobs:
             ${{ runner.os }}-buildx-${{ github.ref }}-
             ${{ runner.os }}-buildx-
 
+      - name: Inspect Incoming Cache
+        run: |
+          ls -la /tmp/.buildx-cache
+
       # Sets up a docker driver that supports caching.
       - name: Set up Docker Buildx
         id: buildx-setup
@@ -228,6 +232,10 @@ jobs:
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+      - name: Inspect Outgoing Cache
+        run: |
+          ls -la /tmp/.buildx-cache
 
       - name: Report Image Details
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,8 +208,9 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx-setup
         uses: docker/setup-buildx-action@v2
-        # with:
-        #   install: true
+        with:
+          # install: true
+          buildkitd-flags: --debug
 
       - name: Build ${{ matrix.repository }}
         uses: docker/build-push-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,6 @@ jobs:
         uses: docker/setup-buildx-action@v2
         # with:
         #   # install: true
-        #   buildkitd-flags: --debug
 
       - name: Build base
         uses: docker/build-push-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
-          # Key is named differently to avoid collision
+          # Use the commit SHA in the key since there's no file that makes sense
+          # to hash for a unique key.
           key: ${{ runner.os }}-buildx-${{ github.ref }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-${{ github.ref }}-${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,20 +186,30 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      # - name: Build ${{ matrix.repository }}
+      #   uses: docker/build-push-action@v3
+      #   with:
+      #     target: "${{ matrix.target }}"
+      #     context: .
+      #     build-args: |
+      #       RELEASE=${{ env.IMAGE_TAG }}
+      #     tags: "${{ env.IMAGE_NAME }}"
+      #     push: false
+      #     # Make output available to Docker CLI for later commands.
+      #     load: true
+      #     # Read/write layers to the GitHub Actions cache.
+      #     cache-from: type=gha
+      #     cache-to: type=gha,mode=max
       - name: Build ${{ matrix.repository }}
-        uses: docker/build-push-action@v3
-        with:
-          target: "${{ matrix.target }}"
-          context: .
-          build-args: |
-            RELEASE=${{ env.IMAGE_TAG }}
-          tags: "${{ env.IMAGE_NAME }}"
-          push: false
-          # Make output available to Docker CLI for later commands.
-          load: true
-          # Read/write layers to the GitHub Actions cache.
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+        run: |
+          docker buildx build \
+            --tag "${IMAGE_NAME}" \
+            --target "${{ matrix.target }}" \
+            --build-arg RELEASE="${IMAGE_TAG}" \
+            --load \
+            --cache-from type=gha \
+            --cache-to type=gha,mode=max \
+            .
 
       - name: Report Image Details
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,14 +202,14 @@ jobs:
         run: |
           ls -lah /tmp/.buildx-cache
           cat /tmp/.buildx-cache/index.json | jq
-          ls -lah /tmp/.buildx-cache/*
+          ls -lah /tmp/.buildx-cache/blobs/sha256
 
       # Sets up a docker driver that supports caching.
       - name: Set up Docker Buildx
         id: buildx-setup
         uses: docker/setup-buildx-action@v2
-        with:
-          install: true
+        # with:
+        #   install: true
 
       - name: Build ${{ matrix.repository }}
         uses: docker/build-push-action@v3
@@ -219,7 +219,7 @@ jobs:
           target: "${{ matrix.target }}"
           build-args: |
             RELEASE=${{ env.IMAGE_TAG }}
-          builder: "${{ steps.buildx-setup.outputs.name }}"
+          # builder: "${{ steps.buildx-setup.outputs.name }}"
           # The caching mechanism will add a new copy of the cache to the
           # destination directory, so we write the cache out to a new, clean
           # directory and then overwrite the old cache directory with it after.
@@ -239,7 +239,7 @@ jobs:
         run: |
           ls -lah /tmp/.buildx-cache
           cat /tmp/.buildx-cache/index.json | jq
-          ls -lah /tmp/.buildx-cache/*
+          ls -lah /tmp/.buildx-cache/blobs/sha256
 
       - name: Report Image Details
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,15 +194,16 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: "."
-          builder: "${{ steps.buildx-setup.outputs.name }}"
+          tags: "${{ env.IMAGE_NAME }}"
           target: "${{ matrix.target }}"
           build-args: |
             RELEASE=${{ env.IMAGE_TAG }}
-          push: false
-          load: true
-          tags: "${{ env.IMAGE_NAME }}"
+          builder: "${{ steps.buildx-setup.outputs.name }}"
           cache-from: "type=gha,mode=max"
           cache-to: "type=gha,mode=max"
+          push: false
+          # Make the image available to Docker CLI commands in the next steps.
+          load: true
 
       - name: Report Image Details
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,26 +186,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      # We have two *nearly* identical Docker build steps here because writing
-      # cached layers does not appear to be compatible with making the build
-      # output available to the Docker CLI for further commands.
-      # - The first build step does the actual build and reads/writes caches.
-      # - The second build step uses `load: true` to make its output available
-      #   to future Docker CLI commands. It's pretty quick, since it winds up
-      #   reading everything from the cache produced by the first build step.
-      - name: Build and Cache ${{ matrix.repository }}
-        uses: docker/build-push-action@v3
-        with:
-          target: "${{ matrix.target }}"
-          context: .
-          build-args: |
-            RELEASE=${{ env.IMAGE_TAG }}
-          tags: "${{ env.IMAGE_NAME }}"
-          push: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,compression=zstd
-
-      - name: Load Cached Image ${{ matrix.repository }}
+      - name: Build ${{ matrix.repository }}
         uses: docker/build-push-action@v3
         with:
           target: "${{ matrix.target }}"
@@ -216,7 +197,7 @@ jobs:
           push: false
           load: true
           cache-from: type=gha
-          cache-to: type=gha,mode=max,compression=zstd
+          cache-to: type=gha,mode=max
 
       - name: Report Image Details
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,12 +198,11 @@ jobs:
             ${{ runner.os }}-buildx-${{ matrix.target }}-${{ github.ref }}-
             ${{ runner.os }}-buildx-${{ matrix.target }}-
 
-      - name: Inspect Incoming Cache
-        run: |
-          ls -lah /tmp/.buildx-cache
-          cat /tmp/.buildx-cache/index.json | jq
-          ls -lah /tmp/.buildx-cache/blobs/sha256
-
+      # - name: Inspect Incoming Cache
+      #   run: |
+      #     ls -lah /tmp/.buildx-cache
+      #     cat /tmp/.buildx-cache/index.json | jq
+      #     ls -lah /tmp/.buildx-cache/blobs/sha256
       # Sets up a docker driver that supports caching.
       - name: Set up Docker Buildx
         id: buildx-setup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
           target: "${{ matrix.target }}"
           context: .
           build-args: |
-            RELEASE="${{ env.IMAGE_TAG }}"
+            RELEASE=${{ env.IMAGE_TAG }}
           tags: "${{ env.IMAGE_NAME }}"
           push: false
           load: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,19 +179,27 @@ jobs:
     env:
       ECR_REPOSITORY: ${{ matrix.repository }}
       IMAGE_TAG: ${{ github.sha }}
+      IMAGE_NAME: "dev/${{ matrix.repository }}:${{ github.sha }}"
     steps:
       - uses: actions/checkout@v3
 
-      - name: Build ${{ matrix.repository }}
-        run: |
-          IMAGE_NAME="dev/${ECR_REPOSITORY}:${IMAGE_TAG}"
-          docker buildx build \
-            --tag "${IMAGE_NAME}" \
-            --target "${{ matrix.target }}" \
-            --build-arg RELEASE="${IMAGE_TAG}" \
-            .
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
-          # Report image info
+      - name: Build ${{ matrix.repository }}
+        uses: docker/build-push-action@v3
+        with:
+          target: "${{ matrix.target }}"
+          context: .
+          build-args: |
+            RELEASE="${{ env.IMAGE_TAG }}"
+          tags: "${{ env.IMAGE_NAME }}"
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max,compression=zstd
+
+      - name: Report Image Details
+        run: |
           SIZE=$(
             docker image inspect \
               --format '{{ .VirtualSize }}' \
@@ -218,8 +226,9 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |
-          docker tag "dev/$ECR_REPOSITORY:$IMAGE_TAG" "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
-          docker push "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+          PUBLISH_NAME="$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+          docker tag "${IMAGE_NAME}" "${PUBLISH_NAME}"
+          docker push "${PUBLISH_NAME}"
 
   deploy:
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,20 @@ jobs:
             RELEASE=${{ env.IMAGE_TAG }}
           tags: "${{ env.IMAGE_NAME }}"
           push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max,compression=zstd
+
+      # This is ugly, but we build again with caches (so it shouldn't really
+      # build) and use `load: true` to make the output usable with Docker CLI.
+      - name: Build ${{ matrix.repository }}
+        uses: docker/build-push-action@v3
+        with:
+          target: "${{ matrix.target }}"
+          context: .
+          build-args: |
+            RELEASE=${{ env.IMAGE_TAG }}
+          tags: "${{ env.IMAGE_NAME }}"
+          push: false
           load: true
           cache-from: type=gha
           cache-to: type=gha,mode=max,compression=zstd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Build ${{ matrix.repository }}
+      # We have two *nearly* identical Docker build steps here because writing
+      # cached layers does not appear to be compatible with making the build
+      # output available to the Docker CLI for further commands.
+      # - The first build step does the actual build and reads/writes caches.
+      # - The second build step uses `load: true` to make its output available
+      #   to future Docker CLI commands. It's pretty quick, since it winds up
+      #   reading everything from the cache produced by the first build step.
+      - name: Build and Cache ${{ matrix.repository }}
         uses: docker/build-push-action@v3
         with:
           target: "${{ matrix.target }}"
@@ -198,9 +205,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max,compression=zstd
 
-      # This is ugly, but we build again with caches (so it shouldn't really
-      # build) and use `load: true` to make the output usable with Docker CLI.
-      - name: Build ${{ matrix.repository }}
+      - name: Load Cached Image ${{ matrix.repository }}
         uses: docker/build-push-action@v3
         with:
           target: "${{ matrix.target }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
             --tag "${IMAGE_NAME}" \
             --target "${{ matrix.target }}" \
             --build-arg RELEASE="${IMAGE_TAG}" \
-            --builder "${{ steps.buildx.outputs.name }}" \
+            --builder "${{ steps.buildx-setup.outputs.name }}" \
             --load \
             --cache-from type=gha,mode=max \
             --cache-to type=gha,mode=max \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,20 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      # The docker action should have the ability to cache directly to the
+      # GitHub Actions cache without an explicit cache action like this, but we
+      # have not been able to get it to work.
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          # Key is named differently to avoid collision
+          key: ${{ runner.os }}-buildx-${{ github.ref }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-${{ github.ref }}-${{ github.sha }}
+            ${{ runner.os }}-buildx-${{ github.ref }}-
+            ${{ runner.os }}-buildx-
+
       # Sets up a docker driver that supports caching.
       - name: Set up Docker Buildx
         id: buildx-setup
@@ -199,11 +213,20 @@ jobs:
           build-args: |
             RELEASE=${{ env.IMAGE_TAG }}
           builder: "${{ steps.buildx-setup.outputs.name }}"
-          cache-from: "type=gha,mode=max"
-          cache-to: "type=gha,mode=max"
+          # The caching mechanism will add a new copy of the cache to the
+          # destination directory, so we write the cache out to a new, clean
+          # directory and then overwrite the old cache directory with it after.
+          # (See next action.)
+          cache-from: "type=local,src=/tmp/.buildx-cache"
+          cache-to: "type=local,dest=/tmp/.buildx-cache-new,mode=max,compression=zstd"
           push: false
           # Make the image available to Docker CLI commands in the next steps.
           load: true
+
+      - name: Overwrite Old Cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
       - name: Report Image Details
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,8 @@ jobs:
           echo "Built image \`${IMAGE_NAME}\`: ${SIZE_MB} MB" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Configure AWS credentials
-        if: github.ref == 'refs/heads/main'
+        # XXX: Testing pushing with the new configuration
+        # if: github.ref == 'refs/heads/main'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -218,12 +219,14 @@ jobs:
           aws-region: us-west-2
 
       - name: Login to Amazon ECR
-        if: github.ref == 'refs/heads/main'
+        # XXX: Testing pushing with the new configuration
+        # if: github.ref == 'refs/heads/main'
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
       - name: Tag and push ${{ matrix.repository }} latest
-        if: github.ref == 'refs/heads/main'
+        # XXX: Testing pushing with the new configuration
+        # if: github.ref == 'refs/heads/main'
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,8 +190,8 @@ jobs:
         with:
           install: true
 
-      # When using a driver that supports caching (see above), you have to use
-      # `--load` to make the built image/layers available to the Docker CLI.
+      # When using a different driver (see above), you have to use `--load` to
+      # make the built image/layers available to the Docker CLI.
       - name: Build ${{ matrix.repository }}
         run: |
           docker buildx build \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,11 +192,11 @@ jobs:
           path: /tmp/.buildx-cache
           # Use the commit SHA in the key since there's no file that makes sense
           # to hash for a unique key.
-          key: ${{ runner.os }}-buildx-${{ github.ref }}-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ matrix.target }}-${{ github.ref }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-buildx-${{ github.ref }}-${{ github.sha }}
-            ${{ runner.os }}-buildx-${{ github.ref }}-
-            ${{ runner.os }}-buildx-
+            ${{ runner.os }}-buildx-${{ matrix.target }}-${{ github.ref }}-${{ github.sha }}
+            ${{ runner.os }}-buildx-${{ matrix.target }}-${{ github.ref }}-
+            ${{ runner.os }}-buildx-${{ matrix.target }}-
 
       - name: Inspect Incoming Cache
         run: |
@@ -208,9 +208,9 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx-setup
         uses: docker/setup-buildx-action@v2
-        with:
-          # install: true
-          buildkitd-flags: --debug
+        # with:
+        #   # install: true
+        #   buildkitd-flags: --debug
 
       - name: Build ${{ matrix.repository }}
         uses: docker/build-push-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Build ${{ matrix.repository }}
+        id: build-image
         uses: docker/build-push-action@v3
         with:
           target: "${{ matrix.target }}"
@@ -203,10 +204,10 @@ jobs:
           SIZE=$(
             docker image inspect \
               --format '{{ .VirtualSize }}' \
-              "${IMAGE_NAME}"
+              "${{ steps.build-image.outputs.imageid }}"
           )
           SIZE_MB=$((SIZE / 1024 / 1024))
-          echo "Built image \`${IMAGE_NAME}\`: ${SIZE_MB} MB" >> "$GITHUB_STEP_SUMMARY"
+          echo "Built image \`${{ steps.build-image.outputs.imageid }}\`: ${SIZE_MB} MB" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Configure AWS credentials
         if: github.ref == 'refs/heads/main'
@@ -227,7 +228,7 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |
           PUBLISH_NAME="$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
-          docker tag "${IMAGE_NAME}" "${PUBLISH_NAME}"
+          docker tag "${{ steps.build-image.outputs.imageid }}" "${PUBLISH_NAME}"
           docker push "${PUBLISH_NAME}"
 
   deploy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,9 @@ jobs:
             RELEASE=${{ env.IMAGE_TAG }}
           tags: "${{ env.IMAGE_NAME }}"
           push: false
+          # Make output available to Docker CLI for later commands.
           load: true
+          # Read/write layers to the GitHub Actions cache.
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
             --target "${{ matrix.target }}" \
             --build-arg RELEASE="${IMAGE_TAG}" \
             --load \
-            --cache-from type=gha \
+            --cache-from type=gha,mode=max \
             --cache-to type=gha,mode=max \
             .
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,10 @@ jobs:
 
       # Sets up a docker driver that supports caching.
       - name: Set up Docker Buildx
+        id: buildx-setup
         uses: docker/setup-buildx-action@v2
+        with:
+          install: true
 
       # When using a driver that supports caching (see above), you have to use
       # `--load` to make the built image/layers available to the Docker CLI.
@@ -195,6 +198,7 @@ jobs:
             --tag "${IMAGE_NAME}" \
             --target "${{ matrix.target }}" \
             --build-arg RELEASE="${IMAGE_TAG}" \
+            --builder "${{ steps.buildx.outputs.name }}" \
             --load \
             --cache-from type=gha,mode=max \
             --cache-to type=gha,mode=max \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,19 +190,19 @@ jobs:
         with:
           install: true
 
-      # When using a different driver (see above), you have to use `--load` to
-      # make the built image/layers available to the Docker CLI.
       - name: Build ${{ matrix.repository }}
-        run: |
-          docker buildx build \
-            --tag "${IMAGE_NAME}" \
-            --target "${{ matrix.target }}" \
-            --build-arg RELEASE="${IMAGE_TAG}" \
-            --builder "${{ steps.buildx-setup.outputs.name }}" \
-            --load \
-            --cache-from type=gha,mode=max \
-            --cache-to type=gha,mode=max \
-            .
+        uses: docker/build-push-action@v3
+        with:
+          context: "."
+          builder: "${{ steps.buildx-setup.outputs.name }}"
+          target: "${{ matrix.target }}"
+          build-args: |
+            RELEASE=${{ env.IMAGE_TAG }}
+          push: false
+          load: true
+          tags: "${{ env.IMAGE_NAME }}"
+          cache-from: "type=gha,mode=max"
+          cache-to: "type=gha,mode=max"
 
       - name: Report Image Details
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,23 +183,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      # Sets up a docker driver that supports caching.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      # - name: Build ${{ matrix.repository }}
-      #   uses: docker/build-push-action@v3
-      #   with:
-      #     target: "${{ matrix.target }}"
-      #     context: .
-      #     build-args: |
-      #       RELEASE=${{ env.IMAGE_TAG }}
-      #     tags: "${{ env.IMAGE_NAME }}"
-      #     push: false
-      #     # Make output available to Docker CLI for later commands.
-      #     load: true
-      #     # Read/write layers to the GitHub Actions cache.
-      #     cache-from: type=gha
-      #     cache-to: type=gha,mode=max
+      # When using a driver that supports caching (see above), you have to use
+      # `--load` to make the built image/layers available to the Docker CLI.
       - name: Build ${{ matrix.repository }}
         run: |
           docker buildx build \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,6 @@ jobs:
           target: "${{ matrix.target }}"
           build-args: |
             RELEASE=${{ env.IMAGE_TAG }}
-          # builder: "${{ steps.buildx-setup.outputs.name }}"
           # The caching mechanism will add a new copy of the cache to the
           # destination directory, so we write the cache out to a new, clean
           # directory and then overwrite the old cache directory with it after.


### PR DESCRIPTION
Docker layers are big and include our dependencies, so we should probably be caching them in CI just like we do our dependencies for tests, linting, etc.

This makes use of the `docker/` GitHub actions instead of our own scripts (like we used to do) because they automatically set some of the configuration up for caching with GitHub Actions.