### PR TITLE
Support HTTPS in the API load balancer

### DIFF
--- a/terraform/api-domains.tf
+++ b/terraform/api-domains.tf
@@ -41,6 +41,22 @@ resource "aws_route53_record" "api_www_domain_record" {
   ttl     = 300
 }
 
+# The `api.internal` subdomain. Used for the API service's load balancer so it
+# can be secured with HTTPS.
+resource "aws_route53_record" "api_load_balancer_domain_record" {
+  count = var.domain_name != "" ? 1 : 0
+
+  zone_id = data.aws_route53_zone.domain_zone[0].zone_id
+  name    = "api.internal"
+  type    = "A"
+
+  alias {
+    name                   = aws_alb.main.dns_name
+    zone_id                = aws_alb.main.zone_id
+    evaluate_target_health = false
+  }
+}
+
 # The `render.` subdomain.
 # This specifically points to the deployment on Render and should be deleted
 # when we tear down that deployment.

--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -80,6 +80,20 @@ resource "aws_alb_listener" "front_end" {
   }
 }
 
+# Redirect all traffic from the ALB to the target group
+resource "aws_alb_listener" "front_end_https" {
+  load_balancer_arn = aws_alb.main.id
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-FS-1-2-Res-2020-10"
+  certificate_arn   = var.ssl_certificate_arn_api_internal
+
+  default_action {
+    target_group_arn = aws_alb_target_group.api.arn
+    type             = "forward"
+  }
+}
+
 resource "aws_alb_listener_rule" "redirect_www" {
   listener_arn = aws_alb_listener.front_end.arn
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -13,6 +13,11 @@ variable "ssl_certificate_arn" {
   default     = ""
 }
 
+variable "ssl_certificate_arn_api_internal" {
+  description = "The ARN of an SSL certificate in ACM to use for the API services load balancer (must be in us-east-1)"
+  default     = ""
+}
+
 variable "domain_name" {
   description = "The domain name to use for HTTPS traffic"
   default     = ""


### PR DESCRIPTION
This covers part of #1181 by making the load balancer speak HTTPS in addition to HTTP. Once it's running, we'll shift CloudFront to using it instead of the HTTP listener. (And then later secure access with a secret header.)