### PR TITLE
Send secret header to API from CloudFront

### DIFF
--- a/terraform/api-domains.tf
+++ b/terraform/api-domains.tf
@@ -171,13 +171,18 @@ resource "aws_cloudfront_distribution" "univaf_api_ecs" {
 
   origin {
     origin_id   = "ecs.${var.domain_name}"
-    domain_name = aws_alb.main.dns_name
+    domain_name = "api.internal.${var.domain_name}"
+
+    custom_header {
+      name  = var.api_cloudfront_secret_header_name
+      value = var.api_cloudfront_secret
+    }
 
     custom_origin_config {
       http_port              = 80
       https_port             = 443
       origin_ssl_protocols   = ["SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2"]
-      origin_protocol_policy = "http-only"
+      origin_protocol_policy = "https-only"
     }
   }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -14,7 +14,7 @@ variable "ssl_certificate_arn" {
 }
 
 variable "ssl_certificate_arn_api_internal" {
-  description = "The ARN of an SSL certificate in ACM to use for the API services load balancer (must be in us-east-1)"
+  description = "The ARN of an SSL certificate in ACM to use for the API services load balancer (cerificate must be in the same region as the `aws_region` variable)"
   default     = ""
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -63,6 +63,17 @@ variable "db_size" {
   default     = 48
 }
 
+variable "api_cloudfront_secret" {
+  description = "A secret key that must be sent as a header to the API load balancer in order to access it. Used to keep the load balancer from being accessed except by CloudFront. (optional)"
+  type        = string
+  sensitive   = true
+}
+
+variable "api_cloudfront_secret_header_name" {
+  description = "Name of the HTTP header to send `api_cloudfront_secret` in."
+  default     = "X-Secret-Access-Key"
+}
+
 variable "api_keys" {
   description = "List of valid API keys for posting data to the API service. The loaders will use the first key."
   type        = list(string)


### PR DESCRIPTION
This is part 2 of #1181, and is a follow-up to #1185. It creates a secret and has CloudFront send it as a header when proxying requests to the API service. (It does not yet make the API load balancer require the secret, since the CloudFront distribution takes a while to change, and we don't want to break the service while that's happening.)

This also fixes a variable description that it turns out I got wrong in #1185.