### PR TITLE
Only allow requests through CloudFront

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -136,7 +136,7 @@ resource "aws_lb_listener_rule" "api_forward_if_secret_header" {
 
   # Add a condition requiring a secret header only if there's a secret to check.
   dynamic "condition" {
-    for_each = var.api_cloudfront_secret ? [1] : []
+    for_each = var.api_cloudfront_secret != "" ? [1] : []
     content {
       http_header {
         http_header_name = var.api_cloudfront_secret_header_name

--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -88,14 +88,21 @@ resource "aws_alb_listener" "front_end_https" {
   ssl_policy        = "ELBSecurityPolicy-FS-1-2-Res-2020-10"
   certificate_arn   = var.ssl_certificate_arn_api_internal
 
+  # Other rules below will forward if the request is OK.
   default_action {
-    target_group_arn = aws_alb_target_group.api.arn
-    type             = "forward"
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Access Denied"
+      status_code  = "403"
+    }
   }
 }
 
 resource "aws_alb_listener_rule" "redirect_www" {
   listener_arn = aws_alb_listener.front_end.arn
+  priority     = 10
 
   condition {
     host_header {
@@ -111,6 +118,37 @@ resource "aws_alb_listener_rule" "redirect_www" {
       port        = "443"
       protocol    = "HTTPS"
       status_code = "HTTP_301"
+    }
+  }
+}
+
+# If a special secret is required for access (i.e. to allow only CloudFront and
+# not any request directly from the public internet), check it before forwarding
+# to the API service.
+resource "aws_lb_listener_rule" "api_forward_if_secret_header" {
+  listener_arn = aws_alb_listener.front_end_https.arn
+  priority     = 20
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_alb_target_group.api.arn
+  }
+
+  # Add a condition requiring a secret header only if there's a secret to check.
+  dynamic "condition" {
+    for_each = var.api_cloudfront_secret ? [1] : []
+    content {
+      http_header {
+        http_header_name = var.api_cloudfront_secret_header_name
+        values           = [var.api_cloudfront_secret]
+      }
+    }
+  }
+
+  # There must be >= 1 condition; this is a no-op in case there's no secret.
+  condition {
+    host_header {
+      values = ["*"]
     }
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -67,6 +67,7 @@ variable "api_cloudfront_secret" {
   description = "A secret key that must be sent as a header to the API load balancer in order to access it. Used to keep the load balancer from being accessed except by CloudFront. (optional)"
   type        = string
   sensitive   = true
+  default     = ""
 }
 
 variable "api_cloudfront_secret_header_name" {


### PR DESCRIPTION
This locks down the API server's load balancer so that it only forwards requests to the actual service if it has a header with a secret value. CloudFront is already configured to set that header (see #1186), so this effectively allows only requests from CloudFront.

Fixes #1181.