### PR TITLE
Only allow requests through CloudFront, take 2

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -96,6 +96,7 @@ resource "aws_alb_listener" "front_end_https" {
 
 resource "aws_alb_listener_rule" "redirect_www" {
   listener_arn = aws_alb_listener.front_end.arn
+  priority     = 10
 
   condition {
     host_header {
@@ -111,6 +112,37 @@ resource "aws_alb_listener_rule" "redirect_www" {
       port        = "443"
       protocol    = "HTTPS"
       status_code = "HTTP_301"
+    }
+  }
+}
+
+# If a special secret is required for access (i.e. to allow only CloudFront and
+# not any request directly from the public internet), check it before forwarding
+# to the API service.
+resource "aws_lb_listener_rule" "api_forward_if_secret_header" {
+  listener_arn = aws_alb_listener.front_end_https.arn
+  priority     = 20
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_alb_target_group.api.arn
+  }
+
+  # Add a condition requiring a secret header only if there's a secret to check.
+  dynamic "condition" {
+    for_each = var.api_cloudfront_secret != "" ? [1] : []
+    content {
+      http_header {
+        http_header_name = var.api_cloudfront_secret_header_name
+        values           = [var.api_cloudfront_secret]
+      }
+    }
+  }
+
+  # There must be >= 1 condition; this is a no-op in case there's no secret.
+  condition {
+    source_ip {
+      values = ["0.0.0.0/0"]
     }
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -67,6 +67,7 @@ variable "api_cloudfront_secret" {
   description = "A secret key that must be sent as a header to the API load balancer in order to access it. Used to keep the load balancer from being accessed except by CloudFront. (optional)"
   type        = string
   sensitive   = true
+  default     = ""
 }
 
 variable "api_cloudfront_secret_header_name" {


### PR DESCRIPTION
This locks down the API server's load balancer so that it only forwards requests to the actual service if it has a header with a secret value. CloudFront is already configured to set that header (see #1186), so this effectively allows only requests from CloudFront.

I tried to do this in #1186 with a wildcard host header, but it turns out AWS rejects that once you actually try and apply it. This approach uses an IP match to allow all IP addresses instead, which I tested in AWS already so it should work.

This also doesn’t set the default rule to block responses, so if this goes wrong, things still work fine.