### PR TITLE
Actually disallow non-CloudFront API traffic

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -75,8 +75,13 @@ resource "aws_alb_listener" "front_end" {
   protocol          = "HTTP"
 
   default_action {
-    target_group_arn = aws_alb_target_group.api.arn
-    type             = "forward"
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
   }
 }
 
@@ -88,9 +93,15 @@ resource "aws_alb_listener" "front_end_https" {
   ssl_policy        = "ELBSecurityPolicy-FS-1-2-Res-2020-10"
   certificate_arn   = var.ssl_certificate_arn_api_internal
 
+  # Other rules below will forward if the request is OK.
   default_action {
-    target_group_arn = aws_alb_target_group.api.arn
-    type             = "forward"
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Access Denied"
+      status_code  = "403"
+    }
   }
 }
 


### PR DESCRIPTION
This actually blocks traffic that doesn't come from CloudFlare (or otherwise have the secret header) in the API server's load balancer. It also makes HTTP traffic redirect to HTTPS (we were already doing this in CloudFront, but good to do here, too).

Actually completely fixes #1181.