### PR TITLE
Actually disallow non-CloudFront traffic, take 2

### DIFF
--- a/terraform/api-domains.tf
+++ b/terraform/api-domains.tf
@@ -9,6 +9,15 @@
 # (e.g. Render.com) as its origin. If there's an external origin, it's defined
 # by the `api_remote_domain_name` variable.
 
+locals {
+  api_internal_subdomain = "api.internal"
+  api_internal_domain = (
+    var.domain_name != ""
+    ? "${local.api_internal_subdomain}.${var.domain_name}"
+    : ""
+  )
+}
+
 # Domains ---------------------------------------------------------------------
 
 data "aws_route53_zone" "domain_zone" {
@@ -47,7 +56,7 @@ resource "aws_route53_record" "api_load_balancer_domain_record" {
   count = var.domain_name != "" ? 1 : 0
 
   zone_id = data.aws_route53_zone.domain_zone[0].zone_id
-  name    = "api.internal"
+  name    = local.api_internal_subdomain
   type    = "A"
 
   alias {
@@ -171,7 +180,7 @@ resource "aws_cloudfront_distribution" "univaf_api_ecs" {
 
   origin {
     origin_id   = "ecs.${var.domain_name}"
-    domain_name = "api.internal.${var.domain_name}"
+    domain_name = local.api_internal_domain
 
     custom_header {
       name  = var.api_cloudfront_secret_header_name

--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -75,8 +75,13 @@ resource "aws_alb_listener" "front_end" {
   protocol          = "HTTP"
 
   default_action {
-    target_group_arn = aws_alb_target_group.api.arn
-    type             = "forward"
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
   }
 }
 
@@ -88,9 +93,15 @@ resource "aws_alb_listener" "front_end_https" {
   ssl_policy        = "ELBSecurityPolicy-FS-1-2-Res-2020-10"
   certificate_arn   = var.ssl_certificate_arn_api_internal
 
+  # Other rules below will forward if the request is OK.
   default_action {
-    target_group_arn = aws_alb_target_group.api.arn
-    type             = "forward"
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Access Denied"
+      status_code  = "403"
+    }
   }
 }
 

--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -158,6 +158,24 @@ resource "aws_lb_listener_rule" "api_forward_if_secret_header" {
   }
 }
 
+# Allow requests in if they have a valid API key.
+resource "aws_lb_listener_rule" "api_forward_if_secret_header" {
+  listener_arn = aws_alb_listener.front_end_https.arn
+  priority     = 30
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_alb_target_group.api.arn
+  }
+
+  condition {
+    http_header {
+      http_header_name = "x-api-key"
+      values           = var.api_keys
+    }
+  }
+}
+
 # This service definition keeps the API server task running, connects it to the
 # load balancer, and manages multiple instances. (The actual scaling policies
 # are in a separate file.)

--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -159,7 +159,7 @@ resource "aws_lb_listener_rule" "api_forward_if_secret_header" {
 }
 
 # Allow requests in if they have a valid API key.
-resource "aws_lb_listener_rule" "api_forward_if_secret_header" {
+resource "aws_lb_listener_rule" "api_forward_if_api_key" {
   listener_arn = aws_alb_listener.front_end_https.arn
   priority     = 30
 

--- a/terraform/loaders.tf
+++ b/terraform/loaders.tf
@@ -56,6 +56,8 @@ module "source_loader" {
   source   = "./modules/task"
   for_each = local.loaders
 
+  depends_on = [aws_alb.main]
+
   name = each.key
   command = concat(
     lookup(each.value, "options", []),
@@ -63,7 +65,11 @@ module "source_loader" {
   )
   env_vars = merge({
     # NOTE: loaders go directly to the API load balancer, not CloudFront.
-    API_URL    = "http://${aws_alb.main.dns_name}"
+    API_URL = (
+      local.api_internal_domain
+      ? "https://${local.api_internal_domain}"
+      : "http://${aws_alb.main.dns_name}"
+    )
     API_KEY    = var.api_keys[0]
     DD_API_KEY = var.datadog_api_key
     SENTRY_DSN = var.loader_sentry_dsn

--- a/terraform/loaders.tf
+++ b/terraform/loaders.tf
@@ -66,7 +66,7 @@ module "source_loader" {
   env_vars = merge({
     # NOTE: loaders go directly to the API load balancer, not CloudFront.
     API_URL = (
-      local.api_internal_domain
+      local.api_internal_domain != ""
       ? "https://${local.api_internal_domain}"
       : "http://${aws_alb.main.dns_name}"
     )


### PR DESCRIPTION
This has been a messy afternoon. I thought I was good to go in #1189, but then realized I had accidentally started blocking the loaders from sending data to the API. This new approach should make sure loaders use HTTPS and the right domain for the load balancer, plus allow them through since they supply a valid API key.