### PR TITLE
Pass auth headers through CloudFlare

### DIFF
--- a/terraform/api-domains.tf
+++ b/terraform/api-domains.tf
@@ -141,7 +141,7 @@ resource "aws_cloudfront_distribution" "univaf_api_render" {
     max_ttl                = 3600
 
     forwarded_values {
-      headers      = ["Host", "Origin"]
+      headers      = ["Host", "Origin", "Authorization", "x-api-key"]
       query_string = true
 
       cookies {
@@ -204,7 +204,7 @@ resource "aws_cloudfront_distribution" "univaf_api_ecs" {
     max_ttl                = 3600
 
     forwarded_values {
-      headers      = ["Host", "Origin"]
+      headers      = ["Host", "Origin", "Authorization", "x-api-key"]
       query_string = true
 
       cookies {


### PR DESCRIPTION
We were accidentally swallowing auth-related headers in CloudFlare! We probably never noticed because the loaders (and other data-submitting partners in the past) went direct to the load balancer. (Noticed in the mess with #1190.) At any rate, this resolves the issue, so we could have the loaders talk through CloudFlare now if we wanted.