### PR TITLE
HyVee: support new infant pfizer bivalent code

### DIFF
--- a/loader/src/sources/hyvee/index.js
+++ b/loader/src/sources/hyvee/index.js
@@ -44,6 +44,7 @@ const VACCINE_NAMES = {
   "Pediatric Pfizer Bivalent (5-11)": VaccineProduct.pfizerBa4Ba5Age5_11,
   "Pediatric-Pfizer (under 5)": VaccineProduct.pfizerAge0_4,
   "Pediatric-Pfizer Bivalent (under 5)": VaccineProduct.pfizerBa4Ba5Age0_4,
+  "Pediatric Pfizer Bivalent 3-4": VaccineProduct.pfizerBa4Ba5Age0_4,
   Janssen: VaccineProduct.janssen,
   Novavax: VaccineProduct.novavax,
 };


### PR DESCRIPTION
HyVee started surfacing appointments with the code `"Pediatric Pfizer Bivalent 3-4"` yesterday afternoon and this adds support for it. There's no change to the cassette recordings for tests because we *stopped* seeing that code shortly after, so making a new recording now wouldn't add it to the test. That said, there's no reason to expect we won't see this again in the future, so it's still worth adding support for. I've also added a version with parentheses to match other styles we've seen from HyVee.

(These are starting to get so varied and non-conventional that I'm beginning to think we should run these through the `matchVaccineProduct()` fuzzy parser instead of keeping a list of exact matches.)

Fixes https://sentry.io/organizations/usdr/issues/3829987637.