### PR TITLE
Ignore chickenpox vaccine in Prepmod

### DIFF
--- a/loader/src/sources/prepmod/index.js
+++ b/loader/src/sources/prepmod/index.js
@@ -295,6 +295,8 @@ const nonCovidProductName = new RegExp(
     raw`\bPPSV(\d+)?\b`,
     // Measles, Mumps, Rubella Vaccine
     raw`\bMMRV??\b`,
+    // Chickenpox Vaccine
+    raw`\b(varicella|chickenpox)\b`,
     // In all cases we've seen, this occurs on schedules that list other actual
     // vaccine names as well. We'll pick up the true products from the other
     // extensions in the schedule.


### PR DESCRIPTION
Prepmod is now showing the chickenpox vaccine. Fixes https://sentry.io/organizations/usdr/issues/3873901705.