### PR TITLE
Add CDN for archived data in S3

### DIFF
--- a/terraform/api-domains.tf
+++ b/terraform/api-domains.tf
@@ -75,21 +75,6 @@ resource "aws_route53_record" "api_load_balancer_domain_record" {
   }
 }
 
-# # Serves archived, historical data from S3 via CloudFront.
-# resource "aws_route53_record" "data_snapshots_domain_record" {
-#   count = var.domain_name != "" ? 1 : 0
-
-#   zone_id = data.aws_route53_zone.domain_zone[0].zone_id
-#   name    = local.data_snapshots_domain
-#   type    = "A"
-
-#   alias {
-#     name                   = module.univaf_data_snaphsots_cdn[0].cf_domain_name
-#     zone_id                = module.univaf_data_snaphsots_cdn[0].cf_hosted_zone_id
-#     evaluate_target_health = false
-#   }
-# }
-
 # The `render.` subdomain.
 # This specifically points to the deployment on Render and should be deleted
 # when we tear down that deployment.
@@ -249,101 +234,29 @@ resource "aws_cloudfront_distribution" "univaf_api_ecs" {
   }
 }
 
-# Use CloudFront to provide a protective caching layer and a nice domain anme
-# in front of the S3 bucket with historical data. (Allowing direct public
-# access can get expensive.)
+# Provide a protective caching layer and a nice domain name for the S3 bucket
+# with historical data. (Allowing direct public access can get expensive.)
+# Docs: https://github.com/cloudposse/terraform-aws-cloudfront-s3-cdn
 module "univaf_data_snaphsots_cdn" {
   count = (
     var.domain_name != ""
     && var.ssl_certificate_arn != "" ? 1 : 0
   )
-
   source  = "cloudposse/cloudfront-s3-cdn/aws"
   version = "0.86.0"
 
-  origin_bucket = aws_s3_bucket.data_snapshots.bucket
-  # FIXME: If `aliases` are DNS records this will create; `external_aliases`
-  # are ones it will not. Both are merged together to create a list of valid
-  # aliases for the distribution.
+  origin_bucket                     = aws_s3_bucket.data_snapshots.bucket
   dns_alias_enabled                 = true
   aliases                           = [local.data_snapshots_domain]
-  parent_zone_name                  = var.domain_name
+  parent_zone_id                    = data.aws_route53_zone.domain_zone[0].zone_id
   acm_certificate_arn               = var.ssl_certificate_arn
   cloudfront_access_logging_enabled = false
 
+  default_ttl     = 60 * 60 * 24 * 7 # 1 Week
   http_version    = "http2and3"
   allowed_methods = ["GET", "HEAD", "OPTIONS"]
   cached_methods  = ["GET", "HEAD", "OPTIONS"]
   # By default, CORS headers are forwarded, but we don't really care about them
   # since the bucket is not operating in "website" mode.
   forward_header_values = []
-  default_ttl           = 60 * 60 * 24 * 7 # 1 Week
 }
-
-# locals {
-#   data_snapshots_origin_id = "s3_data_snapshots_origin"
-# }
-
-# resource "aws_cloudfront_origin_access_control" "univaf_data_snaphsots_access" {
-#   count = (
-#     var.domain_name != ""
-#     && var.ssl_certificate_arn != "" ? 1 : 0
-#   )
-#   name                              = "univaf_data_snaphsots_access"
-#   description                       = "Access control for data snapshots S3 bucket"
-#   origin_access_control_origin_type = "s3"
-#   signing_behavior                  = "always"
-#   signing_protocol                  = "sigv4"
-# }
-
-# resource "aws_cloudfront_distribution" "univaf_data_snapshots" {
-#   count = (
-#     var.domain_name != ""
-#     && var.ssl_certificate_arn != "" ? 1 : 0
-#   )
-#   enabled         = true
-#   is_ipv6_enabled = true
-#   price_class     = "PriceClass_100" # North America
-#   aliases         = [local.data_snapshots_domain]
-#   http_version    = "http2and3"
-
-#   origin {
-#     domain_name              = aws_s3_bucket.data_snapshots.bucket_regional_domain_name
-#     origin_id                = local.data_snapshots_origin_id
-#     origin_access_control_id = aws_cloudfront_origin_access_control.univaf_data_snaphsots_access[0].id
-#   }
-
-#   default_cache_behavior {
-#     # Writes need to be authorized and go through the normal S3 API;
-#     # Disallow "DELETE", "PATCH", "POST", "PUT" in CloudFront.
-#     allowed_methods        = ["GET", "HEAD", "OPTIONS"]
-#     cached_methods         = ["GET", "HEAD", "OPTIONS"]
-#     target_origin_id       = local.data_snapshots_origin_id
-#     viewer_protocol_policy = "redirect-to-https"
-#     min_ttl                = 0
-#     default_ttl            = 60 * 60 * 24 * 7 # 1 Week
-#     max_ttl = 3600
-
-#     forwarded_values {
-#       query_string = false
-
-#       cookies {
-#         forward = "none"
-#       }
-#     }
-#   }
-
-#   viewer_certificate {
-#     # FIXME: need to set up a certificate or this, or expand the existing
-#     # certificate to include the domain for this.
-#     cloudfront_default_certificate = true
-#     # acm_certificate_arn = var.ssl_certificate_arn
-#     # ssl_support_method  = "sni-only"
-#   }
-
-#   restrictions {
-#     geo_restriction {
-#       restriction_type = "none"
-#     }
-#   }
-# }

--- a/terraform/api-domains.tf
+++ b/terraform/api-domains.tf
@@ -75,20 +75,20 @@ resource "aws_route53_record" "api_load_balancer_domain_record" {
   }
 }
 
-# Serves archived, historical data from S3 via CloudFront.
-resource "aws_route53_record" "data_snapshots_domain_record" {
-  count = var.domain_name != "" ? 1 : 0
+# # Serves archived, historical data from S3 via CloudFront.
+# resource "aws_route53_record" "data_snapshots_domain_record" {
+#   count = var.domain_name != "" ? 1 : 0
 
-  zone_id = data.aws_route53_zone.domain_zone[0].zone_id
-  name    = local.data_snapshots_domain
-  type    = "A"
+#   zone_id = data.aws_route53_zone.domain_zone[0].zone_id
+#   name    = local.data_snapshots_domain
+#   type    = "A"
 
-  alias {
-    name                   = module.univaf_data_snaphsots_cdn[0].cf_domain_name
-    zone_id                = module.univaf_data_snaphsots_cdn[0].cf_hosted_zone_id
-    evaluate_target_health = false
-  }
-}
+#   alias {
+#     name                   = module.univaf_data_snaphsots_cdn[0].cf_domain_name
+#     zone_id                = module.univaf_data_snaphsots_cdn[0].cf_hosted_zone_id
+#     evaluate_target_health = false
+#   }
+# }
 
 # The `render.` subdomain.
 # This specifically points to the deployment on Render and should be deleted
@@ -265,16 +265,14 @@ module "univaf_data_snaphsots_cdn" {
   # FIXME: If `aliases` are DNS records this will create; `external_aliases`
   # are ones it will not. Both are merged together to create a list of valid
   # aliases for the distribution.
-  dns_alias_enabled = true
-  # aliases                         = [local.data_snapshots_domain]
-  external_aliases                  = [local.data_snapshots_domain]
+  dns_alias_enabled                 = true
+  aliases                           = [local.data_snapshots_domain]
   parent_zone_name                  = var.domain_name
   acm_certificate_arn               = var.ssl_certificate_arn
   cloudfront_access_logging_enabled = false
   default_ttl                       = 60 * 60 * 24 * 7 # 1 Week
 
-
-
+  http_version    = "http2and3"
   allowed_methods = ["GET", "HEAD", "OPTIONS"]
   cached_methods  = ["GET", "HEAD", "OPTIONS"]
 }

--- a/terraform/api-domains.tf
+++ b/terraform/api-domains.tf
@@ -262,9 +262,10 @@ module "univaf_data_snaphsots_cdn" {
   version = "0.86.0"
 
   origin_bucket = aws_s3_bucket.data_snapshots.bucket
-  # FIXME: If `dns_alias_enabled` is true, this will create DNS records (nice!)
-  # And we should set `aliases` instead of `external_aliases`.
-  # dns_alias_enabled               = true
+  # FIXME: If `aliases` are DNS records this will create; `external_aliases`
+  # are ones it will not. Both are merged together to create a list of valid
+  # aliases for the distribution.
+  dns_alias_enabled = true
   # aliases                         = [local.data_snapshots_domain]
   external_aliases                  = [local.data_snapshots_domain]
   parent_zone_name                  = var.domain_name
@@ -275,7 +276,7 @@ module "univaf_data_snaphsots_cdn" {
   # certificate to include the domain for this.
   # acm_certificate_arn = var.ssl_certificate_arn
 
-  allowed_methods = ["DELETE", "GET", "HEAD", "OPTIONS"]
+  allowed_methods = ["GET", "HEAD", "OPTIONS"]
   cached_methods  = ["GET", "HEAD", "OPTIONS"]
 }
 
@@ -315,7 +316,7 @@ module "univaf_data_snaphsots_cdn" {
 #   default_cache_behavior {
 #     # Writes need to be authorized and go through the normal S3 API;
 #     # Disallow "DELETE", "PATCH", "POST", "PUT" in CloudFront.
-#     allowed_methods        = ["DELETE", "GET", "HEAD", "OPTIONS"]
+#     allowed_methods        = ["GET", "HEAD", "OPTIONS"]
 #     cached_methods         = ["GET", "HEAD", "OPTIONS"]
 #     target_origin_id       = local.data_snapshots_origin_id
 #     viewer_protocol_policy = "redirect-to-https"

--- a/terraform/api-domains.tf
+++ b/terraform/api-domains.tf
@@ -270,11 +270,14 @@ module "univaf_data_snaphsots_cdn" {
   parent_zone_name                  = var.domain_name
   acm_certificate_arn               = var.ssl_certificate_arn
   cloudfront_access_logging_enabled = false
-  default_ttl                       = 60 * 60 * 24 * 7 # 1 Week
 
   http_version    = "http2and3"
   allowed_methods = ["GET", "HEAD", "OPTIONS"]
   cached_methods  = ["GET", "HEAD", "OPTIONS"]
+  # By default, CORS headers are forwarded, but we don't really care about them
+  # since the bucket is not operating in "website" mode.
+  forward_header_values = []
+  default_ttl           = 60 * 60 * 24 * 7 # 1 Week
 }
 
 # locals {

--- a/terraform/api-domains.tf
+++ b/terraform/api-domains.tf
@@ -262,9 +262,11 @@ module "univaf_data_snaphsots_cdn" {
   version = "0.86.0"
 
   origin_bucket = aws_s3_bucket.data_snapshots.bucket
-  aliases       = [local.data_snapshots_domain]
-  # FIXME: don't need to create DNS; dns_alias_enabled does it for us
-  # dns_alias_enabled                   = true
+  # FIXME: If `dns_alias_enabled` is true, this will create DNS records (nice!)
+  # And we should set `aliases` instead of `external_aliases`.
+  # dns_alias_enabled               = true
+  # aliases                         = [local.data_snapshots_domain]
+  external_aliases                  = [local.data_snapshots_domain]
   parent_zone_name                  = var.domain_name
   cloudfront_access_logging_enabled = false
   default_ttl                       = 60 * 60 * 24 * 7 # 1 Week
@@ -272,6 +274,9 @@ module "univaf_data_snaphsots_cdn" {
   # FIXME: need to set up a certificate or this, or expand the existing
   # certificate to include the domain for this.
   # acm_certificate_arn = var.ssl_certificate_arn
+
+  allowed_methods = ["DELETE", "GET", "HEAD", "OPTIONS"]
+  cached_methods  = ["GET", "HEAD", "OPTIONS"]
 }
 
 # locals {
@@ -315,8 +320,7 @@ module "univaf_data_snaphsots_cdn" {
 #     target_origin_id       = local.data_snapshots_origin_id
 #     viewer_protocol_policy = "redirect-to-https"
 #     min_ttl                = 0
-#     # FIXME: determine appropriate long cache lifetime, since this data
-#     # is theoretically immutable.
+#     default_ttl            = 60 * 60 * 24 * 7 # 1 Week
 #     max_ttl = 3600
 
 #     forwarded_values {

--- a/terraform/api-domains.tf
+++ b/terraform/api-domains.tf
@@ -261,10 +261,13 @@ module "univaf_data_snaphsots_cdn" {
   source  = "cloudposse/cloudfront-s3-cdn/aws"
   version = "0.86.0"
 
-  origin_bucket     = aws_s3_bucket.data_snapshots.bucket
-  aliases           = [local.data_snapshots_domain]
-  dns_alias_enabled = true
-  parent_zone_name  = var.domain_name
+  origin_bucket = aws_s3_bucket.data_snapshots.bucket
+  aliases       = [local.data_snapshots_domain]
+  # FIXME: don't need to create DNS; dns_alias_enabled does it for us
+  # dns_alias_enabled                   = true
+  parent_zone_name                  = var.domain_name
+  cloudfront_access_logging_enabled = false
+  default_ttl                       = 60 * 60 * 24 * 7 # 1 Week
 
   # FIXME: need to set up a certificate or this, or expand the existing
   # certificate to include the domain for this.

--- a/terraform/api-domains.tf
+++ b/terraform/api-domains.tf
@@ -269,12 +269,11 @@ module "univaf_data_snaphsots_cdn" {
   # aliases                         = [local.data_snapshots_domain]
   external_aliases                  = [local.data_snapshots_domain]
   parent_zone_name                  = var.domain_name
+  acm_certificate_arn               = var.ssl_certificate_arn
   cloudfront_access_logging_enabled = false
   default_ttl                       = 60 * 60 * 24 * 7 # 1 Week
 
-  # FIXME: need to set up a certificate or this, or expand the existing
-  # certificate to include the domain for this.
-  # acm_certificate_arn = var.ssl_certificate_arn
+
 
   allowed_methods = ["GET", "HEAD", "OPTIONS"]
   cached_methods  = ["GET", "HEAD", "OPTIONS"]

--- a/terraform/api-domains.tf
+++ b/terraform/api-domains.tf
@@ -10,15 +10,24 @@
 # by the `api_remote_domain_name` variable.
 
 locals {
+  # The domain of the API service's load balancer (not for public use).
   api_internal_subdomain = "api.internal"
   api_internal_domain = (
     var.domain_name != ""
     ? "${local.api_internal_subdomain}.${var.domain_name}"
     : ""
   )
+
+  # Domain at which to serve archived, historical data (stored in S3).
+  data_snapshots_subdomain = "archives"
+  data_snapshots_domain = (
+    var.domain_name != ""
+    ? "${local.data_snapshots_subdomain}.${var.domain_name}"
+    : ""
+  )
 }
 
-# Domains ---------------------------------------------------------------------
+# Domain DNS Recods -----------------------------------------------------------
 
 data "aws_route53_zone" "domain_zone" {
   count = var.domain_name != "" ? 1 : 0
@@ -62,6 +71,21 @@ resource "aws_route53_record" "api_load_balancer_domain_record" {
   alias {
     name                   = aws_alb.main.dns_name
     zone_id                = aws_alb.main.zone_id
+    evaluate_target_health = false
+  }
+}
+
+# Serves archived, historical data from S3 via CloudFront.
+resource "aws_route53_record" "data_snapshots_domain_record" {
+  count = var.domain_name != "" ? 1 : 0
+
+  zone_id = data.aws_route53_zone.domain_zone[0].zone_id
+  name    = local.data_snapshots_domain
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.univaf_data_snapshots[0].domain_name
+    zone_id                = aws_cloudfront_distribution.univaf_data_snapshots[0].hosted_zone_id
     evaluate_target_health = false
   }
 }
@@ -216,6 +240,69 @@ resource "aws_cloudfront_distribution" "univaf_api_ecs" {
   viewer_certificate {
     acm_certificate_arn = var.ssl_certificate_arn
     ssl_support_method  = "sni-only"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+}
+
+# Use CloudFront to provide a protective caching layer and a nice domain anme
+# in front of the S3 bucket with historical data. (Allowing direct public
+# access can get expensive.)
+locals {
+  data_snapshots_origin_id = "s3_data_snapshots_origin"
+}
+
+resource "aws_cloudfront_distribution" "univaf_data_snapshots" {
+  count = (
+    var.domain_name != ""
+    && var.ssl_certificate_arn != "" ? 1 : 0
+  )
+  enabled         = true
+  is_ipv6_enabled = true
+  price_class     = "PriceClass_100" # North America
+  aliases         = [local.data_snapshots_domain]
+  http_version    = "http2and3"
+
+  origin {
+    domain_name = aws_s3_bucket.data_snapshots.bucket_regional_domain_name
+    origin_id   = local.data_snapshots_origin_id
+    # origin_access_control_id = aws_cloudfront_origin_access_control.default.id
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.default.cloudfront_access_identity_path
+    }
+  }
+
+  default_cache_behavior {
+    # Writes need to be authorized and go through the normal S3 API;
+    # Disallow "DELETE", "PATCH", "POST", "PUT" in CloudFront.
+    allowed_methods        = ["DELETE", "GET", "HEAD", "OPTIONS"]
+    cached_methods         = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id       = local.data_snapshots_origin_id
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    # FIXME: determine appropriate long cache lifetime, since this data
+    # is theoretically immutable.
+    max_ttl = 3600
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
+  viewer_certificate {
+    # FIXME: need to set up a certificate or this, or expand the existing
+    # certificate to include the domain for this.
+    cloudfront_default_certificate = true
+    # acm_certificate_arn = var.ssl_certificate_arn
+    # ssl_support_method  = "sni-only"
   }
 
   restrictions {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.11"
+      version = "~> 4.52"
     }
   }
 }

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -7,11 +7,13 @@ resource "aws_s3_bucket" "data_snapshots" {
   bucket = "univaf-data-snapshots"
 }
 
+# FIXME: Change acl to "private" once we confirm CloudFront is working.
 resource "aws_s3_bucket_acl" "data_snapshots_acl" {
   bucket = aws_s3_bucket.data_snapshots.id
   acl    = "public-read"
 }
 
+# FIXME: Remove policy once we confirm CloudFront is working.
 resource "aws_s3_bucket_policy" "data_snapshots" {
   bucket = aws_s3_bucket.data_snapshots.id
   policy = jsonencode({


### PR DESCRIPTION
This adds a CloudFront distribution to serve data from our "data snaphsots" S3 bucket at `https://archives.getmyvax.org`. The goal here is mainly to prevent people from potentially driving up S3 costs by making requests we can't control or cache against the bucket. (Per @TylerHendrickson’s guidance.)

This is a first step for #1180. After we confirm this is deployed and working, we’ll need to revoke public read access from the S3 bucket.