### PR TITLE
Revoke public access to data snapshots bucket

### DIFF
--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -7,26 +7,9 @@ resource "aws_s3_bucket" "data_snapshots" {
   bucket = "univaf-data-snapshots"
 }
 
-# FIXME: Change acl to "private" once we confirm CloudFront is working.
 resource "aws_s3_bucket_acl" "data_snapshots_acl" {
   bucket = aws_s3_bucket.data_snapshots.id
-  acl    = "public-read"
-}
-
-# FIXME: Remove policy once we confirm CloudFront is working.
-resource "aws_s3_bucket_policy" "data_snapshots" {
-  bucket = aws_s3_bucket.data_snapshots.id
-  policy = jsonencode({
-    Version = "2008-10-17"
-    Id      = "Policy8542383977173"
-    Statement = [{
-      Sid       = "PublicReadAccess"
-      Effect    = "Allow"
-      Principal = "*"
-      Action    = "s3:GetObject"
-      Resource  = "${aws_s3_bucket.data_snapshots.arn}/*"
-    }]
-  })
+  acl    = "private"
 }
 
 # Alternative deployments that are being tested write to this bucket instead.

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -1,7 +1,8 @@
 # S3 Buckets
 #
-# The API server stores historical logs and daily snapshots of the databse in
-# S3 for later analysis. This data, like the API is publicly accessible.
+# The API server stores historical logs and daily snapshots of the database in
+# S3 for later analysis. It is publicly available via CloudFront, which reads
+# from the bucket.
 
 resource "aws_s3_bucket" "data_snapshots" {
   bucket = "univaf-data-snapshots"


### PR DESCRIPTION
The data in the data snapshots S3 bucket is now available via CloudFront at `https://archives.getmyvax.org`, so we are ready to revoke public read access to the bucket. Fixes #1180.