### PR TITLE
Clean up failed upload parts in S3

### DIFF
--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -51,7 +51,7 @@ resource "aws_s3_bucket_policy" "render_test_data_snapshots" {
   })
 }
 
-resource "aws_s3_bucket_lifecycle_configuration" "data_snapshots" {
+resource "aws_s3_bucket_lifecycle_configuration" "render_test_data_snapshots" {
   bucket = aws_s3_bucket.render_test_data_snapshots.id
 
   rule {

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -13,6 +13,19 @@ resource "aws_s3_bucket_acl" "data_snapshots_acl" {
   acl    = "private"
 }
 
+resource "aws_s3_bucket_lifecycle_configuration" "data_snapshots" {
+  bucket = aws_s3_bucket.data_snapshots.id
+
+  rule {
+    id     = "Delete old incomplete multipart uploads"
+    status = "Enabled"
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
+    }
+  }
+}
+
 # Alternative deployments that are being tested write to this bucket instead.
 resource "aws_s3_bucket" "render_test_data_snapshots" {
   bucket = "univaf-render-test-data-snapshots"
@@ -36,4 +49,17 @@ resource "aws_s3_bucket_policy" "render_test_data_snapshots" {
       Resource  = "${aws_s3_bucket.render_test_data_snapshots.arn}/*"
     }]
   })
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "data_snapshots" {
+  bucket = aws_s3_bucket.render_test_data_snapshots.id
+
+  rule {
+    id     = "Delete old incomplete multipart uploads"
+    status = "Enabled"
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
+    }
+  }
 }


### PR DESCRIPTION
Today I learned that multipart S3 uploads can leave the parts behind if they fail, taking up space in S3 even though they don't show up as complete objects (thanks, @TylerHendrickson). Since all streaming uploads and large uploads done using the AWS libraries or CLI are multipart, this applies to all our uploads. This policy should help clean them up. (We've rarely seen failures, but this is still good practice.)