### PR TITLE
Take more care when writing logs to S3

### DIFF
--- a/server/scripts/availability_dump.js
+++ b/server/scripts/availability_dump.js
@@ -103,7 +103,7 @@ async function getAllBucketObjects(options) {
  * stream might emit data in small chunks, while the next stream in a pipeline
  * works more efficiently with larger chunks, or chunks of a given size.
  *
- * In practice, we use this for gzipping, since gzip stream work most
+ * In practice, we use this for gzipping, since gzip streams work most
  * efficiently if data comes in chunks of at least 32 kB (this actually makes
  * a pretty big difference).
  *

--- a/server/scripts/availability_dump.js
+++ b/server/scripts/availability_dump.js
@@ -195,7 +195,7 @@ function getProviderLocationsStream() {
 /**
  * Create a Knex query for availability logs on a given date.
  * @param {luxon.DateTime} date
- * @returns {knex.Knex<KnexType<any, unknown[]>}
+ * @returns {knex.Knex<any, unknown[]>}
  */
 function availabilityLogQueryForDate(date) {
   return db("availability_log")


### PR DESCRIPTION
At the end of last week, I discovered some bugs with how we write historical data to S3, and this should resolve them:
- Check for logs to be written before actually writing log files. Since we clear out old logs (they inflate the database unreasonably), not doing this previously led to us overwriting some valid log files with empty logs because we’d cleared the data for that date!
- Page through *all* objects in S3. The S3 APIs only list up to 1,000 objects, and we now have more than that many log files in the data snapshots bucket. This led to us overwriting recent log files because the script didn’t see that they already existed, and also led to the above issue where we overwrite valid logfiles with empty ones.