### PR TITLE
Support removing "Remote" domain name

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -9,5 +9,9 @@ output "cloudfront_hostname_ecs" {
 }
 
 output "cloudfront_hostname_render" {
-  value = aws_cloudfront_distribution.univaf_api_render[0].domain_name
+  value = (
+    var.api_remote_domain_name != ""
+    ? aws_cloudfront_distribution.univaf_api_render[0].domain_name
+    : ""
+  )
 }


### PR DESCRIPTION
We no longer have anything deployed in Render or other hosts, so make sure the Terraform configuration can handle removing the remote domain name variable.