### PR TITLE
Turn on Container Instights for ECS

### DIFF
--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -7,6 +7,11 @@
 
 resource "aws_ecs_cluster" "main" {
   name = "univaf-cluster"
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
 }
 
 


### PR DESCRIPTION
While cleaning up old Render.com stuff, I noticed that we are incurring serious costs from traffic going through our NAT Gateways on AWS. It's a little hard to tell the actual cause, and I'm wondering how much of it might be coming from the loaders (and whether that's receiving data from external sources or sending formatted data to the API). The Datadog Agent doesn't work very well on our short-lived loader tasks, so I'm turning on Container Insights, which should give us metrics in CloudWatch about the network usage by each container.