### PR TITLE
Try running loaders on default subnets

### DIFF
--- a/terraform/loaders.tf
+++ b/terraform/loaders.tf
@@ -87,9 +87,12 @@ module "source_loader_schedule" {
   source   = "./modules/schedule"
   for_each = local.loaders
 
-  schedule        = each.value.schedule
-  task            = module.source_loader[each.key]
-  cluster_arn     = aws_ecs_cluster.main.arn
-  subnets         = aws_subnet.private.*.id
+  schedule    = each.value.schedule
+  task        = module.source_loader[each.key]
+  cluster_arn = aws_ecs_cluster.main.arn
+  # TODO: This is a test of whether using the default subnets reduces our NAT
+  # Gateway charges. (The are a lot!)
+  # subnets         = aws_subnet.private.*.id
+  subnets         = aws_default_subnet.public.*.id
   security_groups = [aws_security_group.ecs_tasks.id]
 }

--- a/terraform/networks.tf
+++ b/terraform/networks.tf
@@ -42,6 +42,17 @@ resource "aws_route" "internet_access" {
   gateway_id             = aws_internet_gateway.gw.id
 }
 
+# TODO: This is part of a test with gateway pricing for loaders. Remove when
+# done or add more complete documentation.
+resource "aws_default_subnet" "public" {
+  count             = var.az_count
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+
+  tags = {
+    Name = "Default subnet for ${data.aws_availability_zones.available.names[count.index]}"
+  }
+}
+
 
 # Private Network -------------------------------------------------------------
 


### PR DESCRIPTION
We're getting pretty extreme Internet Gateway costs that appear to mostly be coming from the amount of data we pull in from outside parties in the loader. This is an experiment to see whether running the loaders in the default subnets avoids some of that cost.

(In #1321 I tried compressing the data we send from the loaders, but when charting the dat in cloudwatch it’s clear that the *vast* majority of costs are data from the public internet. That change improved things, but not in a significant way.)