### PR TITLE
Run loaders on UNIVAF public subnets

### DIFF
--- a/terraform/networks.tf
+++ b/terraform/networks.tf
@@ -8,8 +8,6 @@
 # Fetch AZs in the current region
 data "aws_availability_zones" "available" {}
 
-resource "aws_default_vpc" "default" {}
-
 resource "aws_vpc" "main" {
   cidr_block = "172.17.0.0/16"
 
@@ -42,17 +40,6 @@ resource "aws_route" "internet_access" {
   route_table_id         = aws_vpc.main.main_route_table_id
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = aws_internet_gateway.gw.id
-}
-
-# TODO: This is part of a test with gateway pricing for loaders. Remove when
-# done or add more complete documentation.
-resource "aws_default_subnet" "public" {
-  count             = var.az_count
-  availability_zone = data.aws_availability_zones.available.names[count.index]
-
-  tags = {
-    Name = "Default subnet for ${data.aws_availability_zones.available.names[count.index]}"
-  }
 }
 
 


### PR DESCRIPTION
This moves our loaders back onto the UNIVAF VPC, but using the public subnet instead of the private one. In #1322 and #1323, I misunderstood the Internet Gateway vs. NAT Gateway that were operating in our various subnets. What we really needed was for loaders to have public IPs (they always have, it turns out!) and an IG. Our private subnets don't have an IG, and our public networks do (that's *mainly* what makes them private vs. public). The default subnets all have IGs. So really we just need to run the loaders in the UNIVAF VPC's public subnet. The other lesson learned here was that the smart thing in this case is probably to also give them a new Security Group that has no ingress at all (so they can make connections to other services, but not the other way around -- important since they are otherwise publicly addressable because of the public IP and IG).

I’m going to wait until tomorrow morning (March 2) to deploy this change; I want to confirm in the billing panel that the changes I already made did in fact change our NAT Gateway usage issues and that I understand things correctly.