### PR TITLE
Expire old build images in ECR

### DIFF
--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -4,6 +4,27 @@
 # store the container images. Images are built and published to these
 # repositories by GitHub Actions.
 
+locals {
+  ecr_keep_10_images_policy = <<EOF
+    {
+      "rules": [
+        {
+          "rulePriority": 1,
+          "description": "Keep last 10 images",
+          "selection": {
+            "tagStatus": "any",
+            "countType": "imageCountMoreThan",
+            "countNumber": 10
+          },
+          "action": {
+            "type": "expire"
+          }
+        }
+      ]
+    }
+  EOF
+}
+
 resource "aws_ecr_repository" "server_repository" {
   name                 = "univaf-server"
   image_tag_mutability = "IMMUTABLE"
@@ -11,6 +32,11 @@ resource "aws_ecr_repository" "server_repository" {
   image_scanning_configuration {
     scan_on_push = false
   }
+}
+
+resource "aws_ecr_lifecycle_policy" "server_repository" {
+  repository = aws_ecr_repository.server_repository.name
+  policy     = local.ecr_keep_10_images_policy
 }
 
 resource "aws_ecr_repository" "loader_repository" {
@@ -22,6 +48,11 @@ resource "aws_ecr_repository" "loader_repository" {
   }
 }
 
+resource "aws_ecr_lifecycle_policy" "loader_repository" {
+  repository = aws_ecr_repository.loader_repository.name
+  policy     = local.ecr_keep_10_images_policy
+}
+
 # This repository is maintained only for historical reference. The seed image
 # should not actually ever be used in production.
 resource "aws_ecr_repository" "seed_repository" {
@@ -31,4 +62,9 @@ resource "aws_ecr_repository" "seed_repository" {
   image_scanning_configuration {
     scan_on_push = false
   }
+}
+
+resource "aws_ecr_lifecycle_policy" "seed_repository" {
+  repository = aws_ecr_repository.seed_repository.name
+  policy     = local.ecr_keep_10_images_policy
 }


### PR DESCRIPTION
We keep built container images in ECR, but have no lifecycle policy and old images keep accumulating! This sets up a policy to keep only the latest 10 images. I think this is probably plenty — we rarely roll back, and have never needed to do so by more than one build.

(Alternatively, we can expire by date pushed, but I think that means if we ever fully pause development, that could actually expire *every* image, which is not good. Docs: https://docs.aws.amazon.com/AmazonECR/latest/userguide/LifecyclePolicies.html)