### PR TITLE
Move all ECS tasks to public networks

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -193,8 +193,8 @@ resource "aws_ecs_service" "api_service" {
   }
 
   network_configuration {
-    security_groups  = [aws_security_group.ecs_tasks.id]
-    subnets          = aws_subnet.private.*.id
+    security_groups  = [aws_security_group.api_server_tasks.id]
+    subnets          = aws_subnet.public.*.id
     assign_public_ip = true
   }
 
@@ -240,6 +240,6 @@ module "daily_data_snapshot_schedule" {
   schedule        = "cron(0 1 * * ? *)"
   task            = module.daily_data_snapshot_task
   cluster_arn     = aws_ecs_cluster.main.arn
-  subnets         = aws_subnet.private.*.id
-  security_groups = [aws_security_group.ecs_tasks.id]
+  subnets         = aws_subnet.public.*.id
+  security_groups = [aws_security_group.cron_job_tasks.id]
 }

--- a/terraform/loaders.tf
+++ b/terraform/loaders.tf
@@ -83,8 +83,8 @@ module "source_loader" {
   memory = 512
 }
 
-# Loaders need to load lots of data from the public internet, and so have public
-# IP addresses. This SG prevents external systems from accessing them.
+# FIXME: remove when no longer in use!
+# (Transitioning to `aws_security_group.cron_job_tasks`)
 resource "aws_security_group" "loader_tasks" {
   name        = "univaf-loader-tasks-security-group"
   description = "No inbound access at all, in univaf-vpc"
@@ -108,5 +108,5 @@ module "source_loader_schedule" {
   # Loaders do a lot of traffic getting data from external sources on the public
   # internet, so they run in our "public" network with an internet gateway.
   subnets         = aws_subnet.public.*.id
-  security_groups = [aws_security_group.loader_tasks.id]
+  security_groups = [aws_security_group.cron_job_tasks.id]
 }

--- a/terraform/security.tf
+++ b/terraform/security.tf
@@ -31,8 +31,8 @@ resource "aws_security_group" "lb" {
   }
 }
 
-# Traffic to the tasks/services in the ECS cluster should only come from the
-# load balancer.
+# FIXME: remove this when no longer in use!
+# (Transitioning to `aws_security_group.api_server_tasks`)
 resource "aws_security_group" "ecs_tasks" {
   name        = "univaf-ecs-tasks-security-group"
   description = "Allow inbound access only from the load balancer"
@@ -44,6 +44,44 @@ resource "aws_security_group" "ecs_tasks" {
     to_port         = var.api_port
     security_groups = [aws_security_group.lb.id]
   }
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# Traffic to the tasks that run the the API server in ECS should only accept
+# traffic from the load balancer; the public internet and other resources in AWS
+# should not be able to route directly to them.
+resource "aws_security_group" "api_server_tasks" {
+  name        = "univaf-api-server-tasks-security-group"
+  description = "Allow inbound access only from the load balancer"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    protocol        = "tcp"
+    from_port       = var.api_port
+    to_port         = var.api_port
+    security_groups = [aws_security_group.lb.id]
+  }
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# Cron Job-like tasks on ECS may need to reach out to other servicers to load
+# things, but nothing else should be initiating communication with them.
+resource "aws_security_group" "cron_job_tasks" {
+  name        = "univaf-cron-job-tasks-security-group"
+  description = "No inbound access, in univaf-vpc, for ECS Cron Jobs"
+  vpc_id      = aws_vpc.main.id
 
   egress {
     protocol    = "-1"

--- a/terraform/security.tf
+++ b/terraform/security.tf
@@ -76,7 +76,7 @@ resource "aws_security_group" "api_server_tasks" {
   }
 }
 
-# Cron Job-like tasks on ECS may need to reach out to other servicers to load
+# Cron Job-like tasks on ECS may need to reach out to other services to load
 # things, but nothing else should be initiating communication with them.
 resource "aws_security_group" "cron_job_tasks" {
   name        = "univaf-cron-job-tasks-security-group"


### PR DESCRIPTION
Step 1 of #1327.

This moves the API server tasks and the daily data snapshot task from our private subnets to our public subnets (we already did this for the loaders). It also adds a security group for cron jobs that is very strict (the daily data snapshot task was using a security group designed for a server, which is not ideal) and can be used by all our cron-job-like tasks. It also creates a new security group for the API service that is more appropriately named for clarity (the old name may be how we wound up using it for the daily data snapshot).

A follow-up change will remove the old security groups once everything has transitioned over to the new ones.