### PR TITLE
Ensure new API server can talk to DB

### DIFF
--- a/terraform/db.tf
+++ b/terraform/db.tf
@@ -21,6 +21,7 @@ module "db" {
   subnet_ids = aws_subnet.private[*].id
   ingress_allow_security_groups = compact([
     aws_security_group.ecs_tasks.id,
+    aws_security_group.api_server_tasks.id,
     aws_security_group.bastion_security_group.id
   ])
 }


### PR DESCRIPTION
Step 1.1 of #1327.

In #1328, I changed the security group the API server tasks use, but forgot to give that security group access to the database! This should fix the issue.