### PR TITLE
Stop using deprecated security groups

### DIFF
--- a/terraform/db.tf
+++ b/terraform/db.tf
@@ -20,7 +20,6 @@ module "db" {
   vpc_id     = aws_vpc.main.id
   subnet_ids = aws_subnet.private[*].id
   ingress_allow_security_groups = compact([
-    aws_security_group.ecs_tasks.id,
     aws_security_group.api_server_tasks.id,
     aws_security_group.bastion_security_group.id
   ])


### PR DESCRIPTION
Step 3 of #1327. Now that we've rejiggered our security groups, we need to stop using them. After this applies, then we can actually delete them.