### PR TITLE
Remove deprecated security groups

### DIFF
--- a/terraform/loaders.tf
+++ b/terraform/loaders.tf
@@ -83,21 +83,6 @@ module "source_loader" {
   memory = 512
 }
 
-# FIXME: remove when no longer in use!
-# (Transitioning to `aws_security_group.cron_job_tasks`)
-resource "aws_security_group" "loader_tasks" {
-  name        = "univaf-loader-tasks-security-group"
-  description = "No inbound access at all, in univaf-vpc"
-  vpc_id      = aws_vpc.main.id
-
-  egress {
-    protocol    = "-1"
-    from_port   = 0
-    to_port     = 0
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-}
-
 module "source_loader_schedule" {
   source   = "./modules/schedule"
   for_each = local.loaders

--- a/terraform/security.tf
+++ b/terraform/security.tf
@@ -3,12 +3,13 @@
 # Security groups control inbound and outbound network connections to various
 # services (databases, ECS tasks, EC2 instances, load balancers, etc.).
 
-# ALB Security Group: Edit to restrict access to the API Server
+# Traffic to the API server's load balancer.
 resource "aws_security_group" "lb" {
   name        = "univaf-api-load-balancer-security-group"
   description = "Controls access to the API server load balancer"
   vpc_id      = aws_vpc.main.id
 
+  # HTTP
   ingress {
     protocol    = "tcp"
     from_port   = 80
@@ -16,33 +17,12 @@ resource "aws_security_group" "lb" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  # HTTPS
   ingress {
     protocol    = "tcp"
     from_port   = 443
     to_port     = 443
     cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  egress {
-    protocol    = "-1"
-    from_port   = 0
-    to_port     = 0
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-}
-
-# FIXME: remove this when no longer in use!
-# (Transitioning to `aws_security_group.api_server_tasks`)
-resource "aws_security_group" "ecs_tasks" {
-  name        = "univaf-ecs-tasks-security-group"
-  description = "Allow inbound access only from the load balancer"
-  vpc_id      = aws_vpc.main.id
-
-  ingress {
-    protocol        = "tcp"
-    from_port       = var.api_port
-    to_port         = var.api_port
-    security_groups = [aws_security_group.lb.id]
   }
 
   egress {


### PR DESCRIPTION
Step 4 of #1327 (final step!). This cleans up Terraform and removes the security groups we deprecated in earlier steps.