### PR TITLE
Give cron jobs access to database

### DIFF
--- a/terraform/db.tf
+++ b/terraform/db.tf
@@ -21,6 +21,7 @@ module "db" {
   subnet_ids = aws_subnet.private[*].id
   ingress_allow_security_groups = compact([
     aws_security_group.api_server_tasks.id,
+    aws_security_group.cron_job_tasks.id,
     aws_security_group.bastion_security_group.id
   ])
 }


### PR DESCRIPTION
This is a follow-on to #1329 and part of #1327. When I created a new security group for all cron job tasks and made the daily data snapshot task use it, I forgot to give it access to the DB.

This is a little broad — it gives the loaders DB access, but I think I’m ok with that. (Alternatively, we could go back to having separate security groups for loaders and the daily data snapshot.)