### PR TITLE
Disable ECS Container Insights

### DIFF
--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -8,9 +8,11 @@
 resource "aws_ecs_cluster" "main" {
   name = "univaf-cluster"
 
+  # Container Insights is *very* expensive for our configuration, but can be
+  # useful to turn on if granular metrics on cron job resource usage is needed.
   setting {
     name  = "containerInsights"
-    value = "enabled"
+    value = "disabled"
   }
 }
 


### PR DESCRIPTION
We turned on container insights last week to get a better sense of the network usage issues around NAT Gateways. We've resolved those issues, so it makes sense to turn off container insights now (it more than doubles our CloudWatch bill — from ~$0.75/day to ~$2/day).

Fixes #1327.