### PR TITLE
Randomize test order

### DIFF
--- a/common/jest.config.js
+++ b/common/jest.config.js
@@ -11,6 +11,7 @@ module.exports = {
   },
   testMatch: ["**/test/**/*.test.(ts|js)", "!**/dist/test/**/*"],
   testEnvironment: "node",
+  randomize: true,
   reporters: ["default", "github-actions"],
   coverageReporters: ["text", "html"],
 };

--- a/loader/package.json
+++ b/loader/package.json
@@ -46,6 +46,7 @@
     "reporters": [
       "default",
       "github-actions"
-    ]
+    ],
+    "randomize": true
   }
 }

--- a/loader/test/walgreens.test.js
+++ b/loader/test/walgreens.test.js
@@ -12,6 +12,10 @@ const { Available } = require("../src/model");
 // Mock utils so we can track logs.
 jest.mock("../src/utils");
 
+afterEach(() => {
+  nock.cleanAll();
+});
+
 describe("Walgreens SMART Scheduling Links API", () => {
   const [API_BASE, API_MANIFEST_PATH] = splitHostAndPath(API_URL);
 

--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -11,6 +11,7 @@ module.exports = {
   },
   testMatch: ["**/test/**/*.test.(ts|js)", "!**/dist/test/**/*"],
   testEnvironment: "node",
+  randomize: true,
   reporters: ["default", "github-actions"],
   coverageReporters: ["text", "html"],
   globalSetup: "<rootDir>/test/support/globalSetup.ts",


### PR DESCRIPTION
Jest recently added an option to randomize the order of tests. In general, that's a good practice that can help ensure we make tests more independent and robust, so we should be using it.

Fixes #1345.