### PR TITLE
Boost DB connection pool size for API

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -33,6 +33,8 @@ module "api_task" {
     DB_NAME                   = module.db.db_name
     DB_USERNAME               = var.db_user
     DB_PASSWORD               = var.db_password
+    DB_POOL_SIZE_DATA         = var.api_db_pool_size_data
+    DB_POOL_SIZE_AVAILABILITY = var.api_db_pool_size_availability
     API_KEYS                  = join(",", var.api_keys)
     SENTRY_DSN                = var.api_sentry_dsn
     SENTRY_TRACES_SAMPLE_RATE = format("%.2f", var.api_sentry_traces_sample_rate)
@@ -225,7 +227,6 @@ module "daily_data_snapshot_task" {
     DB_NAME                 = module.db.db_name
     DB_USERNAME             = var.db_user
     DB_PASSWORD             = var.db_password
-    DB_POOL_SIZE_DATA       = "15"
     SENTRY_DSN              = var.api_sentry_dsn
     DATA_SNAPSHOT_S3_BUCKET = var.data_snapshot_s3_bucket
     AWS_ACCESS_KEY_ID       = var.data_snapshot_aws_key_id

--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -33,8 +33,8 @@ module "api_task" {
     DB_NAME                   = module.db.db_name
     DB_USERNAME               = var.db_user
     DB_PASSWORD               = var.db_password
-    DB_POOL_SIZE_DATA         = "${var.api_db_pool_size_data}"
-    DB_POOL_SIZE_AVAILABILITY = "${var.api_db_pool_size_availability}"
+    DB_POOL_SIZE_DATA         = format("%d", var.api_db_pool_size_data)
+    DB_POOL_SIZE_AVAILABILITY = format("%d", var.api_db_pool_size_availability)
     API_KEYS                  = join(",", var.api_keys)
     SENTRY_DSN                = var.api_sentry_dsn
     SENTRY_TRACES_SAMPLE_RATE = format("%.2f", var.api_sentry_traces_sample_rate)

--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -33,8 +33,8 @@ module "api_task" {
     DB_NAME                   = module.db.db_name
     DB_USERNAME               = var.db_user
     DB_PASSWORD               = var.db_password
-    DB_POOL_SIZE_DATA         = var.api_db_pool_size_data
-    DB_POOL_SIZE_AVAILABILITY = var.api_db_pool_size_availability
+    DB_POOL_SIZE_DATA         = "${var.api_db_pool_size_data}"
+    DB_POOL_SIZE_AVAILABILITY = "${var.api_db_pool_size_availability}"
     API_KEYS                  = join(",", var.api_keys)
     SENTRY_DSN                = var.api_sentry_dsn
     SENTRY_TRACES_SAMPLE_RATE = format("%.2f", var.api_sentry_traces_sample_rate)

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -99,6 +99,18 @@ variable "api_memory" {
   default     = 2048
 }
 
+variable "api_db_pool_size_data" {
+  description = "The maximum number of DB connection a single API server can hold for general usage."
+  type        = number
+  default     = 20
+}
+
+variable "api_db_pool_size_availability" {
+  description = "The maximum number of DB connection a single API server can hold for logging."
+  type        = number
+  default     = 10
+}
+
 variable "api_sentry_dsn" {
   description = "The Sentry.io DSN to use for the API service"
   default     = ""


### PR DESCRIPTION
On AWS, we can almost certainly handle more DB connections per instance than we are currently using (in general the RDS DB is better resourced and can handle more connections than the one on Render), so we should bump up the number of connections for better throughput. This also makes the pool sizes configurable, since this seems like something that should obviously be tunable.

Note this eliminates the custom pool size from the daily data snapshot job. I'm not sure when we added that, but I suspect I might have done it accidentally while thinking I was adjusting the API server task. In any case, it shouldn't really need many connections, since it just makes one query at a time and streams the results out.