### PR TITLE
Fix www subdomain redirect

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -108,7 +108,7 @@ resource "aws_alb_listener" "front_end_https" {
 }
 
 resource "aws_alb_listener_rule" "redirect_www" {
-  listener_arn = aws_alb_listener.front_end.arn
+  listener_arn = aws_alb_listener.front_end_https.arn
   priority     = 10
 
   condition {


### PR DESCRIPTION
We used to have the load balancer redirecting from `www.getmyvax.org` to `getmyvax.org`, but it looks like I must have broken that at some point when adding CloudFront, or during the Render.com mess. The rule wound up attached to the HTTP listener (not the HTTPS one), and since CloudFront handles the HTTP → HTTPS redirect, a request that would trip that rule never makes it to the load balancer. Moving it to the HTTPS listener (where it always should have been) fixes the issue.