### PR TITLE
Fix security group name in RDS

### DIFF
--- a/terraform/modules/rds/main.tf
+++ b/terraform/modules/rds/main.tf
@@ -3,7 +3,7 @@
 # than the other way around when using `var.ingress_allow_security_groups`.
 resource "aws_security_group" "db_access" {
   name        = "${var.name}-rds-access-group"
-  description = "Grants access to DB '${var.name}'"
+  description = "Grants access to DB ${var.name}"
   vpc_id      = var.vpc_id
 }
 


### PR DESCRIPTION
This fixes a deploy error from #1349. Apparently you can’t use quotes in descriptions.