### PR TITLE
Remove no longer needed DB ingress security

### DIFF
--- a/terraform/db.tf
+++ b/terraform/db.tf
@@ -19,11 +19,4 @@ module "db" {
 
   vpc_id     = aws_vpc.main.id
   subnet_ids = aws_subnet.private[*].id
-  ingress_allow_security_groups = compact([
-    # FIXME: remove all but the bastion here once services are using the new
-    # output security group from the database.
-    aws_security_group.api_server_tasks.id,
-    aws_security_group.cron_job_tasks.id,
-    aws_security_group.bastion_security_group.id
-  ])
 }


### PR DESCRIPTION
In #1349, I flipped how security groups work with RDS, and services that need access to the DB now include a security group that the DB outputs. We no longer need to specify allowed services as inputs.