### PR TITLE
Reduce concurrency for CVS, Walgreens

### DIFF
--- a/terraform/cron-loaders.tf
+++ b/terraform/cron-loaders.tf
@@ -29,8 +29,16 @@ locals {
       }
     },
     waDoh          = { schedule = "cron(3/5 * * * ? *)" }
-    cvsSmart       = { schedule = "cron(0/10 * * * ? *)" }
-    walgreensSmart = { schedule = "cron(2/10 * * * ? *)" }
+    cvsSmart       = {
+      schedule = "cron(0/10 * * * ? *)"
+      # Lower concurrency since this sends so many updates.
+      env_vars = { API_CONCURRENCY = "5" }
+    }
+    walgreensSmart = {
+      schedule = "cron(2/10 * * * ? *)"
+      # Lower concurrency since this sends so many updates.
+      env_vars = { API_CONCURRENCY = "5" }
+    }
     krogerSmart    = { schedule = "cron(4/10 * * * ? *)" }
     albertsons     = { schedule = "cron(6/10 * * * ? *)" }
     hyvee          = { schedule = "cron(8/10 * * * ? *)" }


### PR DESCRIPTION
A couple weeks ago I shrunk the API servers and that caused them to start dropping requests (totally manageable; the loaders retry and never experienced any failures as a result). Reducing the concurrency appears to help alleviate the issue without adding more resources.

It’s also not making the jobs take any longer! Here’s a chart of loader duration (includes some time before and after I made this change ad-hoc to test it):

![loader-duration](https://user-images.githubusercontent.com/74178/225714990-87fcb80d-a5c2-4a6e-9de4-9f496e92cfae.png)

And retries in the loader:

![Screen Shot 2023-03-16 at 11 15 59 AM](https://user-images.githubusercontent.com/74178/225715383-c13a9f67-a2e0-47ae-9169-cfe841aa65a5.png)

This has also reduced 95th percentile response times a bit (not dramatic, but it is clear in the charts).

---

On the other hand, it does not appear to have reduced our CPU usage (it maxes in the upper 90%s regularly), which suggests we have some CPU-constrained stuff going on, and needs further investigation. (Likely culprits: validating updates, comparing updates to existing data when determining changed times, parsing and serializing large JSON availability fields for updates, gets, and at the JS ↔︎ DB boundary.)