### PR TITLE
Use correct radius to load Rite Aid details

### DIFF
--- a/loader/src/sources/riteaid/scraper.js
+++ b/loader/src/sources/riteaid/scraper.js
@@ -135,7 +135,7 @@ async function* queryState(state, rateLimit = null, summaryOnly = false) {
       // appointment slots.
       for (let i = 0; i < newStores.length; i += SLOT_QUERY_CHUNK_SIZE) {
         const chunk = newStores.slice(i, i + SLOT_QUERY_CHUNK_SIZE);
-        const fullData = await queryZipCode(zipCode, 100, chunk);
+        const fullData = await queryZipCode(zipCode, radius, chunk);
         for (const item of fullData.data.stores || []) {
           yield item;
         }


### PR DESCRIPTION
In #1370 and #1371, I changed the Rite Aid Scraper to use a variable radius for each zip code that it queries, but forgot to use the correct radius when issuing a second query for the details of each location (we issue one query for a list of locations, and then the same query again with slightly different arguments to get the details about available slots at those locations).

Should hopefully fix https://usdr.sentry.io/issues/4015111034/