### PR TITLE
Send more info when Rite Aid queries are too big

### DIFF
--- a/loader/src/sources/riteaid/scraper.js
+++ b/loader/src/sources/riteaid/scraper.js
@@ -8,7 +8,6 @@
  * cover the entirety of a given state.
  */
 
-const assert = require("node:assert/strict");
 const { mapKeys } = require("lodash");
 const { DateTime } = require("luxon");
 const Sentry = require("@sentry/node");


### PR DESCRIPTION
In #1382, I fixed an issue that was causing us to see query results in the Rite Aid scraper that were too big because we were using the wrong radius when loading detailed results. Since landing that, however, we've seen this error happen several times on the first, non-detailed query! (Before, I checked the last 15 occurrences and they were *only* on the second, detailed query... hmmmm.)

In all the cases I looked at, the number of known Rite Aid locations within the search radius was *way* fewer than 100, so I'm not sure what's going on. My best idea at this point is to add more telemetry, so that's what I've done here. When we send this error to Sentry, we'll include a list of all the results and their distances.