### PR TITLE
Apply rate limit to all Rite Aid scraper requests

### DIFF
--- a/loader/src/sources/riteaid/scraper.js
+++ b/loader/src/sources/riteaid/scraper.js
@@ -147,6 +147,7 @@ async function* queryState(state, rateLimit = null, summaryOnly = false) {
       // same query again but with a list of store numbers to get actual
       // appointment slots.
       for (let i = 0; i < newStores.length; i += SLOT_QUERY_CHUNK_SIZE) {
+        if (rateLimit) await rateLimit.ready();
         const chunk = newStores.slice(i, i + SLOT_QUERY_CHUNK_SIZE);
         const fullData = await queryZipCode(zipCode, radius, chunk);
         for (const item of fullData.data.stores || []) {


### PR DESCRIPTION
The rate limit for the Rite Aid scraper has been erroneously applied just to the initial "summary data" requests, and not to the secondary "detailed" requests for slot-level info. That's a mistake! We are getting a few 403 (forbidden) responses to the scraper's requests every hour, and remembering to apply the rate limit to all requests is likely to help here.

Note this is likely to make the run-time of the scraper a bit slower (it currently averages right around 6 minutes), but that should be OK. Separately, I think we might want to consider running the scraper less often — it currently runs more often than the officially supported API source (every 10 minutes vs. every 30), which I think is a relic of times when it was critical to get frequent, detailed info (the scraper is *much* more detailed than the official API). That’s no longer true, and we should consider inverting the frequency (hit the API ever 10-15 minutes, and the scraper every 30-60 minutes).