### PR TITLE
Retry Rite Aid requests on 403 status codes

### DIFF
--- a/loader/src/sources/riteaid/api.js
+++ b/loader/src/sources/riteaid/api.js
@@ -19,6 +19,7 @@ const {
   RiteAidApiError,
   getExternalIds,
   getLocationName,
+  MINIMUM_403_RETRY_DELAY,
 } = require("./common");
 
 const warn = createWarningLogger("riteAidApi");
@@ -121,7 +122,7 @@ async function queryState(state, rateLimit = null) {
       statusCodes: [...got.default.defaults.options.retry.statusCodes, 403],
       calculateDelay({ error, computedValue }) {
         if (error.response.statusCode === 403 && computedValue > 0) {
-          return Math.max(computedValue, 10_000);
+          return Math.max(computedValue, MINIMUM_403_RETRY_DELAY);
         }
         return computedValue;
       },

--- a/loader/src/sources/riteaid/common.js
+++ b/loader/src/sources/riteaid/common.js
@@ -1,5 +1,6 @@
 const assert = require("assert").strict;
 const { HttpApiError } = require("../../exceptions");
+const { isTest } = require("../../config");
 
 // States in which Rite Aid has stores.
 const RITE_AID_STATES = [
@@ -21,6 +22,8 @@ const RITE_AID_STATES = [
   "VT",
   "WA",
 ];
+
+const MINIMUM_403_RETRY_DELAY = isTest ? 0 : 10_000;
 
 class RiteAidApiError extends HttpApiError {
   parse(response) {
@@ -78,6 +81,7 @@ function getLocationName(externalIds) {
 
 module.exports = {
   RITE_AID_STATES,
+  MINIMUM_403_RETRY_DELAY,
   RiteAidApiError,
   getExternalIds,
   getLocationName,

--- a/loader/src/sources/riteaid/scraper.js
+++ b/loader/src/sources/riteaid/scraper.js
@@ -8,6 +8,7 @@
  * cover the entirety of a given state.
  */
 
+const got = require("got");
 const { mapKeys } = require("lodash");
 const { DateTime } = require("luxon");
 const Sentry = require("@sentry/node");
@@ -81,6 +82,18 @@ async function queryZipCode(zip, radius = 100, stores = null) {
     },
     responseType: "json",
     throwHttpErrors: false,
+    retry: {
+      // This endpoint occasionally produces 403 status codes. We think this is
+      // an anti-abuse measure, so we still want to retry, but with a longer
+      // than normal delay.
+      statusCodes: [...got.default.defaults.options.retry.statusCodes, 403],
+      calculateDelay({ error, computedValue }) {
+        if (error.response.statusCode === 403 && computedValue > 0) {
+          return Math.max(computedValue, 10_000);
+        }
+        return computedValue;
+      },
+    },
   });
 
   if (response.body.Status !== "SUCCESS") {

--- a/loader/src/sources/riteaid/scraper.js
+++ b/loader/src/sources/riteaid/scraper.js
@@ -26,6 +26,7 @@ const {
   getExternalIds,
   getLocationName,
   RITE_AID_STATES,
+  MINIMUM_403_RETRY_DELAY,
 } = require("./common");
 const { zipCodesCoveringAllRiteAids } = require("./zip-codes");
 
@@ -89,7 +90,7 @@ async function queryZipCode(zip, radius = 100, stores = null) {
       statusCodes: [...got.default.defaults.options.retry.statusCodes, 403],
       calculateDelay({ error, computedValue }) {
         if (error.response.statusCode === 403 && computedValue > 0) {
-          return Math.max(computedValue, 10_000);
+          return Math.max(computedValue, MINIMUM_403_RETRY_DELAY);
         }
         return computedValue;
       },

--- a/loader/test/riteaid.api.test.js
+++ b/loader/test/riteaid.api.test.js
@@ -202,8 +202,8 @@ describe("Rite Aid Source", () => {
     expect(locations).toContainItemsMatchingSchema(locationSchema);
   });
 
-  it("does not attempt to load states without Rite Aid stores", async () => {
-    nock(API_URL).get("?stateCode=AK").reply(403, "uhoh");
+  it("does not throw errors for states without Rite Aid stores", async () => {
+    nock(API_URL).get("?stateCode=AK").times(3).reply(403, "uhoh");
     const results = await checkAvailability(() => {}, { states: ["AK"] });
     expect(results).toHaveLength(0);
   });


### PR DESCRIPTION
The Rite Aid API and scraper sources both occasionally encounter a raft of 403 status codes and fail (anywhere from 1/hour to 1/day). Under the assumption that we’re hitting a rate-limiting/abuse measure, this change sets us up to retry those requests rather than failing immediately, but with a greater than usual delay.

This is an experiment! It might not fix the issue — an equally likely possibility is that because we run on Fargate, each loader run comes from one of a wide set of IP addresses, and some of them have been blocked by Rite Aid. If that's the case, retrying won't do us any good. (OTOH, it should be obvious that this is the case if the change here has zero impact on the rate at which we see errors, and then we take appropriate action, like logging clearer errors and failing faster when we hit this scenario.)