### PR TITLE
Fix Rite Aid 403 retry exception

### DIFF
--- a/loader/src/sources/riteaid/api.js
+++ b/loader/src/sources/riteaid/api.js
@@ -121,7 +121,7 @@ async function queryState(state, rateLimit = null) {
       // than normal delay.
       statusCodes: [...got.default.defaults.options.retry.statusCodes, 403],
       calculateDelay({ error, computedValue }) {
-        if (error.response.statusCode === 403 && computedValue > 0) {
+        if (error.response?.statusCode === 403 && computedValue > 0) {
           return Math.max(computedValue, MINIMUM_403_RETRY_DELAY);
         }
         return computedValue;

--- a/loader/src/sources/riteaid/api.js
+++ b/loader/src/sources/riteaid/api.js
@@ -1,4 +1,3 @@
-const got = require("got");
 const { DateTime } = require("luxon");
 const Sentry = require("@sentry/node");
 const geocoding = require("../../geocoding");
@@ -6,7 +5,6 @@ const { ParseError } = require("../../exceptions");
 const { Available, LocationType } = require("../../model");
 const {
   createWarningLogger,
-  httpClient,
   parseUsPhoneNumber,
   RateLimit,
 } = require("../../utils");
@@ -19,7 +17,7 @@ const {
   RiteAidApiError,
   getExternalIds,
   getLocationName,
-  MINIMUM_403_RETRY_DELAY,
+  riteAidHttpClient,
 } = require("./common");
 
 const warn = createWarningLogger("riteAidApi");
@@ -110,23 +108,11 @@ async function queryState(state, rateLimit = null) {
 
   if (rateLimit) await rateLimit.ready();
 
-  const response = await httpClient({
+  const response = await riteAidHttpClient({
     url: RITE_AID_URL,
     headers: { "Proxy-Authorization": "ldap " + RITE_AID_KEY },
     searchParams: { stateCode: state },
     responseType: "json",
-    retry: {
-      // This endpoint occasionally produces 403 status codes. We think this is
-      // an anti-abuse measure, so we still want to retry, but with a longer
-      // than normal delay.
-      statusCodes: [...got.default.defaults.options.retry.statusCodes, 403],
-      calculateDelay({ error, computedValue }) {
-        if (error.response?.statusCode === 403 && computedValue > 0) {
-          return Math.max(computedValue, MINIMUM_403_RETRY_DELAY);
-        }
-        return computedValue;
-      },
-    },
   });
 
   if (response.body.Status !== "SUCCESS") {

--- a/loader/src/sources/riteaid/scraper.js
+++ b/loader/src/sources/riteaid/scraper.js
@@ -8,14 +8,12 @@
  * cover the entirety of a given state.
  */
 
-const got = require("got");
 const { mapKeys } = require("lodash");
 const { DateTime } = require("luxon");
 const Sentry = require("@sentry/node");
 const { Available, LocationType, VaccineProduct } = require("../../model");
 const { assertSchema } = require("../../schema-validation");
 const {
-  httpClient,
   RateLimit,
   TIME_ZONE_OFFSET_STRINGS,
   createWarningLogger,
@@ -26,7 +24,7 @@ const {
   getExternalIds,
   getLocationName,
   RITE_AID_STATES,
-  MINIMUM_403_RETRY_DELAY,
+  riteAidHttpClient,
 } = require("./common");
 const { zipCodesCoveringAllRiteAids } = require("./zip-codes");
 
@@ -63,7 +61,7 @@ const warn = createWarningLogger("riteAidScraper");
 async function queryZipCode(zip, radius = 100, stores = null) {
   const maximumResultCount = 100;
 
-  const response = await httpClient({
+  const response = await riteAidHttpClient({
     url: API_URL,
     searchParams: {
       address: zip,
@@ -83,18 +81,6 @@ async function queryZipCode(zip, radius = 100, stores = null) {
     },
     responseType: "json",
     throwHttpErrors: false,
-    retry: {
-      // This endpoint occasionally produces 403 status codes. We think this is
-      // an anti-abuse measure, so we still want to retry, but with a longer
-      // than normal delay.
-      statusCodes: [...got.default.defaults.options.retry.statusCodes, 403],
-      calculateDelay({ error, computedValue }) {
-        if (error.response?.statusCode === 403 && computedValue > 0) {
-          return Math.max(computedValue, MINIMUM_403_RETRY_DELAY);
-        }
-        return computedValue;
-      },
-    },
   });
 
   if (response.body.Status !== "SUCCESS") {

--- a/loader/src/sources/riteaid/scraper.js
+++ b/loader/src/sources/riteaid/scraper.js
@@ -89,7 +89,7 @@ async function queryZipCode(zip, radius = 100, stores = null) {
       // than normal delay.
       statusCodes: [...got.default.defaults.options.retry.statusCodes, 403],
       calculateDelay({ error, computedValue }) {
-        if (error.response.statusCode === 403 && computedValue > 0) {
+        if (error.response?.statusCode === 403 && computedValue > 0) {
           return Math.max(computedValue, MINIMUM_403_RETRY_DELAY);
         }
         return computedValue;


### PR DESCRIPTION
I made a mistake in #1397 by assuming every time the `calculateDelay` function runs for retries, the error involved an actual HTTP response. Some are network problems where the client is unable to communicate with the server at all. (I tested 403 responses, but did not test this!)

This also consolidates the logic in one spot, since it was obviously more complicated than I gave it credit for (I didn’t bother before since it was experimental. That was wrong.).

Fixes https://usdr.sentry.io/issues/4048563618