### PR TITLE
Clean up Rite Aid auth error handling

### DIFF
--- a/common/src/exceptions.ts
+++ b/common/src/exceptions.ts
@@ -1,0 +1,6 @@
+export class BaseError extends Error {
+  // Ensure subclasses get an appropriate name instead of "Error". Without this,
+  // console logging, `errorInstance.toString()`, and Sentry may all print
+  // different things for the type of error.
+  name = this.constructor.name || "Error";
+}

--- a/common/src/utils.ts
+++ b/common/src/utils.ts
@@ -12,7 +12,9 @@ export function parseJsonLines(text: string): any[] {
         line = line.replace(/\t/g, "\\t");
         return JSON.parse(line);
       } catch (error) {
-        throw new SyntaxError(`Error parsing line ${index + 1}: ${line}`);
+        throw new SyntaxError(`Error parsing line ${index + 1}: ${line}`, {
+          cause: error,
+        });
       }
     });
 }

--- a/loader/src/cli.js
+++ b/loader/src/cli.js
@@ -116,7 +116,10 @@ async function run(options) {
     for (const report of reports) {
       if (report.error) {
         console.error(`Error in "${report.name}":`, report.error, "\n");
-        Sentry.captureException(report.error);
+        Sentry.withScope((scope) => {
+          scope.setContext("context", { source: report.name });
+          Sentry.captureException(report.error);
+        });
         process.exitCode = 91;
       } else {
         successCount++;
@@ -127,7 +130,7 @@ async function run(options) {
     }
   } catch (error) {
     process.exitCode = 90;
-    console.error(`Error: ${error}`);
+    console.error(error.toString());
     Sentry.captureException(error);
   } finally {
     const duration = (Date.now() - startTime) / 1000;

--- a/loader/src/exceptions.js
+++ b/loader/src/exceptions.js
@@ -1,3 +1,5 @@
+const { BaseError } = require("univaf-common/exceptions");
+
 /**
  * @typedef {object} HttpResponse
  * @property {number} statusCode
@@ -8,7 +10,7 @@
 /**
  * An error from an HTTP response.
  */
-class HttpApiError extends Error {
+class HttpApiError extends BaseError {
   /** @property {number} statusCode The HTTP status code of the response. */
 
   /**
@@ -90,7 +92,7 @@ function assertValidGraphQl(response) {
   }
 }
 
-class ParseError extends Error {}
+class ParseError extends BaseError {}
 
 module.exports = {
   GraphQlError,

--- a/loader/src/schema-validation.js
+++ b/loader/src/schema-validation.js
@@ -1,7 +1,8 @@
 const Ajv = require("ajv");
 const addFormats = require("ajv-formats");
+const { BaseError } = require("univaf-common/exceptions");
 
-class SchemaError extends Error {
+class SchemaError extends BaseError {
   static formatAjvError(error) {
     const value = JSON.stringify(error.data) || "undefined";
     return `${error.instancePath} ${error.message} (value: \`${value}\`)`;

--- a/loader/src/sources/riteaid/api.js
+++ b/loader/src/sources/riteaid/api.js
@@ -5,6 +5,7 @@ const { Available, LocationType } = require("../../model");
 const {
   createWarningLogger,
   parseUsPhoneNumber,
+  httpClient,
   RateLimit,
 } = require("../../utils");
 const {
@@ -16,7 +17,6 @@ const {
   RiteAidApiError,
   getExternalIds,
   getLocationName,
-  riteAidHttpClient,
 } = require("./common");
 
 const warn = createWarningLogger("riteAidApi");
@@ -113,7 +113,7 @@ async function queryState(state, rateLimit = null) {
 
   if (rateLimit) await rateLimit.ready();
 
-  const response = await riteAidHttpClient({
+  const response = await httpClient({
     url: apiUrl,
     headers: { "Proxy-Authorization": "ldap " + apiKey },
     searchParams: { stateCode: state },

--- a/loader/src/sources/riteaid/api.js
+++ b/loader/src/sources/riteaid/api.js
@@ -1,5 +1,4 @@
 const { DateTime } = require("luxon");
-const Sentry = require("@sentry/node");
 const geocoding = require("../../geocoding");
 const { ParseError } = require("../../exceptions");
 const { Available, LocationType } = require("../../model");

--- a/loader/src/sources/riteaid/common.js
+++ b/loader/src/sources/riteaid/common.js
@@ -1,8 +1,5 @@
 const assert = require("assert").strict;
-const got = require("got");
 const { HttpApiError } = require("../../exceptions");
-const { isTest } = require("../../config");
-const { httpClient } = require("../../utils");
 
 // States in which Rite Aid has stores.
 const RITE_AID_STATES = [
@@ -32,29 +29,6 @@ class RiteAidApiError extends HttpApiError {
     this.message = `${this.details.Status} ${this.details.ErrCde}: ${this.details.ErrMsg}`;
   }
 }
-
-const MINIMUM_403_RETRY_DELAY = isTest ? 0 : 30_000;
-
-/**
- * A pre-configured Got instance with appropriate headers, etc. Crucially, this
- * client retries on 403 status codes (auth errors), since Rite Aid seems to
- * occasionally respond with those when our auth is actually valid.
- * @type {import("got").GotRequestFunction}
- */
-const riteAidHttpClient = httpClient.extend({
-  retry: {
-    // This endpoint occasionally produces 403 status codes. We think this is
-    // an anti-abuse measure, so we still want to retry, but fewer times and
-    // with a longer than normal delay.
-    statusCodes: [...got.default.defaults.options.retry.statusCodes, 403],
-    calculateDelay({ attemptCount, error, computedValue }) {
-      if (error.response?.statusCode === 403 && attemptCount < 2) {
-        return Math.max(computedValue, MINIMUM_403_RETRY_DELAY);
-      }
-      return computedValue;
-    },
-  },
-});
 
 /**
  * Get the external IDs for a given Rite Aid store number. Rite Aid has a
@@ -107,5 +81,4 @@ module.exports = {
   RiteAidApiError,
   getExternalIds,
   getLocationName,
-  riteAidHttpClient,
 };

--- a/loader/src/sources/riteaid/scraper.js
+++ b/loader/src/sources/riteaid/scraper.js
@@ -18,13 +18,13 @@ const {
   TIME_ZONE_OFFSET_STRINGS,
   createWarningLogger,
   parseUsPhoneNumber,
+  httpClient,
 } = require("../../utils");
 const {
   RiteAidApiError,
   getExternalIds,
   getLocationName,
   RITE_AID_STATES,
-  riteAidHttpClient,
 } = require("./common");
 const { zipCodesCoveringAllRiteAids } = require("./zip-codes");
 
@@ -61,7 +61,7 @@ const warn = createWarningLogger("riteAidScraper");
 async function queryZipCode(zip, radius = 100, stores = null) {
   const maximumResultCount = 100;
 
-  const response = await riteAidHttpClient({
+  const response = await httpClient({
     url: API_URL,
     searchParams: {
       address: zip,

--- a/loader/test/riteaid.api.test.js
+++ b/loader/test/riteaid.api.test.js
@@ -202,12 +202,6 @@ describe("Rite Aid Source", () => {
     expect(locations).toContainItemsMatchingSchema(locationSchema);
   });
 
-  it("does not throw errors for states without Rite Aid stores", async () => {
-    nock(API_URL).get("?stateCode=AK").times(3).reply(403, "uhoh");
-    const results = await checkAvailability(() => {}, { states: ["AK"] });
-    expect(results).toHaveLength(0);
-  });
-
   it("throws errors for inconsistent slot counts", async () => {
     const badData = {
       ...createMockApiLocation(),

--- a/server/src/exceptions.ts
+++ b/server/src/exceptions.ts
@@ -1,7 +1,9 @@
+import { BaseError } from "univaf-common/exceptions";
+
 /**
  * Error that is safe to surface externally (i.e. in an HTTP response).
  */
-export class ApiError extends Error {
+export class ApiError extends BaseError {
   httpStatus = 500;
   code?: string;
   extra?: any;


### PR DESCRIPTION
This reverts #1397 and ensures we bail out early in the Rite Aid API if we hit auth errors. We previously kept trying other states on auth errors because requests for states with no stores would return 401 or 403 status codes (!), and we wanted to be robust against that. However, Rite Aid has started blocking some of the IP addresses for the Fargate machines we run on, so we occasionally get all our requests blocked with auth errors. (We’ve also added an allowlist of states supported by Rite Aid, so the case where we request a state with no stores is pretty hard to hit now).

This approach lets us stop early and better manage rate-based ignore rules in Sentry (we don’t get blocked on most runs, so as long as the rate of failing runs doesn’t get too high, it’s fine).

While I was at it, I noticed some of the errors we get from the Rite Aid *Scraper* for this case are misclassified in Sentry. It turns out that Sentry infers an error’s type based on its `name` property rather than its actual type (i.e. by checking `error.constructor.name`). I’ve added a base class for all errors that sets the `name` property based on the class name. This also fixes an oddball inconsistency between `console.log(error)` and `error.toString()`.