### PR TITLE
Rebalance rite aid loaders

### DIFF
--- a/terraform/cron-loaders.tf
+++ b/terraform/cron-loaders.tf
@@ -28,17 +28,9 @@ locals {
         NJVSS_AWS_SECRET_KEY = var.njvss_aws_secret_key
       }
     },
-    waDoh = { schedule = "cron(3/5 * * * ? *)" }
-    cvsSmart = {
-      schedule = "cron(0/10 * * * ? *)"
-      # Lower concurrency since this sends so many updates.
-      env_vars = { API_CONCURRENCY = "5" }
-    }
-    walgreensSmart = {
-      schedule = "cron(2/10 * * * ? *)"
-      # Lower concurrency since this sends so many updates.
-      env_vars = { API_CONCURRENCY = "5" }
-    }
+    waDoh          = { schedule = "cron(3/5 * * * ? *)" }
+    cvsSmart       = { schedule = "cron(0/10 * * * ? *)" }
+    walgreensSmart = { schedule = "cron(2/10 * * * ? *)" }
     krogerSmart    = { schedule = "cron(4/10 * * * ? *)" }
     albertsons     = { schedule = "cron(6/10 * * * ? *)" }
     hyvee          = { schedule = "cron(8/10 * * * ? *)" }
@@ -77,9 +69,10 @@ module "source_loader" {
       ? "https://${local.api_internal_domain}"
       : "http://${aws_alb.main.dns_name}"
     )
-    API_KEY    = var.api_keys[0]
-    DD_API_KEY = var.datadog_api_key
-    SENTRY_DSN = var.loader_sentry_dsn
+    API_KEY         = var.api_keys[0]
+    API_CONCURRENCY = "5"
+    DD_API_KEY      = var.datadog_api_key
+    SENTRY_DSN      = var.loader_sentry_dsn
   }, lookup(each.value, "env_vars", {}))
   image = "${aws_ecr_repository.loader_repository.repository_url}:${var.loader_release_version}"
   role  = aws_iam_role.ecs_task_execution_role.arn

--- a/terraform/cron-loaders.tf
+++ b/terraform/cron-loaders.tf
@@ -44,9 +44,9 @@ locals {
     hyvee          = { schedule = "cron(8/10 * * * ? *)" }
     heb            = { schedule = "cron(1/10 * * * ? *)" }
     cdcApi         = { schedule = "cron(0 0,12 * * ? *)" }
-    riteAidScraper = { schedule = "cron(0/10 * * * ? *)" }
+    riteAidScraper = { schedule = "cron(5/30 * * * ? *)" }
     riteAidApi = {
-      schedule = "cron(0/30 * * * ? *)"
+      schedule = "cron(0/15 * * * ? *)"
       env_vars = {
         RITE_AID_URL = var.rite_aid_api_url
         RITE_AID_KEY = var.rite_aid_api_key


### PR DESCRIPTION
We've had the Rite Aid Scraper running every 10 minutes and the API source running every 30 for a long time, largely owing to the fact that the main API was lacking detailed information we wanted from the scraper, and because the scraper was actually reasonably speedy compared to the API. These days, we no longer need as detailed or up-to-date info and the scraper has become much slower (see #1370, #1371, #1396). The scraper is expensive to run for both us and Rite Aid, so I’m turning down to every 30 minutes (and running the API slightly more often).

While I was at it, I also lowered the API concurrency for all loader jobs. I did this a while ago just for CVS and Walgreens to try and reduce retries and other internal errors. It worked, and did not even make the loaders any slower like I’d expected. Based on that, it probably makes sense to turn concurrency down for *all* loader jobs.