### PR TITLE
Ignore Polio vaccines in Prepmod

### DIFF
--- a/loader/src/sources/prepmod/index.js
+++ b/loader/src/sources/prepmod/index.js
@@ -310,6 +310,8 @@ const nonCovidProductName = new RegExp(
     raw`\bMenACWY\b`,
     // Haemophilus influenzae type b
     raw`\bHib\b`,
+    // Polio
+    raw`\bPolio\b`,
     // In all cases we've seen, this occurs on schedules that list other actual
     // vaccine names as well. We'll pick up the true products from the other
     // extensions in the schedule.


### PR DESCRIPTION
Alaska is apparently now scheduling Polio vaccines (!) through Prepmod, which are out of scope for us. Fixes https://usdr.sentry.io/issues/4084081193/