### PR TITLE
Add `valid_time` to NJVSS Output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ scratch.*
 *.pid
 *.gz
 *.swp
+!**/fixtures/*.csv
 
 pids
 logs

--- a/loader/src/sources/njvss/index.js
+++ b/loader/src/sources/njvss/index.js
@@ -1,6 +1,5 @@
 const { Available, LocationType, VaccineProduct } = require("../../model");
 const { parseUsAddress, unpadNumber } = require("../../utils");
-const crypto = require("crypto");
 const csvParse = require("csv-parse/sync");
 const getStream = require("get-stream");
 const { S3 } = require("@aws-sdk/client-s3");

--- a/loader/src/sources/njvss/index.js
+++ b/loader/src/sources/njvss/index.js
@@ -346,10 +346,6 @@ async function findLocationIds(locations) {
   for (const item of matched) {
     if (item.match) {
       item.location.id = item.match.id;
-    } else {
-      console.warn(
-        `No match for "${item.location.name}" IDs: "${item.external_ids}"`
-      );
     }
   }
 
@@ -432,8 +428,6 @@ const walmartPattern = /(walmart(?<sams>\/Sams)?) #?(?<storeId>\d+)\s*$/i;
  * @returns {Promise<Array<object>>}
  */
 async function checkAvailability(handler, _options) {
-  console.error("Checking New Jersey VSS (https://covidvaccine.nj.gov)...");
-
   const data = await getNjvssData();
   const checkTime = new Date().toISOString();
   const validTime = data.lastModified?.toISOString();

--- a/loader/src/sources/njvss/index.js
+++ b/loader/src/sources/njvss/index.js
@@ -15,10 +15,6 @@ const {
 const { corrections } = require("./corrections");
 
 const NJVSS_WEBSITE = "https://covidvaccine.nj.gov";
-const NJVSS_AWS_KEY_ID =
-  process.env["NJVSS_AWS_KEY_ID"] || process.env["AWS_ACCESS_KEY_ID"];
-const NJVSS_AWS_SECRET_KEY =
-  process.env["NJVSS_AWS_SECRET_KEY"] || process.env["AWS_SECRET_ACCESS_KEY"];
 const NJVSS_DATA_REGION = "us-east-1";
 const NJVSS_DATA_BUCKET = "njvss-pinpoint-reports";
 const NJVSS_DATA_KEY = "njvss-available-appointments.csv";
@@ -123,7 +119,12 @@ function parseNjvssCsv(csvText) {
  * @returns {Promise<{lastModified?: Date, rawString: string}>}
  */
 async function getNjvssDataRaw() {
-  if (!NJVSS_AWS_KEY_ID || !NJVSS_AWS_SECRET_KEY) {
+  const accessKeyId =
+    process.env["NJVSS_AWS_KEY_ID"] || process.env["AWS_ACCESS_KEY_ID"];
+  const secretAccessKey =
+    process.env["NJVSS_AWS_SECRET_KEY"] || process.env["AWS_SECRET_ACCESS_KEY"];
+
+  if (!accessKeyId || !secretAccessKey) {
     throw new Error(oneLine`
       To load NJVSS data, you must set the NJVSS_AWS_KEY_ID (or
       AWS_ACCESS_KEY_ID) and NJVSS_AWS_SECRET_KEY (or AWS_SECRET_ACCESS_KEY)
@@ -132,10 +133,7 @@ async function getNjvssDataRaw() {
   }
 
   const client = new S3({
-    credentials: {
-      accessKeyId: NJVSS_AWS_KEY_ID,
-      secretAccessKey: NJVSS_AWS_SECRET_KEY,
-    },
+    credentials: { accessKeyId, secretAccessKey },
     region: NJVSS_DATA_REGION,
   });
   const object = await client.getObject({

--- a/loader/src/sources/njvss/index.js
+++ b/loader/src/sources/njvss/index.js
@@ -497,13 +497,13 @@ async function checkAvailability(handler, _options) {
       location_type = LocationType.pharmacy;
     }
 
-    const external_ids = {
+    const external_ids = [
       // NJ IIS locations sometimes run multiple ad-hoc locations, and so have
       // the same IIS identifier. `njiis_covid` adds in the location name to
       // make the identifier unique.
-      njiis_covid: createNjIisId(location),
-      njvss_res_id: location.res_id || undefined,
-    };
+      ["njiis_covid", createNjIisId(location)],
+      ["njvss_res_id", location.res_id || undefined],
+    ];
 
     let name = location.name;
 
@@ -514,11 +514,11 @@ async function checkAvailability(handler, _options) {
       const storeNumber = unpadNumber(walmartMatch.groups.storeId);
 
       if (walmartMatch.groups.sams) {
-        external_ids.sams_club = storeNumber;
+        external_ids.push(["sams_club", storeNumber]);
         provider = PROVIDER.sams;
         name = `Sam’s Club #${storeNumber}`;
       } else {
-        external_ids.walmart = storeNumber;
+        external_ids.push(["walmart", storeNumber]);
         provider = PROVIDER.walmart;
         name = `Walmart #${storeNumber}`;
       }

--- a/loader/src/sources/walgreens.js
+++ b/loader/src/sources/walgreens.js
@@ -77,6 +77,11 @@ function formatLocation(locationInfo) {
     delete position.altitude;
   }
 
+  // TODO: if all slots are before validTime, consider backdating validTime
+  // or providing some other signal that data is stale. (Important since the
+  // API often surfaces a single multi-day slot per location, so we don't wind
+  // up writing capacity or slot records in practice, and that kind of
+  // freshness data therefore gets lost.)
   const capacity = formatCapacity(locationInfo.slots);
   const available = locationInfo.slots?.some((slot) => slot.status === "free")
     ? Available.yes

--- a/loader/test/fixtures/njvss.fixture.csv
+++ b/loader/test/fixtures/njvss.fixture.csv
@@ -1,0 +1,2 @@
+res_id,provider_id,name,statuscodename,vras_provideraddress,vras_latitude,vras_longitude,vras_typetext,vras_allowschedulingforcountyresidentsonly,county,available
+d591d023-b457-eb11-a812-001dd8018866,13340,Ray Pharmacy,Active,"187 North Ave, Dunellen, NJ 8812",40.59311,-74.4604,"<p>187 North Ave, Dunellen, NJ 8812<br/> </p> <strong><em>Available Vaccines</em></strong><ul><li>Novavax (12 and older)</li></ul> This location is available for 1st and 2nd dose recipients. ",,middlesex,2805

--- a/loader/test/fixtures/nock/njvss_should_output_valid_data.json
+++ b/loader/test/fixtures/nock/njvss_should_output_valid_data.json
@@ -1,0 +1,35 @@
+[
+    {
+        "scope": "https://njvss-pinpoint-reports.s3.us-east-1.amazonaws.com:443",
+        "method": "GET",
+        "path": "/njvss-available-appointments.csv?x-id=GetObject",
+        "body": "",
+        "status": 200,
+        "response": "res_id,provider_id,name,statuscodename,vras_provideraddress,vras_latitude,vras_longitude,vras_typetext,vras_allowschedulingforcountyresidentsonly,county,available\r\nd591d023-b457-eb11-a812-001dd8018866,13340,Ray Pharmacy,Active,\"187 North Ave, Dunellen, NJ 8812\",40.59311,-74.4604,\"<p>187 North Ave, Dunellen, NJ 8812<br/> </p> <strong><em>Available Vaccines</em></strong><ul><li>Novavax (12 and older)</li></ul> This location is available for 1st and 2nd dose recipients. \",,middlesex,2805\r\nb951acec-32f1-eb11-bacb-001dd80283f5,13351,Ewing Pharmacy,Active,\"1400 Parkway Ave # A2, Ewing, New Jersey 08628\",40.26704,-74.80568,\"<p>1400 Parkway Ave # A2, Ewing, New Jersey 08628<br/> </p>  This location is available for 1st and 2nd dose recipients. \",False,mercer,800\r\n976cc7cc-2292-eb11-a812-001dd802d26d,14488,Bells Pharmacy,Active,\"17 N Union Avenue, Cranford, NJ 07016\",40.65606,-74.30391,\"<p>17 N Union Avenue, Cranford, NJ 07016<br/> </p> <strong><em>Available Vaccines</em></strong><ul><li>Janssen (J&J) (18 and older)</li><li>Moderna_Peds (6 months - 5 years)</li><li>Moderna_Peds_DarkBlueCap (6 - 11 years)</li><li>Moderna_RedCap (12 and older)</li><li>Pfizer_GrayCap (12 and older)</li><li>Pfizer_Peds (5 - 11 years)</li><li>Pfizer_Peds (6 months - 4 years)</li></ul> This location is available for 1st and 2nd dose recipients. \",False,union,708\r\n6b0eaeb9-c251-eb11-a812-001dd8020ced,162,Gloucester County Health Department,Active,\"204 E Holly Ave, Sewell, NJ 08080\",39.74471,-75.10931,\"<p>204 E Holly Ave, Sewell, NJ 08080<br/> </p> <strong><em>Available Vaccines</em></strong><ul><li>Novavax (12 and older)</li><li>Pfizer_Bivalent (6 months - 4 years)</li></ul> This location is available for 1st and 2nd dose recipients. \",,gloucester,309\r\n1b535c83-c4a6-eb11-a812-001dd802f902,14586,Franklyns Pharmacy,Active,\"204 Warren Avenue, Ho Ho Kus, NJ 07423\",40.99871,-74.11065,\"<p>204 Warren Avenue, Ho Ho Kus, NJ 07423<br/> </p> <strong><em>Available Vaccines</em></strong><ul><li>Janssen (J&J) (18 and older)</li><li>Moderna_RedCap (12 and older)</li><li>Pfizer_Peds (5 - 11 years)</li></ul> This location is available for 1st and 2nd dose recipients. \",False,bergen,159\r\nacf11ba6-2e04-ec11-94ef-001dd802ac2d,8677,Access Medical Associates Branchburg,Active,\"3322 Route 22 Building 1, Branchburg, NJ 08876\",40.60782,-74.70276,\"<p>3322 Route 22 Building 1, Branchburg, NJ 08876<br/> </p> <strong><em>Available Vaccines</em></strong><ul><li>Janssen (J&J) (18 and older)</li><li>Moderna_RedCap (12 and older)</li><li>Novavax (12 and older)</li></ul> This location is available for 1st and 2nd dose recipients. \",False,somerset,120\r\n4a67c0b2-b003-ed11-bb3a-001dd803f402,734,Montgomery Township Health Department,Active,\"100 Community Drive, Skillman, NJ 08558\",40.41892,-74.65703,\"<p>100 Community Drive, Skillman, NJ 08558<br/> </p>  This location is available for 1st and 2nd dose recipients. \",False,somerset,37\r\n61753bf2-c5a6-eb11-a812-001dd802f038,14319,Richards Pharmacy,Active,\"207 Broad Ave, Palisades Park, NJ 07650\",40.84586,-73.99971,\"<p>207 Broad Ave, Palisades Park, NJ 07650<br/> </p> <strong><em>Available Vaccines</em></strong><ul><li>Janssen (J&J) (18 and older)</li><li>Moderna_RedCap (12 and older)</li></ul> This location is available for 1st and 2nd dose recipients. \",False,bergen,25\r\na1bd2330-3822-ed11-b83c-001dd801ca65,13155,Booster Bivalent Moderna at Campbells Pharmacy,Active,\"2175 Highway 35, Sea Girt, NJ 08750\",40.13658,-74.06378,\"<p>2175 Highway 35, Sea Girt, NJ 08750<br/> </p>  This location is available for 1st and 2nd dose recipients. \",False,monmouth,15\r\n",
+        "rawHeaders": [
+            "x-amz-id-2",
+            "pBbOc0JqRvpkhoiLlSUejCvkBYqgZQvAcXfculWuSFyI3tBKj7OrkbbV1fLV0ZXliDYK9BreCfA=",
+            "x-amz-request-id",
+            "7G7CZG3MZ9M40YAC",
+            "Date",
+            "Tue, 02 May 2023 19:51:41 GMT",
+            "Last-Modified",
+            "Tue, 02 May 2023 19:29:37 GMT",
+            "ETag",
+            "\"8d08f026c219462f2efc8e5d4909e007\"",
+            "x-amz-server-side-encryption",
+            "AES256",
+            "x-amz-meta-title",
+            "someTitle",
+            "Accept-Ranges",
+            "bytes",
+            "Content-Type",
+            "application/CSV",
+            "Server",
+            "AmazonS3",
+            "Content-Length",
+            "3593"
+        ],
+        "responseIsBinary": false
+    }
+]

--- a/loader/test/njvss.test.js
+++ b/loader/test/njvss.test.js
@@ -1,0 +1,46 @@
+const path = require("node:path");
+const nock = require("nock");
+const { checkAvailability } = require("../src/sources/njvss");
+const { locationSchema } = require("./support/schemas");
+
+// Mock utils so we can track logs.
+jest.mock("../src/utils");
+
+const fixturePath = path.join(__dirname, "fixtures/njvss.fixture.csv");
+
+// Pretend our API has no existing locations.
+function mockUnivafLocations(mockedData) {
+  nock(process.env.API_URL || "https://localhost:3000")
+    .get("/api/edge/locations")
+    .query(true)
+    .reply(200, { links: {}, data: mockedData });
+}
+
+describe("NJVSS", () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  it.nock("should output valid data", async () => {
+    const result = await checkAvailability(() => {});
+    expect(result).toContainItemsMatchingSchema(locationSchema);
+  });
+
+  it("uses the last-modified header as the valid time", async () => {
+    mockUnivafLocations([]);
+
+    // Specify the last-modified time for the CSV from NJVSS.
+    nock("https://njvss-pinpoint-reports.s3.us-east-1.amazonaws.com")
+      .get("/njvss-available-appointments.csv")
+      .query(true)
+      .replyWithFile(200, fixturePath, {
+        "last-modified": "Tue, 01 May 2023 12:00:00 GMT",
+      });
+
+    const result = await checkAvailability(() => {});
+    expect(result).toHaveProperty(
+      "0.availability.valid_at",
+      "2023-05-01T12:00:00.000Z"
+    );
+  });
+});

--- a/loader/test/njvss.test.js
+++ b/loader/test/njvss.test.js
@@ -17,7 +17,16 @@ function mockUnivafLocations(mockedData) {
 }
 
 describe("NJVSS", () => {
+  let processMock;
+  beforeEach(() => {
+    processMock = jest.replaceProperty(process, "env", {
+      NJVSS_AWS_KEY_ID: "abc123xyz",
+      NJVSS_AWS_SECRET_KEY: "abc123xyz",
+    });
+  });
+
   afterEach(() => {
+    processMock.restore();
     nock.cleanAll();
   });
 


### PR DESCRIPTION
NJVSS output didn’t used to set `<location>.availability.valid_time`, and now it does. We've had a note about needing to do this for a long time, and now it's needed to support #1459.

I wanted to add tests, which necessarily meant doing some other minor cleanup of the NJVSS source (using modern `external_ids` formatting, removing the no-longer-necessary random ID generation code). Check the first commit (398488a807112e1666ef7fef0239de0da95a15e7) to see just the meaningful changes here.

There are some other quick changes this points to for NJVSS, but those are slightly more risky (outside the `valid_at` stuff, everything here is pure refactor and does not change behavior). I’ll do them in a separate PR.