### PR TITLE
Reduce NJVSS rate to every 15 minutes

### DIFF
--- a/terraform/cron-loaders.tf
+++ b/terraform/cron-loaders.tf
@@ -22,7 +22,7 @@ locals {
   #       njvss = { schedule = "rate(5 minutes)", sources = ["njvss"] }
   loaders = {
     njvss = {
-      schedule = "rate(5 minutes)"
+      schedule = "rate(15 minutes)"
       env_vars = {
         NJVSS_AWS_KEY_ID     = var.njvss_aws_key_id
         NJVSS_AWS_SECRET_KEY = var.njvss_aws_secret_key


### PR DESCRIPTION
New Jersey is no longer frequently updating their data, so it probably doesn’t make sense to run the NJVSS loader especially frequently anymore.