### PR TITLE
Remove specialized Albertsons booking URLs

### DIFF
--- a/loader/src/sources/albertsons/scraper.js
+++ b/loader/src/sources/albertsons/scraper.js
@@ -372,7 +372,7 @@ async function checkAvailability(
         });
         location = formatLocation(apiLocation, checkedAt);
       });
-      handler(location);
+      handler(location, { update_location: true });
       results.push(location);
       storeNumbers.add(location.meta.albertsons_store_number);
     }
@@ -392,7 +392,7 @@ async function checkAvailability(
       const location = formatKnownStore(missing, {
         availability: { checked_at: checkedAt },
       });
-      handler(location);
+      handler(location, { update_location: true });
       results.push(location);
     });
   }

--- a/server/migrations/20230508183648_remove_albertsons_specialized_booking_urls.js
+++ b/server/migrations/20230508183648_remove_albertsons_specialized_booking_urls.js
@@ -1,0 +1,47 @@
+const specializedBookingFields = [
+  "booking_url_adult",
+  "booking_url_pediatric",
+  "booking_url_infant",
+];
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  const ids = new Set();
+
+  for (const field of specializedBookingFields) {
+    const updated = await knex("provider_locations")
+      .whereRaw(
+        `strpos(lower(coalesce(meta->>'${field}', '')), 'mhealthcoach') > 0`
+      )
+      .update("meta", knex.raw(`meta - '${field}'`), ["id"]);
+    for (const row of updated) {
+      ids.add(row.id);
+    }
+  }
+
+  const updated = await knex("provider_locations")
+    .where(
+      knex.raw(
+        `jsonb_path_query_first(meta, '$.booking_urls[*].url \\? (@ like_regex "mhealthcoach" flag "i")') IS NOT NULL`
+      )
+    )
+    .update("meta", knex.raw(`meta - 'booking_urls'`), ["id"]);
+  for (const row of updated) {
+    ids.add(row.id);
+  }
+
+  console.log(`Removed specialized booking URLs from ${ids.size} rows`);
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function () {
+  console.log(
+    "20230508183648_remove_albertsons_specialized_booking_urls: No migrated rows reversed."
+  );
+};


### PR DESCRIPTION
In mHealth Coach, some locations would have different booking URLs for different products (or sets of products). The way those worked in mHealth Coach kept evolving, so we added an ad-hoc system for supporting multiple booking URLs as properties of a location's `meta` field (why didn't we do this as part of the *availability* object's `meta` field? I do not remember. It seems like it would have made more sense.). You can see how that was done here: https://github.com/usdigitalresponse/univaf/blob/a73e3912f36cd5a92b8069695e6149acb784d667/loader/src/sources/albertsons/mhealth.js#L163-L172

and here: https://github.com/usdigitalresponse/univaf/blob/a73e3912f36cd5a92b8069695e6149acb784d667/loader/src/sources/albertsons/mhealth.js#L549-L566

Since Albertsons no longer uses mHealth Coach and these are part of the location rather than the availability, we need to manually clear them out with a migration.

We also need the new scraper to update location info, since it has a new top level `booking_url` property and possibly other new values as well (like store hours).