### PR TITLE
Track and filter stale data

### DIFF
--- a/loader/src/cli.js
+++ b/loader/src/cli.js
@@ -146,18 +146,7 @@ async function run(options) {
     metrics.gauge("loader.jobs.duration_seconds", duration);
 
     staleChecker.printSummary();
-    // Report these manually instead of adding them as individual data points
-    // since we want a single calculation for the whole run rather than flush
-    // in the middle.
-    // XXX: Do we need auto-flushing in the loader at all?
-    for (const stats of staleChecker.listStatistics()) {
-      const tags = [`source:${stats.source}`];
-      const name = "loader.data.age_seconds";
-      metrics.gauge(`${name}.min`, stats.min / 1000, tags);
-      metrics.gauge(`${name}.max`, stats.max / 1000, tags);
-      metrics.gauge(`${name}.avg`, stats.average / 1000, tags);
-      metrics.gauge(`${name}.median`, stats.median / 1000, tags);
-    }
+    staleChecker.sendMetrics("loader.data");
 
     await new Promise((resolve, reject) => {
       metrics.flush(resolve, reject);

--- a/loader/src/stale.js
+++ b/loader/src/stale.js
@@ -64,7 +64,7 @@ class StaleChecker {
     if (!record.availability) return null;
 
     const stats = this.getStatisticsForSource(record.availability.source);
-    const age = StaleChecker.calculateDataAge(this.relativeTime, record);
+    const age = StaleChecker.calculateAge(this.relativeTime, record);
     if (age == null) return null;
 
     this.#finished = false;
@@ -158,7 +158,7 @@ class StaleChecker {
 
     for (const stats of this.bySource.values()) {
       if (stats.samples.length !== 0) {
-        const sorted = stats.samples.sort();
+        const sorted = stats.samples.sort((a, b) => a - b);
         stats.average =
           sorted.reduce((sum, sample) => sum + sample, 0) / sorted.length;
         stats.median =
@@ -171,7 +171,7 @@ class StaleChecker {
     this.#finished = true;
   }
 
-  static calculateDataAge(relativeTime, record) {
+  static calculateAge(relativeTime, record) {
     const data = record.availability;
     if (!data) return null;
 

--- a/loader/src/stale.js
+++ b/loader/src/stale.js
@@ -1,0 +1,148 @@
+const { Duration } = require("luxon");
+
+/**
+ * @typedef {Object} AgeStatistics
+ * @property {string} source
+ * @property {number[]} samples
+ * @property {number} min
+ * @property {number} max
+ * @property {number} [average]
+ * @property {number} [median]
+ */
+
+const DEFAULT_STALE_THRESHOLD = 24 * 60 * 60 * 1000;
+
+class StaleChecker {
+  /** @type {Map<string, AgeStatistics>} */
+  bySource = new Map();
+  #finished = false;
+
+  constructor({
+    relativeTime = new Date(),
+    threshold = DEFAULT_STALE_THRESHOLD,
+  } = {}) {
+    this.relativeTime = relativeTime;
+    this.threshold = threshold;
+  }
+
+  getDataForSource(source) {
+    if (!this.bySource.has(source)) {
+      this.bySource.set(source, {
+        source,
+        min: Infinity,
+        max: -Infinity,
+        samples: [],
+      });
+    }
+    return this.bySource.get(source);
+  }
+
+  checkRecord(record) {
+    if (!record.availability) return null;
+
+    const stats = this.getDataForSource(record.availability.source);
+    const age = StaleChecker.calculateDataAge(this.relativeTime, record);
+    if (age == null) return null;
+
+    this.#finished = false;
+    stats.samples.push(age);
+    if (stats.min > age) stats.min = age;
+    if (stats.max < age) stats.max = age;
+
+    return age;
+  }
+
+  filterRecord(record) {
+    const age = this.checkRecord(record);
+    return age > this.threshold ? null : record;
+  }
+
+  /**
+   * @yields {Required<AgeStatistics>}
+   * @returns {Iterable<Required<AgeStatistics>>}
+   */
+  *listStatistics() {
+    this.finish();
+
+    for (const data of this.bySource.values()) {
+      if (data.samples.length > 0) {
+        yield data;
+      }
+    }
+  }
+
+  printSummary() {
+    this.finish();
+
+    const formatMillis = (s) =>
+      Duration.fromMillis(Math.ceil(s / 1000) * 1000)
+        .rescale()
+        .toHuman();
+
+    for (const stats of this.bySource.values()) {
+      if (stats.samples.length === 0) {
+        console.error(`No age information for locations in ${stats.source}.`);
+      } else if (stats.max > this.threshold) {
+        console.error(`${stats.source} has stale data!`);
+        console.error(`  Minimum age: ${formatMillis(stats.min)}`);
+        console.error(`  Maximum age: ${formatMillis(stats.max)}`);
+        console.error(`  Average age: ${formatMillis(stats.average)}`);
+        console.error(`  Median age:  ${formatMillis(stats.median)}`);
+      }
+    }
+  }
+
+  finish() {
+    if (this.#finished) return;
+
+    for (const stats of this.bySource.values()) {
+      if (stats.samples.length !== 0) {
+        const sorted = stats.samples.sort();
+        stats.average =
+          sorted.reduce((sum, sample) => sum + sample, 0) / sorted.length;
+        stats.median =
+          sorted.length % 2 === 0
+            ? (sorted[sorted.length / 2 - 1] + sorted[sorted.length / 2]) / 2
+            : sorted[(sorted.length - 1) / 2];
+      }
+    }
+
+    this.#finished = true;
+  }
+
+  static calculateDataAge(relativeTime, record) {
+    const data = record.availability;
+    if (!data) return null;
+
+    let validAge, slotsAge;
+    if (data.valid_at) {
+      validAge = relativeTime - new Date(data.valid_at);
+    }
+    // In each of these, we bail out entirely if there is an empty
+    // slots/capcity array. That indicates there ought to have been slot data
+    // that might contradict the declared valid_at time, and valid_at can't be
+    // trusted by itself.
+    if (data.slots && data.slots) {
+      if (data.slots.length === 0) {
+        return null;
+      } else {
+        slotsAge = relativeTime - new Date(data.slots.at(-1).start);
+      }
+    } else if (data.capacity && data.capacity) {
+      if (data.capacity.length === 0) {
+        return null;
+      } else {
+        slotsAge = relativeTime - new Date(data.capacity.at(-1).date);
+      }
+    }
+
+    if (!validAge && !slotsAge) return null;
+
+    return Math.max(0, ...[validAge, slotsAge].filter(Boolean));
+  }
+}
+
+module.exports = {
+  DEFAULT_STALE_THRESHOLD,
+  StaleChecker,
+};

--- a/loader/src/stale.js
+++ b/loader/src/stale.js
@@ -1,4 +1,6 @@
 const { Duration } = require("luxon");
+const metrics = require("./metrics");
+const { createWarningLogger } = require("./utils");
 
 /**
  * @typedef {Object} AgeStatistics
@@ -12,11 +14,22 @@ const { Duration } = require("luxon");
 
 const DEFAULT_STALE_THRESHOLD = 24 * 60 * 60 * 1000;
 
+const warn = createWarningLogger("stale");
+
 class StaleChecker {
   /** @type {Map<string, AgeStatistics>} */
   bySource = new Map();
+
   #finished = false;
 
+  /**
+   * StaleChecker tracks statistics about the age/staleness of location records
+   * found by the loader.
+   * @param {Object} options
+   * @param {Date} [options.relativeTime] When to calculate age relative to.
+   * @param {number} [options.threshold] Consider records older than this many
+   *        milliseconds to be stale.
+   */
   constructor({
     relativeTime = new Date(),
     threshold = DEFAULT_STALE_THRESHOLD,
@@ -25,7 +38,12 @@ class StaleChecker {
     this.threshold = threshold;
   }
 
-  getDataForSource(source) {
+  /**
+   * Get an {@link AgeStatistics} object for the given source.
+   * @param {string} source
+   * @returns {AgeStatistics}
+   */
+  getStatisticsForSource(source) {
     if (!this.bySource.has(source)) {
       this.bySource.set(source, {
         source,
@@ -37,10 +55,15 @@ class StaleChecker {
     return this.bySource.get(source);
   }
 
+  /**
+   * Aggregate statistics for a record and return its age in milliseconds.
+   * @param {any} record
+   * @returns {number}
+   */
   checkRecord(record) {
     if (!record.availability) return null;
 
-    const stats = this.getDataForSource(record.availability.source);
+    const stats = this.getStatisticsForSource(record.availability.source);
     const age = StaleChecker.calculateDataAge(this.relativeTime, record);
     if (age == null) return null;
 
@@ -52,46 +75,84 @@ class StaleChecker {
     return age;
   }
 
+  /**
+   * Aggregate statistics for a record and return the record if it is fresh or
+   * `null` if the record is stale.
+   * @param {any} record
+   * @returns {any|null}
+   */
   filterRecord(record) {
     const age = this.checkRecord(record);
     return age > this.threshold ? null : record;
   }
 
   /**
+   * Get data age statistics. Yields an {@link AgeStatistics} object for each
+   * source.
+   * @param {Object} [options]
+   * @param {boolean} [options.includeUnkown] Yield statistics for sources where
+   *        the age is unknown.
    * @yields {Required<AgeStatistics>}
    * @returns {Iterable<Required<AgeStatistics>>}
    */
-  *listStatistics() {
+  *listStatistics({ includeUnknown = false } = {}) {
     this.finish();
 
     for (const data of this.bySource.values()) {
-      if (data.samples.length > 0) {
+      if (includeUnknown || data.samples.length > 0) {
         yield data;
       }
     }
   }
 
+  /**
+   * Print a summary of any sources with stale data. Will also send a warning
+   * to any configured error tracking system, e.g. Sentry.
+   */
   printSummary() {
-    this.finish();
-
     const formatMillis = (s) =>
       Duration.fromMillis(Math.ceil(s / 1000) * 1000)
         .rescale()
         .toHuman();
 
-    for (const stats of this.bySource.values()) {
+    for (const stats of this.listStatistics({ includeUnknown: true })) {
       if (stats.samples.length === 0) {
-        console.error(`No age information for locations in ${stats.source}.`);
+        console.warn(`No age information for locations in ${stats.source}.`);
       } else if (stats.max > this.threshold) {
-        console.error(`${stats.source} has stale data!`);
-        console.error(`  Minimum age: ${formatMillis(stats.min)}`);
-        console.error(`  Maximum age: ${formatMillis(stats.max)}`);
-        console.error(`  Average age: ${formatMillis(stats.average)}`);
-        console.error(`  Median age:  ${formatMillis(stats.median)}`);
+        warn(
+          `${stats.source} has stale data!`,
+          {
+            min: formatMillis(stats.min),
+            max: formatMillis(stats.max),
+            average: formatMillis(stats.average),
+            median: formatMillis(stats.median),
+          },
+          true
+        );
       }
     }
   }
 
+  /**
+   * Send metrics to Datadog or whatever metrics system is configured.
+   * @param {string} prefix Prefix the metric name with this. Metrics are:
+   *        `<prefix>.age_seconds.<min|max|avg|median>`
+   */
+  sendMetrics(prefix) {
+    for (const stats of this.listStatistics()) {
+      const tags = [`source:${stats.source}`];
+      const name = [prefix, "age_seconds"].join(".");
+      metrics.gauge(`${name}.min`, stats.min / 1000, tags);
+      metrics.gauge(`${name}.max`, stats.max / 1000, tags);
+      metrics.gauge(`${name}.avg`, stats.average / 1000, tags);
+      metrics.gauge(`${name}.median`, stats.median / 1000, tags);
+    }
+  }
+
+  /**
+   * Calculate summary statistics (average, median). Generally you shouldn't
+   * call this directly; use `listStatistics()` instead.
+   */
   finish() {
     if (this.#finished) return;
 

--- a/loader/src/stale.js
+++ b/loader/src/stale.js
@@ -18,7 +18,7 @@ const warn = createWarningLogger("stale");
 
 class StaleChecker {
   /** @type {Map<string, AgeStatistics>} */
-  bySource = new Map();
+  #bySource = new Map();
 
   #finished = false;
 
@@ -44,15 +44,15 @@ class StaleChecker {
    * @returns {AgeStatistics}
    */
   getStatisticsForSource(source) {
-    if (!this.bySource.has(source)) {
-      this.bySource.set(source, {
+    if (!this.#bySource.has(source)) {
+      this.#bySource.set(source, {
         source,
         min: Infinity,
         max: -Infinity,
         samples: [],
       });
     }
-    return this.bySource.get(source);
+    return this.#bySource.get(source);
   }
 
   /**
@@ -98,7 +98,7 @@ class StaleChecker {
   *listStatistics({ includeUnknown = false } = {}) {
     this.finish();
 
-    for (const data of this.bySource.values()) {
+    for (const data of this.#bySource.values()) {
       if (includeUnknown || data.samples.length > 0) {
         yield data;
       }
@@ -117,7 +117,7 @@ class StaleChecker {
 
     for (const stats of this.listStatistics({ includeUnknown: true })) {
       if (stats.samples.length === 0) {
-        console.warn(`No age information for locations in ${stats.source}.`);
+        warn(`${stats.source} has no age information for locations.`);
       } else if (stats.max > this.threshold) {
         warn(
           `${stats.source} has stale data!`,
@@ -156,7 +156,7 @@ class StaleChecker {
   finish() {
     if (this.#finished) return;
 
-    for (const stats of this.bySource.values()) {
+    for (const stats of this.#bySource.values()) {
       if (stats.samples.length !== 0) {
         const sorted = stats.samples.sort((a, b) => a - b);
         stats.average =

--- a/loader/test/stale.test.js
+++ b/loader/test/stale.test.js
@@ -1,4 +1,9 @@
+const utils = require("../src/utils");
+const metrics = require("../src/metrics");
 const { StaleChecker } = require("../src/stale");
+
+jest.mock("../src/utils");
+jest.mock("../src/metrics");
 
 // Keep a single, integerial "now" timestamp so test results are predictable.
 const now = new Date(Math.floor(Date.now()));
@@ -16,6 +21,18 @@ function createMinutesAgoDatestamp(value = 0, relative = now) {
 }
 
 function createRecord(data) {
+  let availability = undefined;
+  if ("availability" in data && data.availability) {
+    availability = {
+      source: "test-source",
+      valid_at: createMinutesAgoTimestamp(10),
+      checked_at: createMinutesAgoTimestamp(10),
+      available: "YES",
+      available_count: 191,
+      ...data.availability,
+    };
+  }
+
   return {
     external_ids: [
       ["njiis", "nj5678"],
@@ -38,21 +55,19 @@ function createRecord(data) {
     requires_waitlist: false,
     is_public: true,
     ...data,
-    availability: {
-      source: "test-source",
-      valid_at: createMinutesAgoTimestamp(10),
-      checked_at: createMinutesAgoTimestamp(10),
-      available: "YES",
-      available_count: 191,
-      ...data.availability,
-    },
+
+    availability,
   };
 }
 
 describe("StaleChecker", () => {
   let checker;
   beforeEach(() => {
-    checker = new StaleChecker({ relativeTime: now });
+    jest.clearAllMocks();
+    checker = new StaleChecker({
+      relativeTime: now,
+      threshold: minutes(24 * 60),
+    });
   });
 
   it("keeps statistics about record age", () => {
@@ -95,6 +110,152 @@ describe("StaleChecker", () => {
       average: minutes(21),
       median: minutes(22),
     });
+  });
+
+  it("filters out stale records based on threshold", () => {
+    const filterOut = checker.filterRecord(
+      createRecord({
+        availability: {
+          valid_at: createMinutesAgoTimestamp(25 * 60),
+        },
+      })
+    );
+    expect(filterOut).toBeNull();
+
+    const filterIn = checker.filterRecord(
+      createRecord({
+        availability: {
+          valid_at: createMinutesAgoTimestamp(23 * 60),
+        },
+      })
+    );
+    expect(filterIn).not.toBeNull();
+  });
+
+  it("keeps records of unknown age", () => {
+    const filterIn = checker.filterRecord(
+      createRecord({
+        availability: {
+          valid_at: undefined,
+        },
+      })
+    );
+    expect(filterIn).not.toBeNull();
+
+    const noAvailability = checker.filterRecord(
+      createRecord({
+        availability: null,
+      })
+    );
+    expect(noAvailability).not.toBeNull();
+  });
+
+  it("logs a warning for each stale source", () => {
+    checker.checkRecord(
+      createRecord({
+        availability: {
+          source: "test-source-1",
+          valid_at: createMinutesAgoTimestamp(25 * 60),
+        },
+      })
+    );
+    checker.checkRecord(
+      createRecord({
+        availability: {
+          source: "test-source-2",
+          valid_at: createMinutesAgoTimestamp(20 * 60),
+        },
+      })
+    );
+    checker.checkRecord(
+      createRecord({
+        availability: {
+          source: "test-source-3",
+          valid_at: createMinutesAgoTimestamp(25 * 60),
+        },
+      })
+    );
+
+    checker.printSummary();
+    expect(utils.__getWarnings()).toContainEqual(
+      expect.stringContaining("test-source-1 has stale data")
+    );
+    expect(utils.__getWarnings()).not.toContainEqual(
+      expect.stringContaining("test-source-2 has stale data")
+    );
+    expect(utils.__getWarnings()).toContainEqual(
+      expect.stringContaining("test-source-3 has stale data")
+    );
+  });
+
+  it("logs a warning for each source with no age information", () => {
+    checker.checkRecord(
+      createRecord({
+        availability: {
+          source: "test-source-1",
+          valid_at: undefined,
+        },
+      })
+    );
+
+    checker.printSummary();
+    expect(utils.__getWarnings()).toContainEqual(
+      expect.stringContaining("test-source-1 has no age information")
+    );
+  });
+
+  it("sends metrics for each source", () => {
+    checker.checkRecord(
+      createRecord({
+        availability: {
+          valid_at: createMinutesAgoTimestamp(10),
+        },
+      })
+    );
+    checker.checkRecord(
+      createRecord({
+        availability: {
+          valid_at: createMinutesAgoTimestamp(20),
+        },
+      })
+    );
+
+    checker.sendMetrics("prefix");
+
+    expect(metrics.gauge).toHaveBeenCalledWith(
+      "prefix.age_seconds.min",
+      minutes(10) / 1000,
+      [`source:test-source`]
+    );
+    expect(metrics.gauge).toHaveBeenCalledWith(
+      "prefix.age_seconds.max",
+      minutes(20) / 1000,
+      [`source:test-source`]
+    );
+    expect(metrics.gauge).toHaveBeenCalledWith(
+      "prefix.age_seconds.avg",
+      minutes(15) / 1000,
+      [`source:test-source`]
+    );
+    expect(metrics.gauge).toHaveBeenCalledWith(
+      "prefix.age_seconds.median",
+      minutes(15) / 1000,
+      [`source:test-source`]
+    );
+  });
+
+  it("does not send metrics for sources with no age data", () => {
+    checker.checkRecord(
+      createRecord({
+        availability: {
+          valid_at: undefined,
+        },
+      })
+    );
+
+    checker.sendMetrics("prefix");
+
+    expect(metrics.gauge).not.toHaveBeenCalled();
   });
 });
 
@@ -150,5 +311,42 @@ describe("StaleChecker.calculateAge", () => {
     );
 
     expect(age).toBe(minutes(72 * 60));
+  });
+
+  it("gives up if there is an empty slot list", () => {
+    const age = StaleChecker.calculateAge(
+      now,
+      createRecord({
+        availability: {
+          valid_at: createMinutesAgoTimestamp(72 * 60),
+          slots: [],
+        },
+      })
+    );
+
+    expect(age).toBeNull();
+  });
+
+  it("gives up if there is an empty capacity list", () => {
+    const age = StaleChecker.calculateAge(
+      now,
+      createRecord({
+        availability: {
+          valid_at: createMinutesAgoTimestamp(72 * 60),
+          capacity: [],
+        },
+      })
+    );
+
+    expect(age).toBeNull();
+  });
+
+  it("gives up if there is no availability object", () => {
+    const age = StaleChecker.calculateAge(
+      now,
+      createRecord({ availability: null })
+    );
+
+    expect(age).toBeNull();
   });
 });

--- a/loader/test/stale.test.js
+++ b/loader/test/stale.test.js
@@ -1,0 +1,154 @@
+const { StaleChecker } = require("../src/stale");
+
+// Keep a single, integerial "now" timestamp so test results are predictable.
+const now = new Date(Math.floor(Date.now()));
+
+function minutes(count) {
+  return count * 60 * 1000;
+}
+
+function createMinutesAgoTimestamp(value = 0, relative = now) {
+  return new Date(relative - minutes(value)).toISOString();
+}
+
+function createMinutesAgoDatestamp(value = 0, relative = now) {
+  return createMinutesAgoTimestamp(value, relative).slice(0, 10);
+}
+
+function createRecord(data) {
+  return {
+    external_ids: [
+      ["njiis", "nj5678"],
+      ["vtrcks", "789"],
+      ["rite_aid", "576"],
+      ["univaf_v0", "rite_aid:576"],
+    ],
+    provider: "RiteAid",
+    location_type: "PHARMACY",
+    name: "Rite Aid #576",
+    address_lines: ["605 North Colony Road"],
+    city: "Wallingford",
+    state: "CT",
+    county: "County",
+    postal_code: "06492-3109",
+    info_phone: "(203) 265-3600",
+    info_url: "https://www.riteaid.com/covid-19",
+    booking_phone: "(203) 265-3600",
+    booking_url: "https://www.riteaid.com/pharmacy/covid-qualifier",
+    requires_waitlist: false,
+    is_public: true,
+    ...data,
+    availability: {
+      source: "test-source",
+      valid_at: createMinutesAgoTimestamp(10),
+      checked_at: createMinutesAgoTimestamp(10),
+      available: "YES",
+      available_count: 191,
+      ...data.availability,
+    },
+  };
+}
+
+describe("StaleChecker", () => {
+  let checker;
+  beforeEach(() => {
+    checker = new StaleChecker({ relativeTime: now });
+  });
+
+  it("keeps statistics about record age", () => {
+    checker.checkRecord(
+      createRecord({
+        availability: {
+          valid_at: createMinutesAgoTimestamp(10),
+        },
+      })
+    );
+    checker.checkRecord(
+      createRecord({
+        availability: {
+          valid_at: createMinutesAgoTimestamp(20),
+        },
+      })
+    );
+    checker.checkRecord(
+      createRecord({
+        availability: {
+          valid_at: createMinutesAgoTimestamp(30),
+        },
+      })
+    );
+    checker.checkRecord(
+      createRecord({
+        availability: {
+          valid_at: createMinutesAgoTimestamp(24),
+        },
+      })
+    );
+
+    const statistics = [...checker.listStatistics()];
+    expect(statistics).toHaveLength(1);
+    expect(statistics[0]).toEqual({
+      source: "test-source",
+      samples: [minutes(10), minutes(20), minutes(24), minutes(30)],
+      min: minutes(10),
+      max: minutes(30),
+      average: minutes(21),
+      median: minutes(22),
+    });
+  });
+});
+
+describe("StaleChecker.calculateAge", () => {
+  it("prefers the newest slot if older than valid_at", () => {
+    const age = StaleChecker.calculateAge(
+      now,
+      createRecord({
+        availability: {
+          valid_at: createMinutesAgoTimestamp(10),
+          slots: [
+            { start: createMinutesAgoTimestamp(60) },
+            { start: createMinutesAgoTimestamp(30) },
+          ],
+        },
+      })
+    );
+
+    expect(age).toBe(minutes(30));
+  });
+
+  it("prefers the newest capacity if older than valid_at", () => {
+    const age = StaleChecker.calculateAge(
+      now,
+      createRecord({
+        availability: {
+          valid_at: createMinutesAgoTimestamp(10),
+          capacity: [
+            { date: createMinutesAgoDatestamp(48 * 60) },
+            { date: createMinutesAgoDatestamp(24 * 60) },
+          ],
+        },
+      })
+    );
+
+    expect(age).toBe(
+      now - new Date(createMinutesAgoDatestamp(24 * 60)).getTime()
+    );
+  });
+
+  it("prefers valid_at if older than capacity", () => {
+    const age = StaleChecker.calculateAge(
+      now,
+      createRecord({
+        availability: {
+          valid_at: createMinutesAgoTimestamp(72 * 60),
+          capacity: [
+            { date: createMinutesAgoDatestamp(48 * 60) },
+            { date: createMinutesAgoDatestamp(24 * 60) },
+          ],
+        },
+      })
+    );
+
+    expect(age).toBe(minutes(72 * 60));
+  });
+});


### PR DESCRIPTION
On each loader run, send metrics about stale data to Datadog and log warnings. This also adds a command-line option to filter out stale data from the result set, too. A record's age is based on the older of `availability.valid_at` and the latest `availability.capacity` entry or latest `availability.slots` entry (sometimes `valid_at` turns out to be a lie, so we use the actual slots or capacity when we can).

The two added CLI options:
- `--filter-stale-data` will cause the loader not to output/send location records that are stale.
- `--stale-threshold N` sets the threshold (in milliseconds) at which stale data is filtered out or warnings are logged. (Metrics are sent to Datadog regardless of the threshold.)

In all cases, metrics are sent to Datadog (as long as Datadog is configured), matching the fields used for histograms:
- `loader.loader.data.age_seconds.min`
- `loader.loader.data.age_seconds.max`
- `loader.loader.data.age_seconds.avg`
- `loader.loader.data.age_seconds.median`

Fixes #1459.