### PR TITLE
Add shutdown notices to docs and API responses

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -31,3 +31,10 @@ export PRIMARY_HOST='getmyvax.org'
 
 # S3 bucket name for daily database dumps
 # export DATA_SNAPSHOT_S3_BUCKET=''
+
+# If set to an ISO 8601 Date or Datetime, the server will add sunset date
+# information to responses.
+# export API_SUNSET_DATE='2023-06-15'
+
+# If set, the server will link to this URL for sunset details.
+# export API_SUNSET_INFO_URL='/docs'

--- a/server/public/docs/index.html
+++ b/server/public/docs/index.html
@@ -18,9 +18,47 @@
         margin: 0;
         padding: 0;
       }
+
+      .warning {
+        --border-color: #ffe69c;
+        background: #fff3cd;
+        color: #664d03;
+        padding: 0.5em 1em;
+      }
+
+      .banner {
+        border-bottom: 1px solid var(--border-color);
+        font-family: Montserrat, sans-serif;
+        line-height: 1.5;
+        padding: 0.5em 1em;
+      }
+
+      .notice-box {
+        border: 1px solid var(--border-color);
+        border-radius: 6px;
+        position: relative;
+        padding-left: 2.5em;
+      }
+
+      .notice-box::before {
+        content: "⚠️";
+        position: absolute;
+        left: 0.5em;
+        top: 0.5em;
+      }
+
+      .notice-box p:first-child {
+        margin-top: 0;
+      }
     </style>
   </head>
   <body>
+    <div role="status" class="warning banner">
+      <span role="presentation">⚠️</span>
+      <strong>Support ends on June 15, 2023!</strong>
+      Because the federal COVID-19 emergency has ended, USDR will shut off
+      this API on June 15, 2023.
+    </div>
     <redoc spec-url="/docs/openapi.yaml"></redoc>
     <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"></script>
   </body>

--- a/server/public/docs/index.html
+++ b/server/public/docs/index.html
@@ -56,8 +56,8 @@
     <div role="status" class="warning banner">
       <span role="presentation">⚠️</span>
       <strong>Support ends on June 15, 2023!</strong>
-      Because the federal COVID-19 emergency has ended, USDR will shut off
-      this API on June 15, 2023.
+      Because the federal COVID-19 emergency has ended, USDR will shut off this
+      API on June 15, 2023.
     </div>
     <redoc spec-url="/docs/openapi.yaml"></redoc>
     <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"></script>

--- a/server/public/docs/openapi.yaml
+++ b/server/public/docs/openapi.yaml
@@ -13,6 +13,21 @@ info:
     the State of New Jersey Office of Innovation, VaccineSpotter.org, and
     Vaccinate the States.
 
+    <div class="warning notice-box">
+      <p>
+        The federal COVID-19 emergency has ended, so <strong>U.S. Digital
+        Response will be shutting off this API</strong> and ending active
+        support and updates for the code behind it on June 15, 2023.
+      </p>
+      <p>
+        This system is open-source software, and you can deploy your own
+        version of it based on the code at
+        <a href="https://github.com/usdigitalresponse/univaf">github.com/usdigitalresponse/univaf</a>.
+        If you need additional information or support, please contact
+        univaf@usdigitalresponse.org.
+      </p>
+    </div>
+
 
     ## Data Sources
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -5,9 +5,10 @@ import errorHandler from "errorhandler";
 import * as Sentry from "@sentry/node";
 import { RELEASE } from "./config";
 import {
-  AppRequest,
   addSunsetHeaders,
   authorizeRequest,
+  cacheControlMaxAge,
+  logRequest,
   parseJsonBody,
   versionedMiddleware,
 } from "./middleware";
@@ -16,30 +17,6 @@ import { logger, logStackTrace } from "./logger";
 import * as apiEdge from "./api/edge";
 import * as apiLegacy from "./api/legacy";
 import { asyncHandler, urlDecodeSpecialPathChars } from "./utils";
-
-// TODO: we should use a proper logging library (e.g. Winston) which has
-// plugins and extensions for this, and will gather better data.
-function logRequest(request: Request, response: Response, next: NextFunction) {
-  logger.debug(`${response.statusCode} ${request.method} ${request.url}`);
-  next();
-}
-
-function cacheControlMaxAge(seconds: number) {
-  return function (
-    request: AppRequest,
-    response: Response,
-    next: NextFunction
-  ) {
-    if (request.method == "GET") {
-      const directives = [
-        request.authorization ? "private" : "public",
-        `max-age=${seconds}`,
-      ];
-      response.set("Cache-Control", directives.join(", "));
-    }
-    next();
-  };
-}
 
 // Express configuration -----------------------------------------
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -6,6 +6,7 @@ import * as Sentry from "@sentry/node";
 import { RELEASE } from "./config";
 import {
   AppRequest,
+  addSunsetHeaders,
   authorizeRequest,
   parseJsonBody,
   versionedMiddleware,
@@ -74,6 +75,7 @@ app.use(parseJsonBody({ limit: "2.5mb" }));
 app.use(cors());
 app.use(authorizeRequest);
 app.use(urlDecodeSpecialPathChars);
+app.use(addSunsetHeaders);
 
 // Diagnostic Routes ---------------------------------------------
 

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -1,5 +1,6 @@
 import os from "node:os";
 import type { Knex } from "knex";
+import { DateTime } from "luxon";
 
 export const LOG_LEVEL = process.env.LOG_LEVEL || "info";
 
@@ -60,6 +61,19 @@ export function getHostInstance(): string {
     return `${process.env.RENDER_SERVICE_NAME}-${process.env.RENDER_INSTANCE_ID}`;
   } else {
     return os.hostname();
+  }
+}
+
+/**
+ * Get a warning message to be included with any API responses. Will be `null`
+ * if there are no warnings.
+ */
+export function getApiSunset(): { date: DateTime; infoUrl: string } | null {
+  if (process.env.API_SUNSET_DATE) {
+    return {
+      date: DateTime.fromISO(process.env.API_SUNSET_DATE),
+      infoUrl: process.env.API_SUNSET_INFO_URL || "/docs",
+    };
   }
 }
 

--- a/server/src/middleware.ts
+++ b/server/src/middleware.ts
@@ -1,6 +1,7 @@
 import { Response, Request, NextFunction } from "express";
 import bodyParser from "body-parser";
 import { getApiKeys, getApiSunset } from "./config";
+import { logger } from "./logger";
 import { absoluteUrl } from "./utils";
 
 export interface AppRequest extends Request {
@@ -87,5 +88,38 @@ export function addSunsetHeaders(
     response.header("Sunset", sunset.date.toHTTP());
     response.header("Link", `<${infoUrl}>;rel="sunset";type="text/html"`);
   }
+  next();
+}
+
+/**
+ * Set the Cache-Control HTTP response header's max-age directive to the given
+ * number of seconds.
+ */
+export function cacheControlMaxAge(seconds: number) {
+  return function (
+    request: AppRequest,
+    response: Response,
+    next: NextFunction
+  ): void {
+    if (request.method == "GET") {
+      const directives = [
+        request.authorization ? "private" : "public",
+        `max-age=${seconds}`,
+      ];
+      response.set("Cache-Control", directives.join(", "));
+    }
+    next();
+  };
+}
+
+/**
+ * Log basic info about the request at DEBUG level.
+ */
+export function logRequest(
+  request: Request,
+  response: Response,
+  next: NextFunction
+): void {
+  logger.debug(`${response.statusCode} ${request.method} ${request.url}`);
   next();
 }

--- a/server/src/smart-scheduling-routes.ts
+++ b/server/src/smart-scheduling-routes.ts
@@ -11,8 +11,7 @@ import { Request, Response } from "express";
 import { DateTime } from "luxon";
 import { states } from "univaf-common";
 import { CVX_CODES, PRODUCT_NAMES, VaccineCode } from "univaf-common/vaccines";
-import { getPrimaryHost } from "./config";
-import { getRequestHost } from "./utils";
+import { absoluteUrl } from "./utils";
 import * as db from "./db";
 import {
   Availability,
@@ -98,26 +97,24 @@ export function fhirNotImplemented(_req: Request, res: Response): void {
 const statesList = states.filter((state: any) => state.type === "State");
 
 export function manifest(req: Request, res: Response): void {
-  const host = getPrimaryHost() || getRequestHost(req);
-  const baseUrl = `${req.protocol}://${host}${req.baseUrl}`;
   res.json({
     // TODO: consider making this the latest updated availability timestamp.
     transactionTime: new Date().toISOString(),
-    request: `${baseUrl}/$bulk-publish`,
+    request: absoluteUrl("$bulk-publish", req),
     output: [
       statesList.map((state: any) => ({
         type: "Location",
-        url: `${baseUrl}/locations/states/${state.usps}.ndjson`,
+        url: absoluteUrl(`locations/states/${state.usps}.ndjson`, req),
         extension: { state: [state.usps] },
       })),
       statesList.map((state: any) => ({
         type: "Schedule",
-        url: `${baseUrl}/schedules/states/${state.usps}.ndjson`,
+        url: absoluteUrl(`schedules/states/${state.usps}.ndjson`, req),
         extension: { state: [state.usps] },
       })),
       statesList.map((state: any) => ({
         type: "Slot",
-        url: `${baseUrl}/slots/states/${state.usps}.ndjson`,
+        url: absoluteUrl(`slots/states/${state.usps}.ndjson`, req),
         extension: { state: [state.usps] },
       })),
     ].flat(),

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -35,7 +35,7 @@ export function asyncHandler(handler: PromiseHandler): RequestHandler {
  */
 export function addQueryToCurrentUrl(request: Request, newQuery: any): string {
   const query = new URLSearchParams({ ...request.query, ...newQuery });
-  return `${request.baseUrl}${request.path}?${query}`;
+  return absoluteUrl(`${request.path}?${query}`, request);
 }
 
 interface PaginationLinks {

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -1,6 +1,7 @@
 import { NextFunction, RequestHandler, Request, Response } from "express";
 import { URLSearchParams, format as urlFormat, parse as urlParse } from "url";
 import { ValueError } from "./exceptions";
+import { getPrimaryHost } from "./config";
 
 export const UUID_PATTERN =
   /^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$/;
@@ -116,4 +117,19 @@ export function getRequestHost(request: Request): string {
   }
 
   return val || undefined;
+}
+
+export function absoluteUrl(localUrl: string, request?: Request): string {
+  if (/^https?:\/\//.test(localUrl)) return localUrl;
+
+  const host = getPrimaryHost() || (request && getRequestHost(request));
+  if (!host) {
+    throw new Error(
+      "You must configure a primary host or provide a request to build an absolute URL from."
+    );
+  }
+
+  const protocol = request?.protocol ?? "https";
+  const baseUrl = `${protocol}://${host}${request?.baseUrl ?? ""}/`;
+  return new URL(localUrl, baseUrl).href;
 }


### PR DESCRIPTION
USDR has decided to shut the service down in a month, so this adds shutdown notices to the docs page and to API responses (using the `Sunset` header and the sunset `Link` header from [RFC 8594](https://datatracker.ietf.org/doc/html/rfc8594).

![Screen Shot 2023-05-15 at 12 27 08 PM](https://github.com/usdigitalresponse/univaf/assets/74178/4e59089c-565d-4759-9d0c-40a7063609dc)

While I was at it, I moved some middleware function to the right place (since I was messing with middleware to do the headers) and cleaned up some URL logic by adding an `absoluteUrl(relativeUrl, request)` utility function.