### PR TITLE
Slow down some loaders, stop Rite Aid SMART

### DIFF
--- a/terraform/cron-loaders.tf
+++ b/terraform/cron-loaders.tf
@@ -49,7 +49,7 @@ locals {
       }
     }
     prepmod = {
-      schedule = "cron(9/30 * * * ? *)"
+      schedule = "cron(9/15 * * * ? *)"
       options  = ["--states", "AK,WA", "--hide-missing-locations"]
     }
   }

--- a/terraform/cron-loaders.tf
+++ b/terraform/cron-loaders.tf
@@ -35,8 +35,12 @@ locals {
     albertsonsScraper = { schedule = "cron(20/30 * * * ? *)" }
     hyvee             = { schedule = "cron(8/10 * * * ? *)" }
     heb               = { schedule = "cron(1/10 * * * ? *)" }
-    cdcApi            = { schedule = "cron(0 0,12 * * ? *)" }
-    riteAidScraper    = { schedule = "cron(5/30 * * * ? *)" }
+    cdcApi = {
+      schedule = "cron(0 0,12 * * ? *)"
+      # CDC updates are often slow; set stale threshold to 3 days.
+      options = ["--stale-threshold", "172800000"]
+    }
+    riteAidScraper = { schedule = "cron(5/30 * * * ? *)" }
     riteAidApi = {
       schedule = "cron(0/15 * * * ? *)"
       env_vars = {
@@ -59,6 +63,7 @@ module "source_loader" {
 
   name = each.key
   command = concat(
+    ["--filter-stale-data"],
     lookup(each.value, "options", []),
     lookup(each.value, "sources", [each.key]),
   )

--- a/terraform/cron-loaders.tf
+++ b/terraform/cron-loaders.tf
@@ -28,18 +28,15 @@ locals {
         NJVSS_AWS_SECRET_KEY = var.njvss_aws_secret_key
       }
     },
-    waDoh             = { schedule = "cron(3/5 * * * ? *)" }
-    cvsSmart          = { schedule = "cron(0/10 * * * ? *)" }
+    waDoh             = { schedule = "cron(3/30 * * * ? *)" }
+    cvsSmart          = { schedule = "cron(0/30 * * * ? *)" }
     walgreensSmart    = { schedule = "cron(2/10 * * * ? *)" }
-    krogerSmart       = { schedule = "cron(4/10 * * * ? *)" }
+    krogerSmart       = { schedule = "cron(4/30 * * * ? *)" }
     albertsonsScraper = { schedule = "cron(20/30 * * * ? *)" }
     hyvee             = { schedule = "cron(8/10 * * * ? *)" }
     heb               = { schedule = "cron(1/10 * * * ? *)" }
     cdcApi            = { schedule = "cron(0 0,12 * * ? *)" }
     riteAidScraper    = { schedule = "cron(5/30 * * * ? *)" }
-    # TODO: Turn off riteAidApi. riteAidSmart + riteAidApi are running in
-    # parallel while testing riteAidSmart.
-    riteAidSmart = { schedule = "cron(8/15 * * * ? *)" }
     riteAidApi = {
       schedule = "cron(0/15 * * * ? *)"
       env_vars = {
@@ -48,7 +45,7 @@ locals {
       }
     }
     prepmod = {
-      schedule = "cron(9/10 * * * ? *)"
+      schedule = "cron(9/30 * * * ? *)"
       options  = ["--states", "AK,WA", "--hide-missing-locations"]
     }
   }


### PR DESCRIPTION
It's time to make some more loader adjustments as we ramp down the service and deal with some sources that have gotten stale or stopped working:

- The CVS and Kroger SMART loaders have stale data or fail frequently, so this slows them both down. We only really want to bother with them so we get notified if they start working again at some point.
- Slow down WA state Dept. of Health and Prepmod, since they are high load, not run by commercial entities, and are less critical.
- Disable the Rite Aid SMART loader, since it didn't actually pan out (see https://github.com/usdigitalresponse/univaf/issues/159#issuecomment-1518109902).

Finally, this makes use of the new stale data filtering feature from #1480 to reduce internal traffic.