### PR TITLE
Set sunset date for the API in Terraform

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -92,6 +92,7 @@ module "api_task" {
     SENTRY_DSN                = var.api_sentry_dsn
     SENTRY_TRACES_SAMPLE_RATE = format("%.2f", var.api_sentry_traces_sample_rate)
     PRIMARY_HOST              = var.domain_name
+    API_SUNSET_DATE           = var.api_sunset_date
   }
 
   depends_on = [aws_alb_listener.front_end, aws_iam_role_policy_attachment.ecs_task_execution_role]

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -123,6 +123,11 @@ variable "api_sentry_traces_sample_rate" {
   }
 }
 
+variable "api_sunset_date" {
+  description = "ISO 8601 Date or Datetime when the API will be turned off."
+  default     = ""
+}
+
 variable "loader_sentry_dsn" {
   description = "The Sentry.io DSN to use for the loaders"
   default     = ""


### PR DESCRIPTION
This actually turns on the API sunset headers. It should have been part of #1488, but I forgot it.