### PR TITLE
Turn CVS and Kroger schedules WAY down

### DIFF
--- a/terraform/cron-loaders.tf
+++ b/terraform/cron-loaders.tf
@@ -29,9 +29,7 @@ locals {
       }
     },
     waDoh             = { schedule = "cron(3/30 * * * ? *)" }
-    cvsSmart          = { schedule = "cron(0/30 * * * ? *)" }
     walgreensSmart    = { schedule = "cron(2/10 * * * ? *)" }
-    krogerSmart       = { schedule = "cron(4/30 * * * ? *)" }
     albertsonsScraper = { schedule = "cron(20/30 * * * ? *)" }
     hyvee             = { schedule = "cron(8/10 * * * ? *)" }
     heb               = { schedule = "cron(1/10 * * * ? *)" }
@@ -52,6 +50,12 @@ locals {
       schedule = "cron(9/15 * * * ? *)"
       options  = ["--states", "AK,WA", "--hide-missing-locations"]
     }
+
+    # CVS appears to have stopped updating the data and Kroger appears to have
+    # shut things off entirely. We just want to run them enough to know if
+    # they start working again.
+    cvsSmart    = { schedule = "cron(0 1/6 * * ? *)" }
+    krogerSmart = { schedule = "cron(0 1/6 * * ? *)" }
   }
 }
 


### PR DESCRIPTION
The scuttlebutt from a Kroger developer who is no longer working on their API is that the team intentionally decided to turn it off (without notifying any government partners), so we probably shouldn't expect it to come back at this point. CVS's data is also so old I'm sure we're seeing something similar. This turns down the schedules for them to only run 4 times a day, since we don't expect to get meaningful data. At this point, they're just there to notify us if they somehow stop failing.