### PR TITLE
Turn up the CVS loader again

### DIFF
--- a/terraform/cron-loaders.tf
+++ b/terraform/cron-loaders.tf
@@ -29,6 +29,7 @@ locals {
       }
     },
     waDoh             = { schedule = "cron(3/30 * * * ? *)" }
+    cvsSmart          = { schedule = "cron(3/15 * * * ? *)" }
     walgreensSmart    = { schedule = "cron(2/10 * * * ? *)" }
     albertsonsScraper = { schedule = "cron(20/30 * * * ? *)" }
     hyvee             = { schedule = "cron(8/10 * * * ? *)" }
@@ -51,10 +52,8 @@ locals {
       options  = ["--states", "AK,WA", "--hide-missing-locations"]
     }
 
-    # CVS appears to have stopped updating the data and Kroger appears to have
-    # shut things off entirely. We just want to run them enough to know if
-    # they start working again.
-    cvsSmart    = { schedule = "cron(0 1/6 * * ? *)" }
+    # Kroger appears to have shut things off entirely. We just want to run them
+    # enough to know if they start working again.
     krogerSmart = { schedule = "cron(0 1/6 * * ? *)" }
   }
 }


### PR DESCRIPTION
It looks like CVS has finally fixed their stale data problem! This moves the CVS source back to relatively frequent loading since there's real data in it.

<img width="1169" alt="Screen Shot 2023-05-19 at 9 19 54 AM" src="https://github.com/usdigitalresponse/univaf/assets/74178/812524b4-0dc2-4903-96d0-82a8890dfa80">

(CVS is the descending yellow line on the right end of that chart.)