### PR TITLE
Make sure all loader sources are directories

### DIFF
--- a/loader/src/index.js
+++ b/loader/src/index.js
@@ -7,7 +7,7 @@ const sources = {
   cvsSmart: require("./sources/cvs/smart"),
   heb: require("./sources/heb"),
   hyvee: require("./sources/hyvee"),
-  krogerSmart: require("./sources/kroger"),
+  krogerSmart: require("./sources/kroger/smart"),
   njvss: require("./sources/njvss"),
   prepmod: require("./sources/prepmod"),
   riteAidApi: require("./sources/riteaid/api"),
@@ -15,8 +15,8 @@ const sources = {
   riteAidScraper: require("./sources/riteaid/scraper"),
   vaccinespotter: require("./sources/vaccinespotter"),
   vtsGeo: require("./sources/vts/geo"),
-  waDoh: require("./sources/wa-doh"),
-  walgreensSmart: require("./sources/walgreens"),
+  waDoh: require("./sources/wa-doh/wa-doh"),
+  walgreensSmart: require("./sources/walgreens/smart"),
 };
 
 module.exports = { sources };

--- a/loader/src/sources/kroger/smart.js
+++ b/loader/src/sources/kroger/smart.js
@@ -21,13 +21,13 @@
  * "The Little Clinic" locations.
  */
 
-const { Available, LocationType } = require("../model");
+const { Available, LocationType } = require("../../model");
 const {
   unpadNumber,
   getUniqueExternalIds,
   createWarningLogger,
   DEFAULT_STATES,
-} = require("../utils");
+} = require("../../utils");
 const {
   EXTENSIONS,
   SmartSchedulingLinksApi,
@@ -35,7 +35,7 @@ const {
   formatExternalIds,
   valuesAsObject,
   getExtensions,
-} = require("../smart-scheduling-links");
+} = require("../../smart-scheduling-links");
 
 const API_URL =
   "https://api.kroger.com/v1/health-wellness/schedules/vaccines/$bulk-publish";

--- a/loader/src/sources/wa-doh/wa-doh.js
+++ b/loader/src/sources/wa-doh/wa-doh.js
@@ -3,15 +3,15 @@
 
 const assert = require("node:assert/strict");
 const { states: allStates } = require("univaf-common");
-const { Available, LocationType } = require("../model");
+const { Available, LocationType } = require("../../model");
 const {
   queryGraphQl,
   matchVaccineProduct,
   createWarningLogger,
   DEFAULT_STATES,
-} = require("../utils");
+} = require("../../utils");
 
-/** @typedef {import("../model").VaccineProduct} VaccineProduct */
+/** @typedef {import("../../model").VaccineProduct} VaccineProduct */
 
 const warn = createWarningLogger("waDoh");
 

--- a/loader/src/sources/walgreens/smart.js
+++ b/loader/src/sources/walgreens/smart.js
@@ -6,13 +6,13 @@
  */
 
 const Sentry = require("@sentry/node");
-const { Available, LocationType } = require("../model");
+const { Available, LocationType } = require("../../model");
 const {
   titleCase,
   unpadNumber,
   createWarningLogger,
   DEFAULT_STATES,
-} = require("../utils");
+} = require("../../utils");
 const {
   EXTENSIONS,
   SmartSchedulingLinksApi,
@@ -21,7 +21,7 @@ const {
   valuesAsObject,
   sourceReference,
   formatExternalIds,
-} = require("../smart-scheduling-links");
+} = require("../../smart-scheduling-links");
 
 const API_URL =
   "https://wbaschedulinglinks.blob.core.windows.net/fhir/$bulk-publish";

--- a/loader/test/kroger.smart.test.js
+++ b/loader/test/kroger.smart.test.js
@@ -1,5 +1,5 @@
 const nock = require("nock");
-const { checkAvailability, API_URL } = require("../src/sources/kroger");
+const { checkAvailability, API_URL } = require("../src/sources/kroger/smart");
 const {
   expectDatetimeString,
   splitHostAndPath,

--- a/loader/test/wa-doh.test.js
+++ b/loader/test/wa-doh.test.js
@@ -5,7 +5,7 @@ const {
   API_URL,
   checkAvailability,
   formatLocation,
-} = require("../src/sources/wa-doh");
+} = require("../src/sources/wa-doh/wa-doh");
 const { expectDatetimeString, splitHostAndPath } = require("./support");
 const { locationSchema } = require("./support/schemas");
 

--- a/loader/test/walgreens.test.js
+++ b/loader/test/walgreens.test.js
@@ -1,5 +1,8 @@
 const nock = require("nock");
-const { checkAvailability, API_URL } = require("../src/sources/walgreens");
+const {
+  checkAvailability,
+  API_URL,
+} = require("../src/sources/walgreens/smart");
 const {
   expectDatetimeString,
   splitHostAndPath,


### PR DESCRIPTION
This is just a little cleanup refactor so that all sources are structured the same. I also have some bits of uncommitted code that's been floating around on my local drive for a while that goes along with some sources that previously weren't in directories, and since I'd like to commit it for posterity, having a directory to put it in is nice.