### PR TITLE
Make server scripts TypeScript, remove duplicated code

### DIFF
--- a/common/src/address.ts
+++ b/common/src/address.ts
@@ -171,3 +171,25 @@ export function parseUsAddress(address: string): UsAddress {
     zip,
   };
 }
+
+/**
+ * Format a US ZIP code into its canonical 5-digit form (plus an optional
+ * 4-digit suffix). This is useful since a lot of systems return ZIP codes
+ * without leading zeroes.
+ */
+export function formatZipCode(zipCode: string | number): string {
+  if (typeof zipCode === "number" && !Number.isInteger(zipCode)) {
+    throw new SyntaxError(`ZIP code is not an integer: "${zipCode}"`);
+  }
+
+  const parts = zipCode.toString().split("-");
+  if (parts.length > 2) {
+    throw new SyntaxError(`ZIP code has multiple dashes: "${zipCode}"`);
+  }
+
+  let result = parts[0].padStart(5, "0");
+  if (parts.length > 1) {
+    result = `${result}-${parts[1].padStart(4, "0")}`;
+  }
+  return result;
+}

--- a/common/src/address.ts
+++ b/common/src/address.ts
@@ -1,0 +1,173 @@
+import { ParseError } from "./exceptions";
+
+const MULTIPLE_SPACE_PATTERN = /[\n\s]+/g;
+const PUNCTUATION_PATTERN = /[.,;\-–—'"“”‘’`!()/\\]+/g;
+const POSSESSIVE_PATTERN = /['’]s /g;
+
+const ADDRESS_LINE_DELIMITER_PATTERN = /,|\n|\s-\s/g;
+const ADDRESS_PATTERN =
+  /^(.*),\s+([^,]+),\s+([A-Z]{2}),?\s+(\d+(-\d{4})?)\s*$/i;
+
+// Common abbreviations in addresses and their expanded, full English form.
+// These are used to match similar addresses. For example:
+//   "600 Ocean Hwy" and "600 Ocean Highway"
+// They're always used in lower-case text where punctuation has been removed.
+// In some cases, the replacements *remove* the abbreviation entirely to enable
+// better loose matching (usually for road types, like "road" vs. "street").
+const ADDRESS_EXPANSIONS: [RegExp, string][] = [
+  [/ i /g, " interstate "],
+  [/ i-(\d+) /g, " interstate $1 "],
+  [/ expy /g, " expressway "],
+  [/ fwy /g, " freeway "],
+  [/ hwy /g, " highway "],
+  [/ (u s|us) /g, " "], // Frequently in "U.S. Highway / US Highway"
+  [/ (s r|sr|st rt|state route|state road) /g, " route "],
+  [/ rt /g, " route "],
+  [/ (tpke?|pike) /g, " turnpike "],
+  [/ ft /g, " fort "],
+  [/ mt /g, " mount "],
+  [/ mtn /g, " mountain "],
+  [/ (is|isl|island) /g, " "],
+  [/ n\s?w /g, " northwest "],
+  [/ s\s?w /g, " southwest "],
+  [/ n\s?e /g, " northeast "],
+  [/ s\s?e /g, " southeast "],
+  [/ n /g, " north "],
+  [/ s /g, " south "],
+  [/ e /g, " east "],
+  [/ w /g, " west "],
+  [/ ave? /g, " "],
+  [/ avenue? /g, " "],
+  [/ dr /g, " "],
+  [/ drive /g, " "],
+  [/ rd /g, " "],
+  [/ road /g, " "],
+  [/ st /g, " "],
+  [/ street /g, " "],
+  [/ saint /g, " "], // Unfortunately, this gets mixed in with st for street.
+  [/ blvd /g, " "],
+  [/ boulevard /g, " "],
+  [/ ln /g, " "],
+  [/ lane /g, " "],
+  [/ cir /g, " "],
+  [/ circle /g, " "],
+  [/ ct /g, " "],
+  [/ court /g, " "],
+  [/ cor /g, " "],
+  [/ corner /g, " "],
+  [/ (cmn|common|commons) /g, " "],
+  [/ ctr /g, " "],
+  [/ center /g, " "],
+  [/ pl /g, " "],
+  [/ place /g, " "],
+  [/ plz /g, " "],
+  [/ plaza /g, " "],
+  [/ pkw?y /g, " "],
+  [/ parkway /g, " "],
+  [/ cswy /g, " "],
+  [/ causeway /g, " "],
+  [/ byp /g, " "],
+  [/ bypass /g, " "],
+  [/ mall /g, " "],
+  [/ (xing|crssng) /g, " "],
+  [/ crossing /g, " "],
+  [/ sq /g, " "],
+  [/ square /g, " "],
+  [/ trl? /g, " "],
+  [/ trail /g, " "],
+  [/ (twp|twsp|townsh(ip)?) /g, " "],
+  [/ est(ate)? /g, " estates "],
+  [/ vlg /g, " "],
+  [/ village /g, " "],
+  [/ (ste|suite|unit|apt|apartment) #?(\d+) /g, " $2 "],
+  [/ (bld|bldg) #?(\d+) /g, " $2 "],
+  [/ #?(\d+) /g, " $1 "],
+  [/ (&|and) /g, " "],
+  // "First" - "Tenth" are pretty common (this could obviously go farther).
+  [/ first /g, " 1st "],
+  [/ second /g, " 2nd "],
+  [/ third /g, " 3rd "],
+  [/ fourth /g, " 4th "],
+  [/ fifth /g, " 5th "],
+  [/ sixth /g, " 6th "],
+  [/ seventh /g, " 7th "],
+  [/ eighth /g, " 8th "],
+  [/ ninth /g, " 9th "],
+  [/ tenth /g, " 10th "],
+];
+
+/**
+ * Simplify a text string (especially an address) as much as possible so that
+ * it might match with a similar string from another source.
+ */
+export function matchable(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(POSSESSIVE_PATTERN, " ")
+    .replace(PUNCTUATION_PATTERN, " ")
+    .replace(MULTIPLE_SPACE_PATTERN, " ")
+    .trim();
+}
+
+export function matchableAddress(
+  text: string | string[],
+  line: number = null
+): string {
+  let lines = Array.isArray(text)
+    ? text
+    : text.split(ADDRESS_LINE_DELIMITER_PATTERN);
+
+  // If there are multiple lines and it looks like the first line is the name
+  // of a place (rather than the street), drop the first line.
+  if (lines.length > 1 && !/\d/.test(lines[0])) {
+    lines = lines.slice(1);
+  }
+
+  if (line != null) {
+    lines = lines.slice(line, line + 1);
+  }
+
+  let result = matchable(lines.join(" "));
+  for (const [pattern, expansion] of ADDRESS_EXPANSIONS) {
+    result = result.replace(pattern, expansion);
+  }
+
+  return result.replace(MULTIPLE_SPACE_PATTERN, " ").trim();
+}
+
+export interface UsAddress {
+  lines: string[];
+  city: string;
+  state: string;
+  zip: string | undefined;
+}
+
+/**
+ * Parse a US-style address string.
+ */
+export function parseUsAddress(address: string): UsAddress {
+  const match = address.match(ADDRESS_PATTERN);
+
+  // Detect whether we have something formatted like an address, but with
+  // obviously incorrect street/city/zip data, e.g. "., ., CA 90210".
+  const invalidMatch =
+    !match ||
+    match[1].replace(PUNCTUATION_PATTERN, "") === "" ||
+    match[2].replace(PUNCTUATION_PATTERN, "") === "" ||
+    match[4].replace(PUNCTUATION_PATTERN, "") === "";
+  if (invalidMatch) {
+    throw new ParseError(`Could not parse address: "${address}"`);
+  }
+
+  const zip = match[4];
+  if (zip.split("-")[0].length < 5) {
+    throw new ParseError(`Invalid ZIP code in address: "${address}"`);
+  }
+
+  return {
+    lines: [match[1]],
+    city: match[2],
+    state: match[3].toUpperCase(),
+    zip,
+  };
+}

--- a/common/src/exceptions.ts
+++ b/common/src/exceptions.ts
@@ -1,6 +1,10 @@
+/** Base class for all exceptions in UNIVAF. */
 export class BaseError extends Error {
   // Ensure subclasses get an appropriate name instead of "Error". Without this,
   // console logging, `errorInstance.toString()`, and Sentry may all print
   // different things for the type of error.
   name = this.constructor.name || "Error";
 }
+
+/** Indicates that a value being parsed was not formatted as expected. */
+export class ParseError extends BaseError {}

--- a/common/test/address.test.ts
+++ b/common/test/address.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "@jest/globals";
+import { parseUsAddress } from "../src/address";
+import { ParseError } from "../src/exceptions";
+
+describe("parseUsAddress", () => {
+  it("Parses simple addresses", () => {
+    const parsed = parseUsAddress("3524 Somewhere St., Nowhere, NV 90210");
+    expect(parsed).toEqual({
+      lines: ["3524 Somewhere St."],
+      city: "Nowhere",
+      state: "NV",
+      zip: "90210",
+    });
+  });
+
+  it("Throws on invalid addresses", () => {
+    expect(() => {
+      parseUsAddress("Not an address or address-like string");
+    }).toThrow(ParseError);
+  });
+
+  it("Throws on invalid addresses that are structured like addresses", () => {
+    expect(() => {
+      parseUsAddress("., ., TX, 75244");
+    }).toThrow(ParseError);
+  });
+});

--- a/loader/src/exceptions.js
+++ b/loader/src/exceptions.js
@@ -1,4 +1,4 @@
-const { BaseError } = require("univaf-common/exceptions");
+const { BaseError, ParseError } = require("univaf-common/exceptions");
 
 /**
  * @typedef {object} HttpResponse
@@ -91,8 +91,6 @@ function assertValidGraphQl(response) {
     throw new HttpApiError(response);
   }
 }
-
-class ParseError extends BaseError {}
 
 module.exports = {
   GraphQlError,

--- a/loader/src/utils.js
+++ b/loader/src/utils.js
@@ -2,7 +2,11 @@ const timers = require("node:timers/promises");
 const nodeUtil = require("util");
 const Sentry = require("@sentry/node");
 const got = require("got");
-const { matchableAddress, parseUsAddress } = require("univaf-common/address");
+const {
+  formatZipCode,
+  matchableAddress,
+  parseUsAddress,
+} = require("univaf-common/address");
 const config = require("./config");
 const {
   GraphQlError,
@@ -176,6 +180,8 @@ module.exports = {
 
   parseUsAddress,
 
+  formatZipCode,
+
   /**
    * Parse and return a US-style phone number with an area code and, optionally,
    * a country code. This handles some oddball situations like phone numbers
@@ -198,30 +204,6 @@ module.exports = {
     }
 
     throw new ParseError(`Invalid U.S. phone number: "${text}"`);
-  },
-
-  /**
-   * Format a US ZIP code into its canonical 5-digit form (plus an optional
-   * 4-digit suffix). This is useful since a lot of systems return ZIP codes
-   * without leading zeroes.
-   * @param {string|number} zipCode
-   * @returns {string}
-   */
-  formatZipCode(zipCode) {
-    if (typeof zipCode === "number" && !Number.isInteger(zipCode)) {
-      throw new SyntaxError(`ZIP code is not an integer: "${zipCode}"`);
-    }
-
-    const parts = zipCode.toString().split("-");
-    if (parts.length > 2) {
-      throw new SyntaxError(`ZIP code has multiple dashes: "${zipCode}"`);
-    }
-
-    let result = parts[0].padStart(5, "0");
-    if (parts.length > 1) {
-      result = `${result}-${parts[1].padStart(4, "0")}`;
-    }
-    return result;
   },
 
   /**

--- a/loader/test/utils.test.js
+++ b/loader/test/utils.test.js
@@ -9,7 +9,6 @@ const {
   filterObject,
   unpadNumber,
   getUniqueExternalIds,
-  parseUsAddress,
   RateLimit,
   parseUsPhoneNumber,
   cleanUrl,
@@ -237,30 +236,6 @@ describe("RateLimit", () => {
     expect(callTimes[1] - callTimes[0]).toBeLessThan(1050);
     expect(callTimes[2] - callTimes[1]).toBeGreaterThanOrEqual(995);
     expect(callTimes[2] - callTimes[1]).toBeLessThan(1050);
-  });
-});
-
-describe("parseUsAddress", () => {
-  it("Parses simple addresses", () => {
-    const parsed = parseUsAddress("3524 Somewhere St., Nowhere, NV 90210");
-    expect(parsed).toEqual({
-      lines: ["3524 Somewhere St."],
-      city: "Nowhere",
-      state: "NV",
-      zip: "90210",
-    });
-  });
-
-  it("Throws on invalid addresses", () => {
-    expect(() => {
-      parseUsAddress("Not an address or address-like string");
-    }).toThrow(ParseError);
-  });
-
-  it("Throws on invalid addresses that are structured like addresses", () => {
-    expect(() => {
-      parseUsAddress("., ., TX, 75244");
-    }).toThrow(ParseError);
   });
 });
 

--- a/server/scripts/merge-locations.ts
+++ b/server/scripts/merge-locations.ts
@@ -4,10 +4,11 @@
  * See CLI help at bottom for complete description and options.
  */
 
-import { knex, Knex } from "knex";
+import { type Knex } from "knex";
 import yargs from "yargs";
 import util from "node:util";
 import { ProviderLocation } from "../src/interfaces";
+import { createDbClient } from "../src/db-client";
 
 // For historical reasons, this script uses a different format for external IDs
 // than the rest of the server codebase.
@@ -46,8 +47,7 @@ export function writeLog(...args: any[]): void {
   console.warn(...args);
 }
 
-const environment = process.env.NODE_ENV || "development";
-export const db = knex(require("../knexfile")[environment]);
+export const db = createDbClient("Scripts");
 
 const MULTIPLE_SPACE_PATTERN = /[\n\s]+/g;
 const PUNCTUATION_PATTERN = /[.,;\-–—'"“”‘’`!()/\\]+/g;

--- a/server/src/JSONStream.d.ts
+++ b/server/src/JSONStream.d.ts
@@ -1,0 +1,9 @@
+declare module "JSONStream" {
+  import { Duplex } from "node:stream";
+
+  function stringify(
+    open?: string | false,
+    sep?: string,
+    close?: string
+  ): Duplex;
+}

--- a/server/src/stream.d.ts
+++ b/server/src/stream.d.ts
@@ -1,0 +1,13 @@
+import stream from "node:stream";
+
+// The "@types/node" module is missing a declaration for stream.compose.
+// See: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/58490
+declare module "node:stream" {
+  function compose(
+    ...streams:
+      | stream.Stream[]
+      | Iterable<any>[]
+      | AsyncIterable<any>[]
+      | CallableFunction[]
+  ): stream.Duplex;
+}

--- a/terraform/cron-data-snapshot.tf
+++ b/terraform/cron-data-snapshot.tf
@@ -8,7 +8,7 @@ module "daily_data_snapshot_task" {
 
   name    = "daily-data-snapshot"
   image   = "${aws_ecr_repository.server_repository.repository_url}:${var.api_release_version}"
-  command = ["node", "scripts/availability_dump.js", "--write-to-s3", "--clear-log"]
+  command = ["node", "dist/scripts/availability_dump.js", "--write-to-s3", "--clear-log"]
   role    = aws_iam_role.ecs_task_execution_role.arn
 
   env_vars = {


### PR DESCRIPTION
This does a little not-entirely-necessary cleanup by finally making the server scripts TypeScript, which also lets us move a bunch of duplicated code to the `univaf-common` module more easily. We can also now use the same tools for databases in the scripts as in the main server.

Fixes #199.