### PR TITLE
Slim down the production service

### DIFF
--- a/terraform/cron-loaders.tf
+++ b/terraform/cron-loaders.tf
@@ -30,10 +30,10 @@ locals {
     },
     waDoh             = { schedule = "cron(3/30 * * * ? *)" }
     cvsSmart          = { schedule = "cron(3/15 * * * ? *)" }
-    walgreensSmart    = { schedule = "cron(2/10 * * * ? *)" }
+    walgreensSmart    = { schedule = "cron(2/15 * * * ? *)" }
     albertsonsScraper = { schedule = "cron(20/30 * * * ? *)" }
-    hyvee             = { schedule = "cron(8/10 * * * ? *)" }
-    heb               = { schedule = "cron(1/10 * * * ? *)" }
+    hyvee             = { schedule = "cron(8/15 * * * ? *)" }
+    heb               = { schedule = "cron(1/15 * * * ? *)" }
     cdcApi = {
       schedule = "cron(0 0,12 * * ? *)"
       # CDC updates are often slow; set stale threshold to 3 days.

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -5,7 +5,7 @@ variable "aws_region" {
 
 variable "az_count" {
   description = "Number of AZs to cover (within the chosen region)"
-  default     = 2
+  default     = 1
 }
 
 variable "ssl_certificate_arn" {


### PR DESCRIPTION
As we move towards shutdown, this simplifies the service to using only one availability zone and reduces the loader schedules so that none run any more often than every 15 minutes.