### PR TITLE
Use same tests for locations JSON and NDJSON

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,7 @@ module.exports = {
       "error",
       {
         argsIgnorePattern: "^_",
+        varsIgnorePattern: "^_",
       },
     ],
 


### PR DESCRIPTION
The `/locations` and `/locations.ndjson` should behave the same and mainly differ in their output format, so we should run the same tests against them. Not really necessary but feels nice to finally fix. 🤷

Fixes #276.