### PR TITLE
Fix new logger call in Prepmod

### DIFF
--- a/loader/src/sources/prepmod/index.js
+++ b/loader/src/sources/prepmod/index.js
@@ -347,7 +347,7 @@ function parseSchedule(schedule) {
       } else if (nonCovidProductName.test(extension.valueCoding.display)) {
         data.hasNonCovidProducts = true;
       } else {
-        logger(`Unparseable product "${extension?.valueCoding?.display}"`, {
+        logger.warn(`Unparseable product "${extension.valueCoding?.display}"`, {
           scheduleId: schedule.id,
           extension,
         });


### PR DESCRIPTION
This is a follow-up to #1525 and fixes a typo in a call to `logger.warn()`.

Fixes https://usdr.sentry.io/issues/4219367729/