### PR TITLE
Support new "Td" vaccine in Prepmod

### DIFF
--- a/loader/src/sources/prepmod/index.js
+++ b/loader/src/sources/prepmod/index.js
@@ -285,6 +285,8 @@ const nonCovidProductName = new RegExp(
     raw`^child and adolescent immunization`,
     raw`monkeypox`,
     raw`jynneos`,
+    // Tetanus & Diptheria
+    raw`^\s*Td\s*$`,
     // Diphtheria, Tetanus, & Pertussis. These two cover the same viruses, but
     // are slightly different formulations for different people.
     raw`\b(tdap|dtap)\b`,


### PR DESCRIPTION
Alaska's Prepmod instance is now showing "Td", which is a Tetanus/Diptheria shot, so we should ignore it.

This was the actual underlying issue that triggered #1527: https://usdr.sentry.io/issues/4219585851/