### PR TITLE
Ignore more new vaccines from Prepmod

### DIFF
--- a/loader/src/sources/prepmod/index.js
+++ b/loader/src/sources/prepmod/index.js
@@ -280,6 +280,7 @@ const nonCovidProductName = new RegExp(
   [
     raw`^influenza`,
     raw`flu`,
+    raw`\bfever\b`,
     raw`zoster`,
     raw`^\s*adenovirus\s*$`,
     raw`^child and adolescent immunization`,
@@ -311,6 +312,12 @@ const nonCovidProductName = new RegExp(
     raw`\bHib\b`,
     // Polio
     raw`\bPolio\b`,
+    // Typhoid
+    raw`\bTyphoid\b`,
+    // Various Encephalitises, e.g. "J.encephalitis" (Japanese Encephalitis)
+    raw`\bencephalitis\b`,
+    // Rabies
+    raw`\bRabies\b`,
     // In all cases we've seen, this occurs on schedules that list other actual
     // vaccine names as well. We'll pick up the true products from the other
     // extensions in the schedule.


### PR DESCRIPTION
A bunch of new vaccines showed up in Prepmod Friday afternoon, and this ignores the non-COVID ones. Fixes:
- https://usdr.sentry.io/issues/4224421573/
- https://usdr.sentry.io/issues/4224421564/
- https://usdr.sentry.io/issues/4224421558/
- https://usdr.sentry.io/issues/4224421556/