### PR TITLE
Clean up duplicative GraphQL error messages

### DIFF
--- a/loader/src/exceptions.js
+++ b/loader/src/exceptions.js
@@ -96,7 +96,7 @@ class GraphQlError extends HttpApiError {
         const key = error.message || code || "[unknown error]";
         const summary = uniqueErrors.get(key);
         if (summary) {
-          summary.errorCount += 1;
+          summary.count += 1;
         } else {
           uniqueErrors.set(key, {
             count: 1,

--- a/loader/src/exceptions.js
+++ b/loader/src/exceptions.js
@@ -48,9 +48,9 @@ class HttpApiError extends BaseError {
  */
 class GraphQlError extends HttpApiError {
   /**
-   * @property {any[]} codes If the GraphQL API returned error codes, the code
-   *           for each error will be listed here (codes are non-standard, but
-   *           commonly used).
+   * @property {string[]} codes If the GraphQL API returned error codes, the
+   *           code for each error will be listed here (codes are non-standard,
+   *           but commonly used).
    */
 
   parse(response) {
@@ -60,18 +60,53 @@ class GraphQlError extends HttpApiError {
       this.details = JSON.parse(response.body);
     }
 
-    this.codes = GraphQlError.getCodes(this.details.errors);
-    this.message = this.details.errors.map((item) => item.message).join(", ");
+    const errors = GraphQlError.getUniqueErrors(this.details.errors);
+    this.codes = errors.map((e) => e.code).filter(Boolean);
+    this.message = errors.map((e) => `${e.message} (×${e.count})`).join(", ");
     if (response.statusCode >= 300) {
       this.message = `(Status: ${response.statusCode}) ${this.message}`;
     }
   }
 
-  static getCodes(errorList) {
+  /**
+   * Normalizes and dedupes a list of of errors from a GraphQL response.
+   * Different GraphQL servers format errors slightly differently, and this
+   * makes sure we get a `message` and `code`, wherever those properties may
+   * be stored. It also dedupes the list of errors, since we frequently see
+   * responses that are just a long list of the same error (often
+   * "internal server error"). The `count` property of each error indicates how
+   * many times that error was seen.
+   *
+   * This dedupes based on the error message (if found), since we expect that
+   * multiple errors of the same type/code may have slightly different details
+   * and messages, which we don't want to lose.
+   * @param {any[]} errorList
+   * @returns {{
+   *   count: number,
+   *   message: string,
+   *   code?: string,
+   *   [index: string]: any
+   * }[]}
+   */
+  static getUniqueErrors(errorList) {
     if (Array.isArray(errorList)) {
-      return errorList
-        .map((error) => error.code || error.extensions?.code)
-        .filter(Boolean);
+      const uniqueErrors = new Map();
+      for (const error of errorList) {
+        const code = error.code || error.extensions?.code;
+        const key = error.message || code || "[unknown error]";
+        const summary = uniqueErrors.get(key);
+        if (summary) {
+          summary.errorCount += 1;
+        } else {
+          uniqueErrors.set(key, {
+            count: 1,
+            message: key,
+            code,
+            ...error,
+          });
+        }
+      }
+      return [...uniqueErrors.values()];
     } else {
       return [];
     }

--- a/loader/test/exceptions.test.js
+++ b/loader/test/exceptions.test.js
@@ -31,4 +31,19 @@ describe("GraphQlError", () => {
     const matchCount = [...error.message.matchAll(/First error/g)].length;
     expect(matchCount).toBe(1);
   });
+
+  it("Should indicate how many times the same error occurred", () => {
+    const error = new GraphQlError({
+      statusCode: 400,
+      body: {
+        errors: [
+          { message: "First error", code: "ERROR__TYPE_1" },
+          { message: "Second error", code: "ERROR__TYPE_2" },
+          { message: "First error", code: "ERROR__TYPE_1" },
+        ],
+      },
+    });
+
+    expect(error.message).toContain("×2");
+  });
 });

--- a/loader/test/exceptions.test.js
+++ b/loader/test/exceptions.test.js
@@ -1,0 +1,34 @@
+const { GraphQlError } = require("../src/exceptions");
+
+describe("GraphQlError", () => {
+  it("Should format a nice message aggregating all the messages", () => {
+    const error = new GraphQlError({
+      statusCode: 400,
+      body: {
+        errors: [
+          { message: "First error", code: "ERROR__TYPE_1" },
+          { message: "Second error", code: "ERROR__TYPE_2" },
+        ],
+      },
+    });
+
+    expect(error.message).toContain("First error");
+    expect(error.message).toContain("Second error");
+  });
+
+  it("Should only include unique errors", () => {
+    const error = new GraphQlError({
+      statusCode: 400,
+      body: {
+        errors: [
+          { message: "First error", code: "ERROR__TYPE_1" },
+          { message: "Second error", code: "ERROR__TYPE_2" },
+          { message: "First error", code: "ERROR__TYPE_1" },
+        ],
+      },
+    });
+
+    const matchCount = [...error.message.matchAll(/First error/g)].length;
+    expect(matchCount).toBe(1);
+  });
+});


### PR DESCRIPTION
GraphQL error responses are a list of N errors, and we often see the same error repeated multiple times (for example, this one from this morning is just the same "internal server error" message repeated 280 times: https://usdr.sentry.io/issues/4228325474/events/b3e7cf68182e4786b5a660d835880367/). To keep errors readable, our GraphQlError class now dedupes repeated messages.

For example, instead of this error:

    GraphQlError: Internal Server Error, Internal Server Error, Internal Server Error, Internal Server Error...

We'll now see:

    GraphQlError: Internal Server Error (×280)

This also makes some minor improvements to the JSDoc types for GraphQlError.