### PR TITLE
Update Walgreens SMART URL

### DIFF
--- a/loader/src/sources/walgreens/smart.js
+++ b/loader/src/sources/walgreens/smart.js
@@ -18,8 +18,9 @@ const {
   formatExternalIds,
 } = require("../../smart-scheduling-links");
 
+// The querystring here is required for access, but is not secret.
 const API_URL =
-  "https://wbaschedulinglinks.blob.core.windows.net/fhir/$bulk-publish";
+  "https://wbaschedulinglinks.blob.core.windows.net/fhir/$bulk-publish?sv=2022-11-02&ss=b&srt=co&sp=rlf&se=2027-01-01T05:02:56Z&st=2023-06-05T20:02:56Z&spr=https&sig=Yd%2Bguve3J7ZlkNPoT88RqJ%2FhEgbaRiltcpzMSc2OlCk%3D";
 
 // System used for Walgreens store IDs.
 const WALGREENS_ID_SYSTEM = "https://walgreens.com";

--- a/loader/test/walgreens.test.js
+++ b/loader/test/walgreens.test.js
@@ -22,7 +22,10 @@ describe("Walgreens SMART Scheduling Links API", () => {
   const [API_BASE, API_MANIFEST_PATH] = splitHostAndPath(API_URL);
 
   it("should load Walgreens SMART API data", async () => {
-    nock(API_BASE).get(API_MANIFEST_PATH).reply(200, fixtures.TestManifest);
+    nock(API_BASE)
+      .get(API_MANIFEST_PATH)
+      .query(true)
+      .reply(200, fixtures.TestManifest);
     nock(API_BASE)
       .get("/fhir/locations.ndjson")
       .reply(200, toNdJson(fixtures.TestLocations));
@@ -80,7 +83,10 @@ describe("Walgreens SMART Scheduling Links API", () => {
   });
 
   it("should set availability to NO if no slots are free", async () => {
-    nock(API_BASE).get(API_MANIFEST_PATH).reply(200, fixtures.TestManifest);
+    nock(API_BASE)
+      .get(API_MANIFEST_PATH)
+      .query(true)
+      .reply(200, fixtures.TestManifest);
     nock(API_BASE)
       .get("/fhir/locations.ndjson")
       .reply(200, toNdJson(fixtures.TestLocations));
@@ -102,7 +108,10 @@ describe("Walgreens SMART Scheduling Links API", () => {
   });
 
   it("should set availability to NO if there are no slots", async () => {
-    nock(API_BASE).get(API_MANIFEST_PATH).reply(200, fixtures.TestManifest);
+    nock(API_BASE)
+      .get(API_MANIFEST_PATH)
+      .query(true)
+      .reply(200, fixtures.TestManifest);
     nock(API_BASE)
       .get("/fhir/locations.ndjson")
       .reply(200, toNdJson(fixtures.TestLocations));
@@ -117,7 +126,10 @@ describe("Walgreens SMART Scheduling Links API", () => {
   });
 
   it("should not return results outside the requested states", async () => {
-    nock(API_BASE).get(API_MANIFEST_PATH).reply(200, fixtures.TestManifest);
+    nock(API_BASE)
+      .get(API_MANIFEST_PATH)
+      .query(true)
+      .reply(200, fixtures.TestManifest);
     nock(API_BASE)
       .get("/fhir/locations.ndjson")
       .reply(200, toNdJson(fixtures.TestLocations));


### PR DESCRIPTION
Walgreens's SMART Scheduling Links API now requires some extra querystring fields in order to access it. This isn't private info — it's really just an implementation detail that's chanaged with Azure Blob Storage.

Fixes https://usdr.sentry.io/issues/2420647478/