### PR TITLE
HOTFIX: Support nested arrays in Walgreens

### DIFF
--- a/loader/src/smart-scheduling-links.js
+++ b/loader/src/smart-scheduling-links.js
@@ -120,7 +120,10 @@ class SmartSchedulingLinksApi {
         ...this.httpOptions,
         url: this.url,
       }).json();
+      // FIXME: We should validate the schema of the response.
       this.manifest = { time: Date.now(), data };
+      // HACK: This is a [temporary?] workaround for bad data from Walgreens.
+      this.manifest.data.output = this.manifest.data.output.flat();
     }
     return this.manifest.data;
   }
@@ -139,6 +142,7 @@ class SmartSchedulingLinksApi {
         url: entry.url,
       });
       for (const record of parseJsonLines(response.body)) {
+        // FIXME: We should validate the schema of the data.
         record[sourceReference] = entry;
         yield record;
       }


### PR DESCRIPTION
Walgreens's SMART SL manifest file currently lists the slots as a nested array of output items inside the main `output` array, which is not correct, and has been causing us to list all Walgreens as unavailable.

For example, we are seeing a manifest like:

```js
{
  "transactionTime": "2023-06-06T03:21:31.360Z",
  "request": "...",
  "output": [
    { "type": "Location", "url": "..." },
    { "type": "Schedule", "url": "..." },
    // These items should not be in a sub-array; they should just be in the `output` array directly.
    [
      { "type": "Slot", "url": "...", "extension": { "state": ["AK"] } },
      { "type": "Slot", "url": "...", "extension": { "state": ["AL"] } },
      // etc...
    ]
  ]
}

```


This hacks in a quick fix: we just flatten the `output` array before handling it. I've also alerted the maintainer of the Walgreens API to the issue, so hopefully the underlying system gets fixed soon.

Discovered while looking into to some transient errors from Walgreens after merging #1531. Not sure whether it’s new with the authorization fix this morning on Walgreens's side, or if it's been happening for a while. :\