### PR TITLE
Validate schema for SMART SL data

### DIFF
--- a/loader/test/smart-scheduling-links.test.js
+++ b/loader/test/smart-scheduling-links.test.js
@@ -7,6 +7,7 @@ const {
   sourceReference,
   SmartSchedulingLinksApi,
 } = require("../src/smart-scheduling-links");
+const { createSmartLocation } = require("./support/smart-scheduling-links");
 
 jest.mock("../src/logging");
 
@@ -200,13 +201,19 @@ describe("smart-scheduling-links", () => {
       nock("http://example.com").get("/manifest.json").reply(200, manifest);
       nock("http://example.com")
         .get("/l/test1.ndjson")
-        .reply(200, `{"source": "test1.ndjson"}`);
+        .reply(
+          200,
+          JSON.stringify(createSmartLocation({ id: "test1" }).location)
+        );
       nock("http://example.com")
         .get("/l/NJ.ndjson")
-        .reply(200, `{"source": "NJ.ndjson"}`);
+        .reply(200, JSON.stringify(createSmartLocation({ id: "NJ" }).location));
       nock("http://example.com")
         .get("/l/test3.ndjson")
-        .reply(200, `{"source": "test3.ndjson"}`);
+        .reply(
+          200,
+          JSON.stringify(createSmartLocation({ id: "test3" }).location)
+        );
 
       const client = new SmartSchedulingLinksApi(
         "http://example.com/manifest.json"
@@ -216,9 +223,18 @@ describe("smart-scheduling-links", () => {
       ).toArray();
 
       expect(locations).toEqual([
-        { source: "test1.ndjson", [sourceReference]: manifest.output[0] },
-        { source: "NJ.ndjson", [sourceReference]: manifest.output[2] },
-        { source: "test3.ndjson", [sourceReference]: manifest.output[4] },
+        expect.objectContaining({
+          id: "test1",
+          [sourceReference]: manifest.output[0],
+        }),
+        expect.objectContaining({
+          id: "NJ",
+          [sourceReference]: manifest.output[2],
+        }),
+        expect.objectContaining({
+          id: "test3",
+          [sourceReference]: manifest.output[4],
+        }),
       ]);
       expect(nock.isDone()).toBe(true);
     });


### PR DESCRIPTION
We recently had the Walgreens SMART Scheduling Links API break (#1544), and only found out about it because I happened to be looking into some unrelated errors that I thought were happening with Walgreens (they were not) and noticed some fishy output. That's not good, so this adds schema validation to the SMART Scheduling Links utilities, which would alert us to this issue if it happened again.

This also removes yesterday's hotfix for the Walgreens issue, since it already got fixed at the source! It's nice when some providers are quick and attentive. :)

Fixes #1545.