### PR TITLE
Drop deprecated provider_locations fields

### DIFF
--- a/server/migrations/20230606194142_remove_deprecated_provider_location_fields.js
+++ b/server/migrations/20230606194142_remove_deprecated_provider_location_fields.js
@@ -1,4 +1,9 @@
 /**
+ * Clean out the original ID and external ID fields for locations. They were
+ * deprecated and renamed way back in May 2021, and should be dropped.
+ */
+
+/**
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
  */

--- a/server/migrations/20230606194142_remove_deprecated_provider_location_fields.js
+++ b/server/migrations/20230606194142_remove_deprecated_provider_location_fields.js
@@ -1,0 +1,24 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.alterTable("provider_locations", function (table) {
+    table.dropColumn("id_old");
+    table.dropColumn("external_ids_old");
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.alterTable("provider_locations", (table) => {
+    table.specificType("id_old", "varchar(128)").nullable();
+    table
+      .specificType("external_ids_old", "jsonb")
+      .notNullable()
+      .defaultTo("{}");
+  });
+};

--- a/server/scripts/merge-locations.ts
+++ b/server/scripts/merge-locations.ts
@@ -39,7 +39,6 @@ export interface MergePlan {
 export const NON_MERGE_FIELDS = new Set([
   "id",
   "external_ids",
-  "id_old",
   "created_at",
   "updated_at",
 ]);


### PR DESCRIPTION
The `provider_locations` table has `id_old` and `external_ids_old` fields that have been deprecated and irrelevant for a long time (so long that they are empty for most location records!). This migration drops those columns so they don't show up in historical data dumps and aren't confusing to future folks who might want to fork the project.