### PR TITLE
Add support for all-ages Moderna in Prepmod

### DIFF
--- a/loader/src/utils.js
+++ b/loader/src/utils.js
@@ -422,7 +422,9 @@ module.exports = {
     } else if (text.includes("moderna")) {
       if (/ages?\s+(6|12|18)( (years )?and up|\s*\+)/i.test(text)) {
         return isBa4Ba5 ? VaccineProduct.modernaBa4Ba5 : VaccineProduct.moderna;
-      } else if (/ages?\s+6\s*(m|months)\b/i.test(text)) {
+      } else if (/ages?\s+6\s*(m|mo|months)(\s+and up|\s*\+)/i.test(text)) {
+        return isBa4Ba5 ? VaccineProduct.modernaBa4Ba5 : VaccineProduct.moderna;
+      } else if (/ages?\s+6\s*(m|mo|months)\b/i.test(text)) {
         return isBa4Ba5
           ? VaccineProduct.modernaBa4Ba5Age0_5
           : VaccineProduct.modernaAge0_5;

--- a/loader/test/utils.test.js
+++ b/loader/test/utils.test.js
@@ -324,6 +324,7 @@ describe("matchVaccineProduct", () => {
     [v.modernaBa4Ba5, "Moderna COVID-19, Bivalent Booster (Ages 18+)"],
     [v.modernaBa4Ba5, "Moderna bivalent booster, ages 12 years and up"],
     [v.modernaBa4Ba5, "Moderna COVID-19 Bivalent Booster (Ages 6+)"],
+    [v.modernaBa4Ba5, "Moderna COVID-19, Bivalent (Ages 6mo+ blue)"],
 
     [v.modernaAge6_11, "Moderna COVID-19 Vaccine (ages 6-11 Primary, 18+ Booster)"],
     [v.modernaAge6_11, "Moderna Pediatric COVID-19 Vaccine (Ages 6 through 11)"],


### PR DESCRIPTION
We started seeing new all-ages listings for Moderna in Prepmod today (the FDA authorized a single formulation of Moderna for all ages in April) that weren't fuzzy matching correctly. This adds support for the new vaccine name.

Fixes https://usdr.sentry.io/issues/4234804919/