### PR TITLE
Absurdly unnecessary cleanup refactor: Make loader sources async iterators

### DIFF
--- a/loader/src/sources/albertsons/mhealth.js
+++ b/loader/src/sources/albertsons/mhealth.js
@@ -577,13 +577,15 @@ function formatLocation(data, validAt, checkedAt) {
   };
 }
 
-async function checkAvailability(handler, { states = DEFAULT_STATES }) {
+async function* checkAvailability({ states = DEFAULT_STATES }) {
   logger.warn("DEPRECATED: albertsons is no longer maintained.");
 
   const stores = await getData(states);
-  stores.forEach((store) => handler(store, { update_location: true }));
+  for (const store of stores) {
+    yield [store, { update_location: true }];
+  }
+
   logger.debug("Matches to known locations:", knownLocationMatches);
-  return stores;
 }
 
 module.exports = {

--- a/loader/src/sources/cdc/api.js
+++ b/loader/src/sources/cdc/api.js
@@ -559,9 +559,8 @@ function formatProductTypes(products) {
   return result.length ? result : undefined;
 }
 
-async function checkAvailability(handler, { states = DEFAULT_STATES }) {
+async function* checkAvailability({ states = DEFAULT_STATES }) {
   const checkedAt = new Date().toISOString();
-  let results = [];
   for (const state of states) {
     const entriesByStoreId = {};
     for await (const entry of queryState(state)) {
@@ -577,12 +576,10 @@ async function checkAvailability(handler, { states = DEFAULT_STATES }) {
       .filter(Boolean)
       .map(markUnexpectedCvsIds);
 
-    formatted.forEach((item) => handler(item, { update_location: true }));
-
-    results = results.concat(formatted);
+    for (const store of formatted) {
+      yield [store, { update_location: true }];
+    }
   }
-
-  return results;
 }
 
 // 18 locations we don't have from the official CVS API that need special treatment

--- a/loader/src/sources/cvs/api.js
+++ b/loader/src/sources/cvs/api.js
@@ -132,7 +132,7 @@ function parseApiLocation(location, lastUpdated) {
  * @param {(any) => void} handler
  * @param {any} [_options]
  */
-async function checkAvailability(handler, _options) {
+async function* checkAvailability(_options) {
   logger.warn("DEPRECATED: cvsApi is no longer maintained.");
 
   const apiKey = process.env.CVS_API_KEY;
@@ -161,11 +161,10 @@ async function checkAvailability(handler, _options) {
       },
     }).json();
 
-    return body.covaxAvailability.map((location) => {
-      const record = parseApiLocation(location, body.lastUpdated);
-      handler(record);
-      return record;
-    });
+    for (const rawLocation of body.covaxAvailability) {
+      const record = parseApiLocation(rawLocation, body.lastUpdated);
+      yield record;
+    }
   } catch (error) {
     if (error instanceof got.HTTPError) {
       throw new CvsApiError(error.response, { cause: error });

--- a/loader/src/sources/cvs/scraper.js
+++ b/loader/src/sources/cvs/scraper.js
@@ -357,7 +357,7 @@ function createCannedUnavailableStore() {
  *
  * @return {Promise<Array>} Array of results conforming to the scraper standard.
  */
-async function checkAvailability(handler, _options) {
+async function* checkAvailability(_options) {
   logger.warn("DEPRECATED: cvsScraper is no longer maintained.");
 
   const clinicsZip = njClinicZip;
@@ -368,7 +368,9 @@ async function checkAvailability(handler, _options) {
     if (rawResults) {
       const clinicResults = convertToStandardSchema(rawResults);
       Object.assign(standardResults, clinicResults);
-      Object.values(clinicResults).forEach((item) => handler(item));
+      for (const clinic of Object.values(clinicResults)) {
+        yield [clinic];
+      }
     }
 
     await timers.setTimeout(randomInt(3, 7) * 1000);
@@ -381,7 +383,7 @@ async function checkAvailability(handler, _options) {
 
   for (const store of Object.values(finalResult)) {
     if (store.availability.available === Available.no) {
-      handler(store);
+      yield [store];
     }
   }
 

--- a/loader/src/sources/cvs/scraper.js
+++ b/loader/src/sources/cvs/scraper.js
@@ -368,9 +368,7 @@ async function* checkAvailability(_options) {
     if (rawResults) {
       const clinicResults = convertToStandardSchema(rawResults);
       Object.assign(standardResults, clinicResults);
-      for (const clinic of Object.values(clinicResults)) {
-        yield [clinic];
-      }
+      yield* Object.values(clinicResults);
     }
 
     await timers.setTimeout(randomInt(3, 7) * 1000);
@@ -383,7 +381,7 @@ async function* checkAvailability(_options) {
 
   for (const store of Object.values(finalResult)) {
     if (store.availability.available === Available.no) {
-      yield [store];
+      yield store;
     }
   }
 

--- a/loader/src/sources/cvs/smart.js
+++ b/loader/src/sources/cvs/smart.js
@@ -141,10 +141,11 @@ function formatCapacity(slots) {
     .map((key) => byDate[key]);
 }
 
-async function checkAvailability(handler, { states = DEFAULT_STATES }) {
+async function* checkAvailability({ states = DEFAULT_STATES }) {
   const stores = await getData(states);
-  stores.forEach((store) => handler(store));
-  return stores;
+  for (const store of stores) {
+    yield [store];
+  }
 }
 
 module.exports = {

--- a/loader/src/sources/cvs/smart.js
+++ b/loader/src/sources/cvs/smart.js
@@ -143,9 +143,7 @@ function formatCapacity(slots) {
 
 async function* checkAvailability({ states = DEFAULT_STATES }) {
   const stores = await getData(states);
-  for (const store of stores) {
-    yield [store];
-  }
+  yield* stores;
 }
 
 module.exports = {

--- a/loader/src/sources/heb/index.js
+++ b/loader/src/sources/heb/index.js
@@ -316,9 +316,7 @@ function formatUrl(url) {
 
 async function* checkAvailability({ states = DEFAULT_STATES }) {
   const stores = await getData(states);
-  for (const store of stores) {
-    yield [store];
-  }
+  yield* stores;
 }
 
 module.exports = {

--- a/loader/src/sources/heb/index.js
+++ b/loader/src/sources/heb/index.js
@@ -314,10 +314,11 @@ function formatUrl(url) {
   return url ? url : "https://vaccine.heb.com/scheduler";
 }
 
-async function checkAvailability(handler, { states = DEFAULT_STATES }) {
+async function* checkAvailability({ states = DEFAULT_STATES }) {
   const stores = await getData(states);
-  stores.forEach((store) => handler(store));
-  return stores;
+  for (const store of stores) {
+    yield [store];
+  }
 }
 
 module.exports = {

--- a/loader/src/sources/hyvee/index.js
+++ b/loader/src/sources/hyvee/index.js
@@ -261,9 +261,7 @@ async function getData(states) {
 
 async function* checkAvailability({ states = DEFAULT_STATES }) {
   const locations = await getData(states);
-  for (const location of locations) {
-    yield [location];
-  }
+  yield* locations;
 }
 
 module.exports = {

--- a/loader/src/sources/hyvee/index.js
+++ b/loader/src/sources/hyvee/index.js
@@ -259,10 +259,11 @@ async function getData(states) {
     .filter((location) => states.includes(location.state));
 }
 
-async function checkAvailability(handler, { states = DEFAULT_STATES }) {
+async function* checkAvailability({ states = DEFAULT_STATES }) {
   const locations = await getData(states);
-  locations.forEach((location) => handler(location));
-  return locations;
+  for (const location of locations) {
+    yield [location];
+  }
 }
 
 module.exports = {

--- a/loader/src/sources/kroger/smart.js
+++ b/loader/src/sources/kroger/smart.js
@@ -294,10 +294,9 @@ function formatCapacity(slots) {
     .map((key) => byDate[key]);
 }
 
-async function checkAvailability(handler, { states = DEFAULT_STATES }) {
+async function* checkAvailability({ states = DEFAULT_STATES }) {
   const stores = await getData(states);
-  stores.forEach((store) => handler(store));
-  return stores;
+  yield* stores;
 }
 
 module.exports = {

--- a/loader/src/sources/njvss/index.js
+++ b/loader/src/sources/njvss/index.js
@@ -259,13 +259,12 @@ const walmartPattern = /(walmart(?<sams>\/Sams)?) #?(?<storeId>\d+)\s*$/i;
  * Get availability for locations scheduled through NJVSS.
  * @returns {Promise<Array<object>>}
  */
-async function checkAvailability(handler, _options) {
+async function* checkAvailability(_options) {
   const data = await getNjvssData();
   const checkTime = new Date().toISOString();
   const validTime = data.lastModified?.toISOString();
   const locations = filterHiddenNjvssLocations(data.records);
 
-  const result = [];
   for (const location of locations) {
     let provider = PROVIDER.njvss;
 
@@ -360,11 +359,8 @@ async function checkAvailability(handler, _options) {
       },
     };
 
-    result.push(record);
-    handler(record, { update_location: true });
+    yield [record, { update_location: true }];
   }
-
-  return result;
 }
 
 module.exports = {

--- a/loader/src/sources/riteaid/scraper.js
+++ b/loader/src/sources/riteaid/scraper.js
@@ -375,13 +375,9 @@ function formatSlots(location) {
   return allSlots;
 }
 
-async function checkAvailability(
-  handler,
-  { states = RITE_AID_STATES, rateLimit }
-) {
+async function* checkAvailability({ states = RITE_AID_STATES, rateLimit }) {
   const rateLimiter = new RateLimit(rateLimit || 1);
 
-  const results = [];
   for (const state of states) {
     for await (const apiLocation of queryState(state, rateLimiter)) {
       let location;
@@ -392,12 +388,9 @@ async function checkAvailability(
         });
         location = formatLocation(apiLocation);
       });
-      handler(location);
-      results.push(location);
+      yield location;
     }
   }
-
-  return results;
 }
 
 module.exports = {

--- a/loader/src/sources/riteaid/smart.js
+++ b/loader/src/sources/riteaid/smart.js
@@ -179,10 +179,9 @@ function formatCapacity(slots) {
     .map((key) => byDate[key]);
 }
 
-async function checkAvailability(handler, { states = DEFAULT_STATES }) {
+async function* checkAvailability({ states = DEFAULT_STATES }) {
   const stores = await getData(states);
-  stores.forEach((store) => handler(store));
-  return stores;
+  yield* stores;
 }
 
 module.exports = {

--- a/loader/src/sources/vaccinespotter/index.js
+++ b/loader/src/sources/vaccinespotter/index.js
@@ -432,22 +432,18 @@ function formatStore(store) {
   return result;
 }
 
-async function checkAvailability(handler, { states = DEFAULT_STATES }) {
+async function* checkAvailability({ states = DEFAULT_STATES }) {
   logger.warn("DEPRECATED: vaccinespotter is no longer maintained.");
 
-  let results = [];
   for (const state of states) {
     const stores = await queryState(state);
     const formatted = stores.features
       .filter(hasUsefulData)
       .map(formatStore)
-      .filter((item) => !!item)
-      .forEach((item) => handler(item));
+      .filter((item) => !!item);
 
-    results = results.concat(formatted);
+    yield* formatted;
   }
-
-  return results;
 }
 
 module.exports = {

--- a/loader/src/sources/vts/geo.js
+++ b/loader/src/sources/vts/geo.js
@@ -142,7 +142,7 @@ function formatStore(store) {
   return result;
 }
 
-async function updateGeo(handler, { states = DEFAULT_STATES }) {
+async function* updateGeo({ states = DEFAULT_STATES }) {
   throw new Error(oneLine`
     The vtsGeo source is unsafe!
     Please fix https://github.com/usdigitalresponse/univaf/issues/433 first.
@@ -158,8 +158,9 @@ async function updateGeo(handler, { states = DEFAULT_STATES }) {
     .map(formatStore)
     .filter(Boolean);
 
-  results.forEach((item) => handler(item, { update_location: true }));
-  return results;
+  for (const item of results) {
+    yield [item, { update_location: true }];
+  }
   /* eslint-enable no-unreachable */
 }
 

--- a/loader/src/sources/wa-doh/wa-doh.js
+++ b/loader/src/sources/wa-doh/wa-doh.js
@@ -288,7 +288,7 @@ function formatLocation(data) {
 /**
  * Get availability data from the WA Department of Health API.
  */
-async function checkAvailability(handler, { states = DEFAULT_STATES }) {
+async function* checkAvailability({ states = DEFAULT_STATES }) {
   // WA doesn't support some US territories.
   const unsupported = new Set(["AA", "AP", "AE"]);
   states = states.filter((state) => {
@@ -299,7 +299,7 @@ async function checkAvailability(handler, { states = DEFAULT_STATES }) {
     return true;
   });
 
-  const results = [];
+  let count = 0;
   for (const state of states) {
     for await (const page of queryState(state)) {
       for (const item of page) {
@@ -328,18 +328,16 @@ async function checkAvailability(handler, { states = DEFAULT_STATES }) {
 
         const location = formatLocation(item);
         if (location) {
-          results.push(location);
-          handler(location);
+          yield location;
+          count++;
         }
       }
     }
   }
 
-  if (!results.length) {
+  if (!count) {
     logger.warn("No locations were found. Something has probably gone wrong.");
   }
-
-  return results;
 }
 
 module.exports = {

--- a/loader/src/sources/walgreens/smart.js
+++ b/loader/src/sources/walgreens/smart.js
@@ -186,10 +186,9 @@ function formatCapacity(slots) {
     .map((key) => byDate[key]);
 }
 
-async function checkAvailability(handler, { states = DEFAULT_STATES }) {
+async function* checkAvailability({ states = DEFAULT_STATES }) {
   const stores = await getData(states);
-  stores.forEach((store) => handler(store));
-  return stores;
+  yield* stores;
 }
 
 module.exports = {

--- a/loader/test/albertsons.mhealth.test.js
+++ b/loader/test/albertsons.mhealth.test.js
@@ -7,7 +7,11 @@ const {
 } = require("../src/sources/albertsons/mhealth");
 const { corrections } = require("../src/sources/albertsons/corrections");
 const { Available } = require("../src/model");
-const { expectDatetimeString, splitHostAndPath } = require("./support");
+const {
+  getLocations,
+  expectDatetimeString,
+  splitHostAndPath,
+} = require("./support");
 const { locationSchema } = require("./support/schemas");
 const { ParseError } = require("../src/exceptions");
 
@@ -40,7 +44,7 @@ describe("Albertsons mHealth", () => {
   });
 
   it.nock("should output valid data", { ignoreQuery: ["v"] }, async () => {
-    const result = await checkAvailability(() => {}, { states: ["AK"] });
+    const result = await getLocations(checkAvailability({ states: ["AK"] }));
     expect(result).toContainItemsMatchingSchema(locationSchema);
   });
 
@@ -75,7 +79,7 @@ describe("Albertsons mHealth", () => {
         { "Last-Modified": "Thu, 28 Oct 2021 07:06:13 GMT" }
       );
 
-    const result = await checkAvailability(() => {}, { states: ["AK"] });
+    const result = await getLocations(checkAvailability({ states: ["AK"] }));
     expect(result).toContainItemsMatchingSchema(locationSchema);
     expect(result).toEqual([
       {
@@ -187,7 +191,7 @@ describe("Albertsons mHealth", () => {
         },
       ]);
 
-    const result = await checkAvailability(() => {}, { states: ["AK"] });
+    const result = await getLocations(checkAvailability({ states: ["AK"] }));
     expect(result[0]).toHaveProperty("name", "Safeway Pharmacy #3410");
     expect(result[0]).toHaveProperty("address_lines", ["30 College Rd"]);
     expect(result).toContainItemsMatchingSchema(locationSchema);
@@ -204,7 +208,7 @@ describe("Albertsons mHealth", () => {
         },
       ]);
 
-    const result = await checkAvailability(() => {}, { states: ["MD"] });
+    const result = await getLocations(checkAvailability({ states: ["MD"] }));
     expect(result).toContainItemsMatchingSchema(locationSchema);
     expect(result[0]).toHaveProperty(
       "availability.available",
@@ -228,7 +232,7 @@ describe("Albertsons mHealth", () => {
         },
       ]);
 
-    const result = await checkAvailability(() => {}, { states: ["AK"] });
+    const result = await getLocations(checkAvailability({ states: ["AK"] }));
     expect(result).toContainItemsMatchingSchema(locationSchema);
     expect(result[0].availability.products).toBe(undefined);
   });
@@ -244,7 +248,7 @@ describe("Albertsons mHealth", () => {
         },
       ]);
 
-    const result = await checkAvailability(() => {}, { states: ["MD"] });
+    const result = await getLocations(checkAvailability({ states: ["MD"] }));
     expect(result).toContainItemsMatchingSchema(locationSchema);
     expect(result[0]).toHaveProperty("availability.products", ["pfizer"]);
   });
@@ -260,7 +264,7 @@ describe("Albertsons mHealth", () => {
         },
       ]);
 
-    const result = await checkAvailability(() => {}, { states: ["AK"] });
+    const result = await getLocations(checkAvailability({ states: ["AK"] }));
     expect(result).toHaveLength(0);
   });
 
@@ -308,7 +312,7 @@ describe("Albertsons mHealth", () => {
         { "Last-Modified": "Thu, 28 Oct 2021 07:06:13 GMT" }
       );
 
-    const result = await checkAvailability(() => {}, { states: ["VA"] });
+    const result = await getLocations(checkAvailability({ states: ["VA"] }));
     expect(result).toContainItemsMatchingSchema(locationSchema);
     expect(result).toEqual([
       {
@@ -417,7 +421,7 @@ describe("Albertsons mHealth", () => {
         ],
         { "Last-Modified": "Thu, 28 Oct 2021 07:06:13 GMT" }
       );
-    const result = await checkAvailability(() => {}, { states: ["CA"] });
+    const result = await getLocations(checkAvailability({ states: ["CA"] }));
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchSchema(locationSchema);
     expect(result).toHaveProperty("0.meta", {
@@ -474,7 +478,7 @@ describe("Albertsons mHealth", () => {
         ],
         { "Last-Modified": "Thu, 28 Oct 2021 07:06:13 GMT" }
       );
-    const result = await checkAvailability(() => {}, { states: ["CA"] });
+    const result = await getLocations(checkAvailability({ states: ["CA"] }));
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchSchema(locationSchema);
     expect(result).toHaveProperty("0.meta", {
@@ -517,7 +521,7 @@ describe("Albertsons mHealth", () => {
         { "Last-Modified": "Thu, 28 Oct 2021 07:06:13 GMT" }
       );
 
-    const result = await checkAvailability(() => {}, { states: ["MD"] });
+    const result = await getLocations(checkAvailability({ states: ["MD"] }));
     expect(result[0]).toMatchSchema(locationSchema);
     expect(result[0]).toHaveProperty("name", "Takoma Park Recreation Center");
     expect(result[0]).toHaveProperty("location_type", "CLINIC");
@@ -543,7 +547,7 @@ describe("Albertsons mHealth", () => {
         { "Last-Modified": "Thu, 28 Oct 2021 07:06:13 GMT" }
       );
 
-    const result = await checkAvailability(() => {}, { states: ["MD"] });
+    const result = await getLocations(checkAvailability({ states: ["MD"] }));
     expect(result).toHaveLength(0);
   });
 
@@ -552,11 +556,9 @@ describe("Albertsons mHealth", () => {
       errors: "Oh no!",
     });
 
-    const error = await checkAvailability(() => null, { states: ["AK"] }).then(
-      () => null,
-      (error) => error
-    );
-    expect(error).toBeInstanceOf(Error);
+    await expect(
+      getLocations(checkAvailability({ states: ["AK"] }))
+    ).rejects.toThrow();
   });
 
   it("errors when formatting locations with a name and address that can't be separated", () => {

--- a/loader/test/albertsons.scraper.test.js
+++ b/loader/test/albertsons.scraper.test.js
@@ -3,7 +3,7 @@ const {
   API_URL,
   checkAvailability,
 } = require("../src/sources/albertsons/scraper");
-const { splitHostAndPath } = require("./support");
+const { getLocations, splitHostAndPath } = require("./support");
 const { locationSchema } = require("./support/schemas");
 
 jest.mock("../src/logging");
@@ -16,7 +16,7 @@ describe("Albertsons Scraper", () => {
   });
 
   it.nock("should output valid data", async () => {
-    const result = await checkAvailability(() => {}, { states: ["NJ"] });
+    const result = await getLocations(checkAvailability({ states: ["NJ"] }));
     expect(result).toContainItemsMatchingSchema(locationSchema);
     expect(result.length).toBeGreaterThan(0);
   });
@@ -25,7 +25,7 @@ describe("Albertsons Scraper", () => {
   // from different underlying data.
   it("should output valid data for unavailable locations", async () => {
     nock(API_URL_BASE).post(API_URL_PATH).reply(200, []);
-    const result = await checkAvailability(() => {}, { states: ["DC"] });
+    const result = await getLocations(checkAvailability({ states: ["DC"] }));
     expect(result).toContainItemsMatchingSchema(locationSchema);
     expect(result.length).toBeGreaterThan(0);
   });

--- a/loader/test/cdc.api.test.js
+++ b/loader/test/cdc.api.test.js
@@ -9,6 +9,7 @@ const {
 } = require("../src/sources/cdc/api");
 const { Available } = require("../src/model");
 const { locationSchema } = require("./support/schemas");
+const { getLocations } = require("./support");
 
 jest.mock("../src/logging");
 
@@ -20,7 +21,7 @@ describe("CDC Open Data API", () => {
   const fixturePath = path.join(__dirname, "fixtures/cdc.api.01929.json");
 
   it.nock("should output valid data", async () => {
-    const result = await checkAvailability(() => {}, { states: ["AK"] });
+    const result = await getLocations(checkAvailability({ states: ["AK"] }));
     expect(result).toContainItemsMatchingSchema(locationSchema);
   });
 
@@ -31,7 +32,7 @@ describe("CDC Open Data API", () => {
       "Content-Type": "application/json",
     });
 
-    const locations = await checkAvailability(() => null, { states: ["NJ"] });
+    const locations = await getLocations(checkAvailability({ states: ["NJ"] }));
     expect(locations).toHaveLength(1);
     expect(locations[0]).toHaveProperty("availability.products", ["pfizer"]);
   });
@@ -62,7 +63,7 @@ describe("CDC Open Data API", () => {
         },
       ]);
 
-    const locations = await checkAvailability(() => null, { states: ["NJ"] });
+    const locations = await getLocations(checkAvailability({ states: ["NJ"] }));
     expect(locations).toHaveProperty("0.availability.available", Available.yes);
     expect(locations).toHaveProperty("1.availability.available", Available.no);
     expect(locations).toHaveProperty(
@@ -92,7 +93,7 @@ describe("CDC Open Data API", () => {
         },
       ]);
 
-    const locations = await checkAvailability(() => null, { states: ["NJ"] });
+    const locations = await getLocations(checkAvailability({ states: ["NJ"] }));
     expect(locations).toHaveProperty(
       "0.availability.available",
       Available.unknown

--- a/loader/test/cvs.smart.test.js
+++ b/loader/test/cvs.smart.test.js
@@ -7,6 +7,7 @@ const {
   expectDatetimeString,
   splitHostAndPath,
   toNdJson,
+  getLocations,
 } = require("./support");
 const { locationSchema } = require("./support/schemas");
 const fixtures = require("./fixtures/cvs.smart.fixtures");
@@ -29,7 +30,7 @@ describe("CVS SMART Scheduling Links API", () => {
       .get("/immunizations/inventory/data/slot.ndjson")
       .reply(200, toNdJson(fixtures.TestSlots));
 
-    const result = await checkAvailability(() => null, { states: ["VA"] });
+    const result = await getLocations(checkAvailability({ states: ["VA"] }));
     expect(result).toEqual([
       {
         external_ids: [
@@ -91,7 +92,7 @@ describe("CVS SMART Scheduling Links API", () => {
         )
       );
 
-    const result = await checkAvailability(() => null, { states: ["VA"] });
+    const result = await getLocations(checkAvailability({ states: ["VA"] }));
     expect(result).toHaveProperty("0.availability.available", Available.no);
     expect(result).toContainItemsMatchingSchema(locationSchema);
   });
@@ -108,7 +109,7 @@ describe("CVS SMART Scheduling Links API", () => {
       .get("/immunizations/inventory/data/slot.ndjson")
       .reply(200, toNdJson(fixtures.TestSlots));
 
-    const result = await checkAvailability(() => null, { states: ["NJ"] });
+    const result = await getLocations(checkAvailability({ states: ["NJ"] }));
     expect(result).toHaveLength(0);
   });
 });

--- a/loader/test/heb.test.js
+++ b/loader/test/heb.test.js
@@ -1,6 +1,6 @@
 const { checkAvailability, formatLocation } = require("../src/sources/heb");
 const { LocationType, Available } = require("../src/model");
-const { expectDatetimeString } = require("./support");
+const { expectDatetimeString, getLocations } = require("./support");
 const { locationSchema } = require("./support/schemas");
 
 jest.mock("../src/logging");
@@ -47,7 +47,7 @@ const baseLocation = {
 
 describe("H-E-B", () => {
   it.nock("should output valid data", { ignoreQuery: ["v"] }, async () => {
-    const result = await checkAvailability(() => {}, { states: ["TX"] });
+    const result = await getLocations(checkAvailability({ states: ["TX"] }));
     expect(result).toContainItemsMatchingSchema(locationSchema);
   });
 

--- a/loader/test/hyvee.test.js
+++ b/loader/test/hyvee.test.js
@@ -1,7 +1,7 @@
 const { states: stateData } = require("univaf-common");
 const { checkAvailability, formatLocation } = require("../src/sources/hyvee");
 const { Available, LocationType } = require("../src/model");
-const { expectDatetimeString } = require("./support");
+const { expectDatetimeString, getLocations } = require("./support");
 const { locationSchema } = require("./support/schemas");
 
 jest.mock("../src/logging");
@@ -134,7 +134,7 @@ describe("HyVee", () => {
 
   it.nock("should output valid data", async () => {
     const states = stateData.map((x) => x.usps);
-    const result = await checkAvailability(() => {}, { states });
+    const result = await getLocations(checkAvailability({ states }));
     expect(result).toContainItemsMatchingSchema(locationSchema);
   });
 });

--- a/loader/test/kroger.smart.test.js
+++ b/loader/test/kroger.smart.test.js
@@ -2,6 +2,7 @@ const nock = require("nock");
 const { checkAvailability, API_URL } = require("../src/sources/kroger/smart");
 const {
   expectDatetimeString,
+  getLocations,
   splitHostAndPath,
   toNdJson,
 } = require("./support");
@@ -26,7 +27,7 @@ describe("Kroger SMART Scheduling Links API", () => {
       .get("/v1/health-wellness/schedules/vaccines/slot_AK.ndjson")
       .reply(200, toNdJson(fixtures.TestSlots));
 
-    const result = await checkAvailability(() => null, { states: ["AK"] });
+    const result = await getLocations(checkAvailability({ states: ["AK"] }));
     expect(result).toEqual([
       {
         external_ids: [
@@ -98,7 +99,7 @@ describe("Kroger SMART Scheduling Links API", () => {
         )
       );
 
-    const result = await checkAvailability(() => null, { states: ["AK"] });
+    const result = await getLocations(checkAvailability({ states: ["AK"] }));
     expect(result).toHaveProperty("0.availability.available", Available.no);
     expect(result).toContainItemsMatchingSchema(locationSchema);
   });
@@ -115,7 +116,7 @@ describe("Kroger SMART Scheduling Links API", () => {
       .get("/v1/health-wellness/schedules/vaccines/slot_NJ.ndjson")
       .reply(200, toNdJson(fixtures.TestSlots));
 
-    const result = await checkAvailability(() => null, { states: ["NJ"] });
+    const result = await getLocations(checkAvailability({ states: ["NJ"] }));
     expect(result).toHaveLength(0);
   });
 
@@ -149,7 +150,7 @@ describe("Kroger SMART Scheduling Links API", () => {
         return toNdJson(items);
       });
 
-    const result = await checkAvailability(() => null, { states: ["AK"] });
+    const result = await getLocations(checkAvailability({ states: ["AK"] }));
     expect(result).toHaveLength(0);
   });
 });

--- a/loader/test/njvss.test.js
+++ b/loader/test/njvss.test.js
@@ -1,6 +1,7 @@
 const path = require("node:path");
 const nock = require("nock");
 const { checkAvailability } = require("../src/sources/njvss");
+const { getLocations } = require("./support");
 const { locationSchema } = require("./support/schemas");
 
 jest.mock("../src/logging");
@@ -30,7 +31,7 @@ describe("NJVSS", () => {
   });
 
   it.nock("should output valid data", async () => {
-    const result = await checkAvailability(() => {});
+    const result = await getLocations(checkAvailability());
     expect(result).toContainItemsMatchingSchema(locationSchema);
   });
 
@@ -45,7 +46,7 @@ describe("NJVSS", () => {
         "last-modified": "Tue, 01 May 2023 12:00:00 GMT",
       });
 
-    const result = await checkAvailability(() => {});
+    const result = await getLocations(checkAvailability());
     expect(result).toHaveProperty(
       "0.availability.valid_at",
       "2023-05-01T12:00:00.000Z"

--- a/loader/test/prepmod.test.js
+++ b/loader/test/prepmod.test.js
@@ -10,7 +10,7 @@ const {
   createSmartLocation,
   createSmartManifest,
 } = require("./support/smart-scheduling-links");
-const { expectDatetimeString, toNdJson } = require("./support");
+const { expectDatetimeString, getLocations, toNdJson } = require("./support");
 const { locationSchema } = require("./support/schemas");
 const { VaccineProduct } = require("../src/model");
 const { EXTENSIONS } = require("../src/smart-scheduling-links");
@@ -34,7 +34,7 @@ describe("PrepMod API", () => {
   // have tests with simpler, more contrived API responses to verify values.
   // This is too complicated to set up again if the API changes.
   it.nock("should successfully format results", async () => {
-    const result = await checkAvailability(() => {}, { states: ["WA"] });
+    const result = await getLocations(checkAvailability({ states: ["WA"] }));
     expect(result).toEqual([
       {
         address_lines: ["500 Tausick Way"],
@@ -861,10 +861,12 @@ describe("PrepMod API", () => {
       .get("/test/slots.ndjson")
       .reply(200, toNdJson(testLocation.slots));
 
-    const results = await checkAvailability(() => {}, {
-      states: ["AK"],
-      hideMissingLocations: true,
-    });
+    const results = await getLocations(
+      checkAvailability({
+        states: ["AK"],
+        hideMissingLocations: true,
+      })
+    );
     expect(results).toHaveLength(2);
     expect(results).toHaveProperty("0.is_public", true);
     expect(results).toHaveProperty("1.is_public", false);

--- a/loader/test/riteaid.api.test.js
+++ b/loader/test/riteaid.api.test.js
@@ -6,6 +6,7 @@ const {
   queryState,
   formatStore,
 } = require("../src/sources/riteaid/api");
+const { getLocations } = require("./support");
 const { locationSchema } = require("./support/schemas");
 const responseFixture = require("./fixtures/riteaid.api.test.json");
 
@@ -57,7 +58,7 @@ describe("Rite Aid Source", () => {
 
     nock(API_URL).get("?stateCode=NJ").reply(200, responseFixture);
 
-    const locations = await checkAvailability(() => {}, { states: ["NJ"] });
+    const locations = await getLocations(checkAvailability({ states: ["NJ"] }));
     expect(locations.length).toBe(108);
 
     expect(locations[0]).toStrictEqual({

--- a/loader/test/riteaid.scraper.test.js
+++ b/loader/test/riteaid.scraper.test.js
@@ -4,7 +4,11 @@ const {
   API_URL,
   checkAvailability,
 } = require("../src/sources/riteaid/scraper");
-const { expectDatetimeString, splitHostAndPath } = require("./support");
+const {
+  expectDatetimeString,
+  getLocations,
+  splitHostAndPath,
+} = require("./support");
 const { locationSchema } = require("./support/schemas");
 
 jest.mock("../src/logging");
@@ -42,10 +46,12 @@ describe("Rite Aid Scraper", () => {
   });
 
   it.nock("should output valid data", async () => {
-    const result = await checkAvailability(() => {}, {
-      states: ["CT"],
-      rateLimit: 0,
-    });
+    const result = await getLocations(
+      checkAvailability({
+        states: ["CT"],
+        rateLimit: 0,
+      })
+    );
     expect(result).toContainItemsMatchingSchema(locationSchema);
   });
 
@@ -144,7 +150,7 @@ describe("Rite Aid Scraper", () => {
         },
       });
 
-    const result = await checkAvailability(() => {}, { states: ["CT"] });
+    const result = await getLocations(checkAvailability({ states: ["CT"] }));
     expect(result).toContainItemsMatchingSchema(locationSchema);
     expect(result).toEqual([
       {
@@ -286,7 +292,7 @@ describe("Rite Aid Scraper", () => {
         },
       });
 
-    const result = await checkAvailability(() => {}, { states: ["CT"] });
+    const result = await getLocations(checkAvailability({ states: ["CT"] }));
     expect(result).toContainItemsMatchingSchema(locationSchema);
     expect(result[0].availability.slots).toEqual([
       {
@@ -338,7 +344,7 @@ describe("Rite Aid Scraper", () => {
         },
       });
 
-    const result = await checkAvailability(() => {}, { states: ["CT"] });
+    const result = await getLocations(checkAvailability({ states: ["CT"] }));
     expect(result).toContainItemsMatchingSchema(locationSchema);
     expect(result).toHaveProperty("0.availability.available", Available.no);
   });
@@ -353,7 +359,7 @@ describe("Rite Aid Scraper", () => {
     });
 
     await expect(
-      checkAvailability(() => {}, { states: ["CT"] })
+      getLocations(checkAvailability({ states: ["CT"] }))
     ).rejects.toThrow("Something went wrong");
   });
 
@@ -391,7 +397,7 @@ describe("Rite Aid Scraper", () => {
         },
       });
 
-    const result = await checkAvailability(() => {}, { states: ["CT"] });
+    const result = await getLocations(checkAvailability({ states: ["CT"] }));
     expect(result).toHaveProperty("0.external_ids", [
       ["rite_aid", "6958"],
       ["bartell", "58"],

--- a/loader/test/support/index.js
+++ b/loader/test/support/index.js
@@ -14,6 +14,22 @@ module.exports = {
   },
 
   /**
+   * Convert the iterator from a source's `checkAvailability()` function to an
+   * array of location objects. This discards any extra processing instructions
+   * that might be emitted by `checkAvailability()` so you just get the
+   * locations.
+   * @param {AsyncIterator} resultsIterator
+   * @returns {Promise<any[]>}
+   */
+  async getLocations(resultsIterator) {
+    const locations = [];
+    for await (const item of resultsIterator) {
+      locations.push(Array.isArray(item) ? item[0] : item);
+    }
+    return locations;
+  },
+
+  /**
    * Split up a URL into two strings: a URL for the host and the path.
    * @param {string} url
    * @returns {[string, string]}

--- a/loader/test/vts.geo.test.js
+++ b/loader/test/vts.geo.test.js
@@ -1,10 +1,10 @@
 const nock = require("nock");
 const { checkAvailability } = require("../src/sources/vts/geo");
+const { getLocations } = require("./support");
 
 jest.mock("../src/logging");
 
 const apiResponse = require("./fixtures/vts.geo.test.json");
-const noopHandler = () => {};
 
 describe.skip("VtS Geo", () => {
   const S3_URL = "https://univaf-data-snapshots.s3.us-west-2.amazonaws.com/";
@@ -18,28 +18,28 @@ describe.skip("VtS Geo", () => {
   });
 
   it("gracefully handles no states", async () => {
-    const locations = await checkAvailability(noopHandler, {});
+    const locations = await getLocations(checkAvailability());
     expect(locations).toEqual([]);
   });
 
   it("filters by state", async () => {
     let locations;
-    locations = await checkAvailability(noopHandler, { states: ["NJ"] });
+    locations = await getLocations(checkAvailability({ states: ["NJ"] }));
     expect(locations.length).toBe(0);
 
-    locations = await checkAvailability(noopHandler, { states: ["CA"] });
+    locations = await getLocations(checkAvailability({ states: ["CA"] }));
     expect(locations.length).not.toBe(0);
   });
 
   it("skips stores we don't care about", async () => {
     expect(apiResponse.features.length).toBe(3);
 
-    const locations = await checkAvailability(noopHandler, { states: ["CA"] });
+    const locations = await getLocations(checkAvailability({ states: ["CA"] }));
     expect(locations.length).toBe(2);
   });
 
   it("formats stores as expected", async () => {
-    const locations = await checkAvailability(noopHandler, { states: ["CA"] });
+    const locations = await getLocations(checkAvailability({ states: ["CA"] }));
     expect(locations[0]).toStrictEqual({
       external_ids: [
         ["vaccines_gov", "d91cd449-36c2-4cf5-9c1a-f4136d9a2bf7"],

--- a/loader/test/wa-doh.test.js
+++ b/loader/test/wa-doh.test.js
@@ -6,7 +6,11 @@ const {
   checkAvailability,
   formatLocation,
 } = require("../src/sources/wa-doh/wa-doh");
-const { expectDatetimeString, splitHostAndPath } = require("./support");
+const {
+  expectDatetimeString,
+  getLocations,
+  splitHostAndPath,
+} = require("./support");
 const { locationSchema } = require("./support/schemas");
 
 jest.mock("../src/logging");
@@ -19,7 +23,7 @@ describe("Washington DoH API", () => {
   });
 
   it.nock("should successfully format results", async () => {
-    const result = await checkAvailability(() => {}, { states: ["PR"] });
+    const result = await getLocations(checkAvailability({ states: ["PR"] }));
     expect(result).toEqual([
       {
         address_lines: ["PR #30 INTERSECCION AVENDIA", "RAFAEL CORDERO BARIO"],
@@ -104,10 +108,9 @@ describe("Washington DoH API", () => {
         ],
       });
 
-    const error = await checkAvailability(() => null, { states: ["PR"] }).then(
-      () => null,
-      (error) => error
-    );
+    const error = await getLocations(
+      checkAvailability({ states: ["PR"] })
+    ).catch((error) => error);
     expect(error).toBeInstanceOf(GraphQlError);
     expect(error.message).toContain("Expected type Int!");
     expect(error.codes).toContain("GRAPHQL_VALIDATION_FAILED");

--- a/loader/test/walgreens.test.js
+++ b/loader/test/walgreens.test.js
@@ -5,6 +5,7 @@ const {
 } = require("../src/sources/walgreens/smart");
 const {
   expectDatetimeString,
+  getLocations,
   splitHostAndPath,
   toNdJson,
 } = require("./support");
@@ -36,7 +37,7 @@ describe("Walgreens SMART Scheduling Links API", () => {
       .get("/fhir/Slot-abc.ndjson")
       .reply(200, toNdJson(fixtures.TestSlots));
 
-    const result = await checkAvailability(() => null, { states: ["AK"] });
+    const result = await getLocations(checkAvailability({ states: ["AK"] }));
     expect(result).toEqual([
       {
         external_ids: [
@@ -102,7 +103,7 @@ describe("Walgreens SMART Scheduling Links API", () => {
         )
       );
 
-    const result = await checkAvailability(() => null, { states: ["AK"] });
+    const result = await getLocations(checkAvailability({ states: ["AK"] }));
     expect(result).toHaveProperty("0.availability.available", Available.no);
     expect(result).toContainItemsMatchingSchema(locationSchema);
   });
@@ -120,7 +121,7 @@ describe("Walgreens SMART Scheduling Links API", () => {
       .reply(200, toNdJson(fixtures.TestSchedules));
     nock(API_BASE).get("/fhir/Slot-abc.ndjson").reply(200, "");
 
-    const result = await checkAvailability(() => null, { states: ["AK"] });
+    const result = await getLocations(checkAvailability({ states: ["AK"] }));
     expect(result).toHaveProperty("0.availability.available", Available.no);
     expect(result).toContainItemsMatchingSchema(locationSchema);
   });
@@ -140,7 +141,7 @@ describe("Walgreens SMART Scheduling Links API", () => {
       .get("/fhir/Slot-abc.ndjson")
       .reply(200, toNdJson(fixtures.TestSlots));
 
-    const result = await checkAvailability(() => null, { states: ["VA"] });
+    const result = await getLocations(checkAvailability({ states: ["VA"] }));
     expect(result).toHaveLength(0);
   });
 });


### PR DESCRIPTION
This fixes #55 by getting rid of the callback argument for `checkAvailability()` entirely. One of the weird and messy things in the loader sources is that their main function (`checkAvailability()`) takes a callback to run for every found location (so we get results outputting progressively and reducing load to the server receiving them) but also returns an array of all the found locations (mostly for easy testing). IIRC, I was originally going to make it return a stream instead, but the mechanics of that turned out to be pretty complicated. In #55 I wanted to at least clean it up a bit and position the callback in a more conventional spot, but I actually think async iteration makes the most sense here; it gets us the stream-like stuff with simpler syntax.

Not everything is as clean as I was hoping here; I had been thinking test code would be really simple because we could polyfill the new `Array.fromAsyc()` or `AsyncIterator.prototoype.toArray()` functions, but forgot that the callbacks optionally take a second argument for options about how the location is sent to the database, and so an array of a sources outputs is not necessarily an array of the location objects. So the tests have a new helper to get just the locations.

The CLI module has slightly more code to manage this, too, but I think the overall working of it is slightly simpler, since we can just compose a series of iterators using `stream.compose()` for all the result processing steps.