### PR TITLE
Add note about AWS Terraform provider version

### DIFF
--- a/terraform/api-domains.tf
+++ b/terraform/api-domains.tf
@@ -166,6 +166,9 @@ module "univaf_data_snaphsots_cdn" {
     var.domain_name != ""
     && var.ssl_certificate_arn != "" ? 1 : 0
   )
+  # NOTE: If upgrading this module, please check whether it's now compatible
+  # with the current version of the AWS provider and upgrade that, too!
+  # See https://github.com/cloudposse/terraform-aws-cloudfront-s3-cdn/issues/279
   source  = "cloudposse/cloudfront-s3-cdn/aws"
   version = "0.90.0"
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -3,7 +3,9 @@ terraform {
 
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
+      source = "hashicorp/aws"
+      # We use a module that is not yet compatible with v5 of the AWS provider:
+      # https://github.com/cloudposse/terraform-aws-cloudfront-s3-cdn/issues/279
       version = "~> 4.52"
     }
   }


### PR DESCRIPTION
We use a Terraform module that isn't yet compatible with v5 of the AWS provider, and this adds a note about the situation, since it might not be clear to someone coming in fresh to the codebase. Hopefully Cloudposse will update the module we use, but it doesn't look like that's coming soon, given that they recently updated their tutorials to specify AWS < 5. (See https://github.com/cloudposse/tutorials/pull/21#discussion_r1219948021)