### PR TITLE
Shutdown: Replace the API with a tombstone

### DIFF
--- a/terraform/api-domains.tf
+++ b/terraform/api-domains.tf
@@ -40,13 +40,9 @@ resource "aws_route53_record" "api_domain_record" {
 
   zone_id = data.aws_route53_zone.domain_zone[0].zone_id
   name    = var.domain_name
-  type    = "A"
-
-  alias {
-    name                   = aws_cloudfront_distribution.univaf_api_ecs[0].domain_name
-    zone_id                = aws_cloudfront_distribution.univaf_api_ecs[0].hosted_zone_id
-    evaluate_target_health = false
-  }
+  type    = "CNAME"
+  records = [var.domain_name_remote_api]
+  ttl     = 300
 }
 
 # The `www.` subdomain. It is an alias for the primary domain name.

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -23,6 +23,11 @@ variable "domain_name" {
   default     = ""
 }
 
+variable "domain_name_remote_api" {
+  description = "The domain name for a service outside AWS to send API traffic to"
+  default     = ""
+}
+
 variable "data_snapshot_s3_bucket" {
   description = "The S3 bucket to store database snapshot data into"
   default     = "univaf-data-snapshots"


### PR DESCRIPTION
This updates DNS to send API server traffic to our new tombstone page (see #1569). Once this is done and propagated, I'll start shutting down production services.

Part of #1550.