### PR TITLE
Shutdown: Replace API with tombstone, 2nd try

### DIFF
--- a/terraform/api-domains.tf
+++ b/terraform/api-domains.tf
@@ -35,18 +35,13 @@ data "aws_route53_zone" "domain_zone" {
 }
 
 # DNS record for the domain specified in the `domain_name` variable.
-resource "aws_route53_record" "api_domain_record" {
-  count = var.domain_name != "" ? 1 : 0
-
+resource "aws_route53_record" "api_apex_domain_record" {
+  count   = var.domain_name != "" ? 1 : 0
   zone_id = data.aws_route53_zone.domain_zone[0].zone_id
   name    = var.domain_name
-  type    = "A"
-
-  alias {
-    name                   = aws_cloudfront_distribution.univaf_api_ecs[0].domain_name
-    zone_id                = aws_cloudfront_distribution.univaf_api_ecs[0].hosted_zone_id
-    evaluate_target_health = false
-  }
+  type    = "CNAME"
+  records = [var.domain_name_remote_api]
+  ttl     = 300
 }
 
 # The `www.` subdomain. It is an alias for the primary domain name.

--- a/terraform/api-domains.tf
+++ b/terraform/api-domains.tf
@@ -35,13 +35,18 @@ data "aws_route53_zone" "domain_zone" {
 }
 
 # DNS record for the domain specified in the `domain_name` variable.
-resource "aws_route53_record" "api_apex_domain_record" {
-  count   = var.domain_name != "" ? 1 : 0
+resource "aws_route53_record" "api_domain_record" {
+  count = var.domain_name != "" ? 1 : 0
+
   zone_id = data.aws_route53_zone.domain_zone[0].zone_id
   name    = var.domain_name
-  type    = "CNAME"
-  records = [var.domain_name_remote_api]
-  ttl     = 300
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.univaf_api_ecs[0].domain_name
+    zone_id                = aws_cloudfront_distribution.univaf_api_ecs[0].hosted_zone_id
+    evaluate_target_health = false
+  }
 }
 
 # The `www.` subdomain. It is an alias for the primary domain name.

--- a/terraform/api-domains.tf
+++ b/terraform/api-domains.tf
@@ -35,9 +35,8 @@ data "aws_route53_zone" "domain_zone" {
 }
 
 # DNS record for the domain specified in the `domain_name` variable.
-resource "aws_route53_record" "api_domain_record" {
-  count = var.domain_name != "" ? 1 : 0
-
+resource "aws_route53_record" "api_apex_domain_record" {
+  count   = var.domain_name != "" ? 1 : 0
   zone_id = data.aws_route53_zone.domain_zone[0].zone_id
   name    = var.domain_name
   type    = "CNAME"


### PR DESCRIPTION
The previous change (#1571) did not take when Terraform applied it. Hopefully changing the resource name (so we delete the previous record and create a new one) works.

The specific error was:

> Error: updating Route 53 resource record sets: InvalidChangeBatch: [RRSet of type CNAME with DNS name getmyvax.org. is not permitted at apex in zone getmyvax.org.] status code: 400, request id: 14b91d13-0fc8-4e6f-b70c-606f403e8965
> with aws_route53_record.api_domain_record[0]
> on api-domains.tf line 38, in resource "aws_route53_record" "api_domain_record":

So it may also turn out that we can't use a CNAME here in Route 53, but that seems surprising. We’ll see.

Part of #1550.