### PR TITLE
Shutdown: Replace API with tombstone, 3rd try

### DIFF
--- a/terraform/api-domains.tf
+++ b/terraform/api-domains.tf
@@ -40,7 +40,7 @@ resource "aws_route53_record" "api_apex_domain_record" {
   zone_id = data.aws_route53_zone.domain_zone[0].zone_id
   name    = var.domain_name
   type    = "CNAME"
-  records = [var.domain_name_remote_api]
+  records = var.domain_name_remote_api_ips
   ttl     = 300
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -23,9 +23,10 @@ variable "domain_name" {
   default     = ""
 }
 
-variable "domain_name_remote_api" {
-  description = "The domain name for a service outside AWS to send API traffic to"
-  default     = ""
+variable "domain_name_remote_api_ips" {
+  description = "The IP addresses for a service outside AWS to send API traffic to."
+  type        = list(string)
+  default     = []
 }
 
 variable "data_snapshot_s3_bucket" {


### PR DESCRIPTION
Replace apex DNS record with A records for GitHub pages (docs: https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site). This should fix things after #1571 and #1572.

TIL I learned you technically are not supposed to have CNAME records for apex domains, despite the fact that I've done this on other providers in the past! (Now I’m curious whether those providers are automatically resolving IP addresses under the hood, or if most clients are just tolerant of you doing this.)

Part of #1550.