### PR TITLE
Shutdown: Remove CloudFront and DNS for API

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,9 +1,0 @@
-# outputs.tf
-
-output "alb_hostname" {
-  value = aws_alb.main.dns_name
-}
-
-output "cloudfront_hostname_ecs" {
-  value = aws_cloudfront_distribution.univaf_api_ecs[0].domain_name
-}


### PR DESCRIPTION
The `getmyvax.org` and `www.getmyvax.org` domains no longer point to CloudFront, so we can get rid of it and the old `ecs.` subdomain.

Part of #1550.