### PR TITLE
Fix missing ignore paths in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ on:
     paths-ignore:
       - "docs/**"
       - "terraform/**"
+      - "tombstone/**"
+      - "docker/postgis/**"
   push:
     branches:
       - main


### PR DESCRIPTION
We had some ignore paths set for pushes but not PRs. These shouldn't have gotten out of sync.