### PR TITLE
Shutdown: Prep ECR for deletion

### DIFF
--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -28,6 +28,7 @@ locals {
 resource "aws_ecr_repository" "server_repository" {
   name                 = "univaf-server"
   image_tag_mutability = "IMMUTABLE"
+  force_delete         = true
 
   image_scanning_configuration {
     scan_on_push = false
@@ -42,6 +43,7 @@ resource "aws_ecr_lifecycle_policy" "server_repository" {
 resource "aws_ecr_repository" "loader_repository" {
   name                 = "univaf-loader"
   image_tag_mutability = "IMMUTABLE"
+  force_delete         = true
 
   image_scanning_configuration {
     scan_on_push = false
@@ -58,6 +60,7 @@ resource "aws_ecr_lifecycle_policy" "loader_repository" {
 resource "aws_ecr_repository" "seed_repository" {
   name                 = "univaf-db-seed"
   image_tag_mutability = "IMMUTABLE"
+  force_delete         = true
 
   image_scanning_configuration {
     scan_on_push = false

--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -1,0 +1,70 @@
+# ECR (Elastic Container Registry)
+#
+# All our code is run as tasks on ECS, which means they need repositories to
+# store the container images. Images are built and published to these
+# repositories by GitHub Actions.
+
+locals {
+  ecr_keep_10_images_policy = <<EOF
+    {
+      "rules": [
+        {
+          "rulePriority": 1,
+          "description": "Keep last 10 images",
+          "selection": {
+            "tagStatus": "any",
+            "countType": "imageCountMoreThan",
+            "countNumber": 10
+          },
+          "action": {
+            "type": "expire"
+          }
+        }
+      ]
+    }
+  EOF
+}
+
+resource "aws_ecr_repository" "server_repository" {
+  name                 = "univaf-server"
+  image_tag_mutability = "IMMUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = false
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "server_repository" {
+  repository = aws_ecr_repository.server_repository.name
+  policy     = local.ecr_keep_10_images_policy
+}
+
+resource "aws_ecr_repository" "loader_repository" {
+  name                 = "univaf-loader"
+  image_tag_mutability = "IMMUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = false
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "loader_repository" {
+  repository = aws_ecr_repository.loader_repository.name
+  policy     = local.ecr_keep_10_images_policy
+}
+
+# This repository is maintained only for historical reference. The seed image
+# should not actually ever be used in production.
+resource "aws_ecr_repository" "seed_repository" {
+  name                 = "univaf-db-seed"
+  image_tag_mutability = "IMMUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = false
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "seed_repository" {
+  repository = aws_ecr_repository.seed_repository.name
+  policy     = local.ecr_keep_10_images_policy
+}


### PR DESCRIPTION
#1581 did not succeed because the ECR repositories are not empty. I think we need. to set `force_delete` on them, *then* delete them. But first we'll see if restoring the configuration is going to cause Terraform to try and recreate them, or if it just puts things back into a good state.

If it causes Terraform to try and recreate them, I'll close this and just delete them manually.