### PR TITLE
Shutdown: Use S3 bucket name variable

### DIFF
--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -5,7 +5,7 @@
 # from the bucket.
 
 resource "aws_s3_bucket" "data_snapshots" {
-  bucket = "univaf-data-snapshots"
+  bucket = var.data_snapshot_s3_bucket
 }
 
 resource "aws_s3_bucket_acl" "data_snapshots_acl" {


### PR DESCRIPTION
Follow-on to #1585. Not sure why we weren't using this variable before. But we're using it now!

Part of #1550.