### PR TITLE
Test TypeScript 5.1 library type checking bugfix

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -19,7 +19,7 @@
     "@types/node": "^18.16.17",
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
-    "typescript": "5.0.4"
+    "typescript": "https://typescript.visualstudio.com/cf7ac146-d525-443c-b23c-0d58337efebc/_apis/build/builds/155637/artifacts?artifactName=tgz&fileId=04DE374095785839F62F13D7F462400B471B8FC647A291E41CD31D23BFD6186002&fileName=/typescript-5.2.0-insiders.20230626.tgz"
   },
   "scripts": {
     "clean": "tsc --build --clean",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,20 @@
         "@types/node": "^18.16.17",
         "jest": "^29.5.0",
         "ts-jest": "^29.1.0",
-        "typescript": "5.0.4"
+        "typescript": "https://typescript.visualstudio.com/cf7ac146-d525-443c-b23c-0d58337efebc/_apis/build/builds/155637/artifacts?artifactName=tgz&fileId=04DE374095785839F62F13D7F462400B471B8FC647A291E41CD31D23BFD6186002&fileName=/typescript-5.2.0-insiders.20230626.tgz"
+      }
+    },
+    "common/node_modules/typescript": {
+      "version": "5.2.0-insiders.20230626",
+      "resolved": "https://typescript.visualstudio.com/cf7ac146-d525-443c-b23c-0d58337efebc/_apis/build/builds/155637/artifacts?artifactName=tgz&fileId=04DE374095785839F62F13D7F462400B471B8FC647A291E41CD31D23BFD6186002&fileName=/typescript-5.2.0-insiders.20230626.tgz",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "loader": {
@@ -10310,6 +10323,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
       "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10714,7 +10728,7 @@
         "nodemon": "2.0.22",
         "ts-jest": "^29.1.0",
         "ts-node": "10.9.1",
-        "typescript": "5.0.4"
+        "typescript": "https://typescript.visualstudio.com/cf7ac146-d525-443c-b23c-0d58337efebc/_apis/build/builds/155637/artifacts?artifactName=tgz&fileId=04DE374095785839F62F13D7F462400B471B8FC647A291E41CD31D23BFD6186002&fileName=/typescript-5.2.0-insiders.20230626.tgz"
       }
     },
     "server/node_modules/body-parser": {
@@ -10765,6 +10779,19 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "server/node_modules/typescript": {
+      "version": "5.2.0-insiders.20230626",
+      "resolved": "https://typescript.visualstudio.com/cf7ac146-d525-443c-b23c-0d58337efebc/_apis/build/builds/155637/artifacts?artifactName=tgz&fileId=04DE374095785839F62F13D7F462400B471B8FC647A291E41CD31D23BFD6186002&fileName=/typescript-5.2.0-insiders.20230626.tgz",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     }
   }

--- a/server/package.json
+++ b/server/package.json
@@ -74,6 +74,6 @@
     "nodemon": "2.0.22",
     "ts-jest": "^29.1.0",
     "ts-node": "10.9.1",
-    "typescript": "5.0.4"
+    "typescript": "https://typescript.visualstudio.com/cf7ac146-d525-443c-b23c-0d58337efebc/_apis/build/builds/155637/artifacts?artifactName=tgz&fileId=04DE374095785839F62F13D7F462400B471B8FC647A291E41CD31D23BFD6186002&fileName=/typescript-5.2.0-insiders.20230626.tgz"
   }
 }


### PR DESCRIPTION
This isn’t meant to be fixed. It’s a quick test of an upstream fix to a bug in TypeScript 5.1 that broke our builds and prevented upgrading. Works great locally, but I just want to test in CI. :)