### PR TITLE
Allow Dockerfile to build again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM node:18.16.0-slim AS base
+FROM node:18.18.2-slim AS base
 # Name for the version/release of the software. (Optional)
 ARG RELEASE
 
+# FIXME: This repo is no longer actively maintained! If you start using it, you
+# should re-enable this, which may also require updating the Node.js version.
 # Upgrade to latest NPM.
-RUN npm install -g npm
+# RUN npm install -g npm
 
 WORKDIR /app
 


### PR DESCRIPTION
The changes in #1591 caused the CI pipeline to try and build a new release (even if it doesn’t deploy anymore), but it turns out that the passage of time has broken our Dockerfile. Specifically, the first thing the Dockerfile does is try and update NPM to the latest version (usually a good practice), but the latest NPM is no longer compatible with the version of Node.js that the Dockerfile uses.

Since this project is effectively shut down and not actively maintained, I went ahead and removed the step that updates NPM so this won't happen again. For good measure, I also updated the base image to the latest Node.js 18.x release just in case.

This supersedes #1592.